### PR TITLE
Add Oscar animated companion to OddOscar engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,18 @@ endif()
 # JUCE
 add_subdirectory(Libs/JUCE)
 
+# Rive C++ runtime (MIT licensed — https://github.com/rive-app/rive-cpp)
+# Clone into Libs/rive-cpp:
+#   git clone https://github.com/rive-app/rive-cpp Libs/rive-cpp
+add_subdirectory(Libs/rive-cpp)
+
+# Oscar character — oscar.riv embedded as C++ binary data.
+# Place the authored .riv file at Resources/Oscar/oscar.riv before building.
+# JUCE generates BinaryData::oscar_riv and BinaryData::oscar_rivSize.
+juce_add_binary_data(OscarRivData SOURCES
+    Resources/Oscar/oscar.riv
+)
+
 juce_add_plugin(XOmnibus
     COMPANY_NAME "XO_OX Designs"
     PLUGIN_MANUFACTURER_CODE XoOx
@@ -193,6 +205,11 @@ target_sources(XOmnibus PRIVATE
     Source/UI/OpticVisualizer/OpticVisualizer.h
     Source/UI/PresetBrowser/PresetBrowser.h
 
+    # Oscar (OddOscar animated companion)
+    Source/UI/OddOscar/OscarAnimState.h
+    Source/UI/OddOscar/OscarJuceRenderer.h
+    Source/UI/OddOscar/OscarRiveComponent.h
+
     # UI (Mobile — compiled on all platforms, gated by XO_MOBILE)
     Source/UI/Mobile/MobileTouchHandler.h
     Source/UI/Mobile/SensorManager.h
@@ -231,6 +248,8 @@ target_link_libraries(XOmnibus PRIVATE
     juce::juce_audio_processors
     juce::juce_dsp
     juce::juce_gui_extra
+    rive          # Rive C++ runtime
+    OscarRivData  # Embedded oscar.riv binary data
 )
 
 if(XO_MOBILE)

--- a/Docs/oscar_rive_spec.md
+++ b/Docs/oscar_rive_spec.md
@@ -1,0 +1,230 @@
+# Oscar — Rive State Machine Specification
+
+*For the artist building `oscar.riv` in the Rive editor.*
+*Version 1.0 | XO_OX Designs | March 2026*
+
+---
+
+## Overview
+
+Oscar is an axolotl. Pink gills breathing slowly in a coral cave. He is the warm, living heart of the OddOscar synthesizer — always breathing, always watching, evolving across five stages of life.
+
+The `.riv` file is the canonical Oscar. One file, one character, event-driven. The C++ code pushes values; the state machine decides what Oscar does.
+
+---
+
+## Artboard
+
+| Property | Value |
+|---|---|
+| Name | `Oscar` |
+| Size | 200 × 200 px |
+| Background | Transparent |
+| Origin | Centred |
+
+The character is displayed at any size from **24 px** (header indicator) to **200 px** (main panel). At small sizes, hide detail layers. At large sizes, show full body.
+
+---
+
+## Character Shape Inventory
+
+Oscar is exactly **15 vector shapes**. No more. This keeps the `.riv` file under 50 KB and the CPU cost trivial.
+
+| # | Name | Description | Layer |
+|---|---|---|---|
+| 1 | `body` | Main pink blob, rounded rectangle with soft corners | Base |
+| 2 | `belly` | Lighter pink ellipse, slightly off-centre, gives 3D volume | Base |
+| 3 | `eye_left` | Circle, dark fill | Face |
+| 4 | `eye_right` | Circle, dark fill | Face |
+| 5 | `pupil_left` | Smaller circle, near-black | Face |
+| 6 | `pupil_right` | Smaller circle, near-black | Face |
+| 7 | `smile` | Subtle arc, neutral expression by default | Face |
+| 8 | `gill_1` | Feathery bezier stalk, left cluster | Gills |
+| 9 | `gill_2` | Feathery bezier stalk, left cluster | Gills |
+| 10 | `gill_3` | Feathery bezier stalk, left cluster | Gills |
+| 11 | `gill_4` | Feathery bezier stalk, right cluster | Gills |
+| 12 | `gill_5` | Feathery bezier stalk, right cluster | Gills |
+| 13 | `gill_6` | Feathery bezier stalk, right cluster | Gills |
+| 14 | `leg_left` | Stubby rounded limb (hidden at < 64 px render size) | Body |
+| 15 | `leg_right` | Stubby rounded limb (hidden at < 64 px render size) | Body |
+
+### Scale-based visibility (use Rive constraints or a number input `renderSize`)
+- `leg_left` and `leg_right`: visible when `renderSize > 64`
+- `belly`: always visible
+- All gill detail (feathery branching): always visible
+
+---
+
+## Color Palette
+
+| Role | Hex | Usage |
+|---|---|---|
+| Axolotl Gill Pink | `#E8839B` | `body`, gill stalks |
+| Soft Belly | `#F2B3C1` | `belly` |
+| Deep Pink | `#C45E7A` | Outline/shadow strokes |
+| Near-black | `#1A1A2E` | Pupils |
+| Warm dark | `#3D2B3D` | Eyes |
+| Coral highlight | `#FFD6E0` | Gill tips at high excitation |
+
+Body color should shift subtly based on morph position (see state machine inputs below). At morph=0 (sine, at rest): pure `#E8839B`. At morph=3 (noise, dissolved): desaturate to `#C4A8B0` with 80% opacity.
+
+---
+
+## State Machine
+
+**Name in file:** `OscarBehavior`
+
+### Inputs
+
+These are the exact names the C++ code uses. Any typo breaks the integration.
+
+| Name | Type | Range | Description |
+|---|---|---|---|
+| `gillSpeed` | Number | 0.0 – 1.0 | Gill oscillation rate. 0.12 = resting breath. 1.0 = full excited flutter. |
+| `morphPosition` | Number | 0.0 – 3.0 | Wavetable position. Drives body colour desaturation and slight transparency. |
+| `evolutionLevel` | Number | 0 – 5 | Oscar's age/stage. Drives blend state morphing. |
+| `levelPct` | Number | 0.0 – 1.0 | Output amplitude. Drives subtle body swell on loud chords. |
+| `noteOn` | Trigger | — | Fires on every new note. Brief blink + gill flutter spike. |
+| `celebration` | Trigger | — | Fires on level clear. Full 3-second celebration animation. |
+| `bossMode` | Boolean | true/false | Held true during boss phase. Oscar goes alert, pupils dilate. |
+
+### States
+
+| State | Entry Condition | Description |
+|---|---|---|
+| `IDLE` | Default / no notes | Slow gill oscillation at `gillSpeed`. Eyes soft. Body slight sway. |
+| `ACTIVE` | `noteOn` trigger | Gill flutter spikes for 0.5s then smooths to `gillSpeed`. Pupils widen. |
+| `ALERT` | `bossMode = true` | Eyes widen. Gill speed locked to 0.8. Body tenses (slight scale-down). |
+| `CELEBRATION` | `celebration` trigger | Full body wiggle. Gills fan outward. Eyes happy-squint. 3 seconds. Returns to IDLE. |
+| `EVOLUTION` | `evolutionLevel` changes | 3-second morph between age stages. Oscar shifts shape, grows slightly. Returns to previous state. |
+
+### State Transitions
+
+```
+IDLE ──(noteOn)──────────────► ACTIVE
+IDLE ──(bossMode=true)────────► ALERT
+IDLE ──(celebration)──────────► CELEBRATION ──(3s)──► IDLE
+IDLE ──(evolutionLevel change)► EVOLUTION ───(3s)──► IDLE
+
+ACTIVE ──(no voice, 2s)───────► IDLE
+ACTIVE ──(bossMode=true)──────► ALERT
+ACTIVE ──(celebration)────────► CELEBRATION ──(3s)──► IDLE
+
+ALERT ──(bossMode=false)──────► IDLE
+ALERT ──(celebration)─────────► CELEBRATION ──(3s)──► IDLE
+
+EVOLUTION can be interrupted by CELEBRATION.
+EVOLUTION cannot be interrupted by noteOn (too noisy).
+```
+
+---
+
+## Gill Animation — The Soul
+
+The gills are the single most expressive element. They must feel alive at all times.
+
+**Anatomy:** 6 stalks (`gill_1` through `gill_6`), arranged in clusters of 3 on each side of the head. Each stalk has a feathery tip — 3-4 small branches at the top of each bezier stalk.
+
+**Base oscillation:**
+Each gill oscillates independently with a slightly different phase offset and rate multiplier:
+
+| Gill | Phase offset | Rate multiplier |
+|---|---|---|
+| gill_1 | 0.0 | 1.00 |
+| gill_2 | 0.4 rad | 0.87 |
+| gill_3 | 1.1 rad | 1.13 |
+| gill_4 | 0.2 rad | 0.95 |
+| gill_5 | 0.8 rad | 1.07 |
+| gill_6 | 1.5 rad | 0.91 |
+
+The multiplier and phase offsets ensure no two gills move in sync — this is what makes Oscar feel organic rather than mechanical.
+
+**Oscillation motion:** Each gill stalk rotates ±12° at idle (`gillSpeed=0.12`). At `gillSpeed=1.0`, rotation increases to ±28° with faster frequency. The gill tips trail the stalk with a 2-frame lag (gives fluid, jellyfish-like softness).
+
+**On `noteOn`:** Gill tips briefly fan outward (extra ±15°) for 4 frames, then settle back. Like a startled but not frightened creature.
+
+**On `celebration`:** All 6 gills fan full outward simultaneously, hold for 8 frames, then oscillate in a wider range (±35°) for the celebration duration.
+
+**On `bossMode`:** Gill rate locked to `0.8` regardless of `gillSpeed` input. Stalks hold slightly tighter (±20° max). Oscar is wary.
+
+---
+
+## Evolution Blend States
+
+Oscar evolves across 6 stages. Each stage has distinct visual characteristics. The transition between stages is a 3-second path interpolation (Rive blend state).
+
+| Level | Stage | Size | Key Visual |
+|---|---|---|---|
+| 0 | Hatchling | 80% | Small, large eyes relative to body, 4 tiny gill stalks |
+| 1 | Juvenile | 88% | Eyes proportionate, 6 gill stalks but short |
+| 2 | Adolescent | 94% | Full gill length, legs appear |
+| 3 | Adult | 100% | Canonical Oscar, full presence |
+| 4 | Ancient | 103% | Gills longer, slightly translucent body, deep pink |
+| 5 | Elder | 106% | Gills very long and fan-like, body near-translucent, luminescent gill tips |
+
+**Transition:** Use Rive's blend state with `evolutionLevel` as the blend input. Set the animation to interpolate vertex positions (not just scale) so the gills grow organically — stalks lengthen, not just scale up.
+
+Elder gill tips should emit a soft glow (`#FFD6E0`, Additive blend, 40% opacity pulsing at 0.5 Hz).
+
+---
+
+## Body Swell (`levelPct`)
+
+On loud chords, Oscar's body expands slightly:
+- `body` scale: `1.0 + levelPct * 0.04` (max 4% expansion)
+- `belly` scale: `1.0 + levelPct * 0.06` (slightly more, gives breathing feel)
+- Smoothed with a 60ms attack, 200ms release to avoid jitter
+
+This is subtle. It should feel like a breath, not a pump.
+
+---
+
+## Morph Body Tint (`morphPosition`)
+
+As `morphPosition` increases from 0 to 3, Oscar's body gradually desaturates and becomes slightly translucent:
+
+| morphPosition | Body opacity | Saturation |
+|---|---|---|
+| 0.0 | 100% | 100% — vivid coral pink |
+| 1.0 | 97% | 85% — slightly muted |
+| 2.0 | 90% | 65% — washed, reef-like |
+| 3.0 | 80% | 40% — near-transparent, dissolved into reef |
+
+At morph=3.0 Oscar is still visible but ghostly — he has "become the reef."
+
+---
+
+## Reduced Motion Mode
+
+When the host sets reduced motion (WCAG 2.3.3), Oscar should:
+- Stop all gill oscillation
+- Hold a gentle static pose (gills slightly fanned, neutral expression)
+- Still respond to state changes (EVOLUTION still happens, but instantly — no 3s transition)
+- Still show `celebration` (but as a 0.5s brief glow, not full animation)
+
+The C++ timer drops from 60 Hz to 10 Hz in reduced motion mode. The Rive advance call still happens; just less frequently.
+
+---
+
+## File Requirements
+
+- Format: `.riv` (Rive runtime format, not `.rev`)
+- Target runtime: rive-cpp 2.x (C++ runtime, MIT licensed)
+- Max file size: 50 KB
+- Artboard name: `Oscar` (exact)
+- State machine name: `OscarBehavior` (exact)
+- All input names must match the table above exactly (case-sensitive)
+
+---
+
+## What NOT to include
+
+- No background (transparent artboard)
+- No shadow/glow effects baked in (the JUCE component handles any drop shadow)
+- No text or labels
+- No more than 15 shapes (keep the file tiny and the renderer fast)
+- No bitmap assets — all vector
+
+---
+
+*XO_OX Designs | oscar.riv | The canonical axolotl*

--- a/Resources/Oscar/README.txt
+++ b/Resources/Oscar/README.txt
@@ -1,0 +1,1 @@
+# Place oscar.riv here — authored in the Rive app per Docs/oscar_rive_spec.md

--- a/Source/Engines/Morph/MorphEngine.h
+++ b/Source/Engines/Morph/MorphEngine.h
@@ -3,6 +3,7 @@
 #include "../../Core/PolyAftertouch.h"
 #include "../../DSP/PolyBLEP.h"
 #include "../../DSP/FastMath.h"
+#include "../../UI/OddOscar/OscarAnimState.h"
 #include <array>
 #include <cmath>
 
@@ -707,6 +708,28 @@ public:
                 outputCacheRight[static_cast<size_t> (sampleIndex)] = outputRight;
             }
         }
+
+        //----------------------------------------------------------------------
+        // Update Oscar animation state (lock-free atomics, UI thread reads at 60 Hz)
+        //----------------------------------------------------------------------
+        if (oscarState != nullptr)
+        {
+            // Peak amplitude this block — drives gill sympathetic flutter
+            float blockPeak = 0.0f;
+            int peakSamples = std::min (numSamples, static_cast<int> (outputCacheLeft.size()));
+            for (int i = 0; i < peakSamples; ++i)
+                blockPeak = std::max (blockPeak, std::abs (outputCacheLeft[i]));
+
+            // Voice activity: any voice in Attack/Decay/Sustain (not releasing or off)
+            bool anyVoiceActive = false;
+            for (const auto& v : voices)
+                anyVoiceActive = anyVoiceActive || (v.active && !v.releasing);
+
+            oscarState->gillSpeed.store    (driftAmount,                              std::memory_order_relaxed);
+            oscarState->morphPosition.store (effectiveMorph,                          std::memory_order_relaxed);
+            oscarState->voiceActive.store   (anyVoiceActive,                          std::memory_order_relaxed);
+            oscarState->outputLevel.store   (juce::jlimit (0.0f, 1.0f, blockPeak),   std::memory_order_relaxed);
+        }
     }
 
     //==========================================================================
@@ -911,6 +934,10 @@ public:
     juce::String getEngineId() const override { return "OddOscar"; }
     juce::Colour getAccentColour() const override { return juce::Colour (0xFFE8839B); } // Axolotl Gill Pink
     int getMaxVoices() const override { return kMaxVoices; }
+
+    /// Wire Oscar's animation state. Call from the main thread before playback starts.
+    /// Pass nullptr to detach (headless / no UI mode).
+    void setOscarAnimState (OscarAnimState* state) { oscarState = state; }
 
 private:
     //==========================================================================
@@ -1196,6 +1223,9 @@ private:
     //-- Output cache for coupling reads ---------------------------------------
     std::vector<float> outputCacheLeft;         // left channel output (per-sample, for getSampleForCoupling)
     std::vector<float> outputCacheRight;        // right channel output
+
+    //-- Oscar animation state (optional — null if no UI is present) -----------
+    OscarAnimState* oscarState = nullptr;
 
     //-- Random number generator for drift initialization ----------------------
     juce::Random driftPhaseRandomizer;          // randomizes per-voice drift starting phase

--- a/Source/UI/OddOscar/OscarAnimState.h
+++ b/Source/UI/OddOscar/OscarAnimState.h
@@ -1,0 +1,89 @@
+#pragma once
+#include <atomic>
+#include <cstdint>
+
+namespace xomnibus {
+
+//==============================================================================
+// OscarAnimState — lock-free atomic bridge between the MorphEngine (audio
+// thread) and OscarRiveComponent (UI thread).
+//
+// The MorphEngine writes these values during renderBlock(). The UI timer
+// reads them at 60 Hz. No locks, no allocation, no cross-thread contention.
+//
+// Layout mirrors OpticModOutputs in OpticVisualizer — one struct of atomics,
+// one raw pointer held by both owner and observer. The engine owns the struct.
+//==============================================================================
+struct OscarAnimState
+{
+    //--------------------------------------------------------------------------
+    // Written by MorphEngine on the audio thread
+    //--------------------------------------------------------------------------
+
+    /// Gill oscillation speed — maps to Rive input "gillSpeed".
+    /// Derived from morph_drift parameter + Perlin noise phase velocity.
+    /// Range 0.0 (barely breathing) to 1.0 (excited / fast flutter).
+    std::atomic<float> gillSpeed { 0.25f };
+
+    /// Wavetable morph position — maps to Rive input "morphPosition".
+    /// 0.0 = sine (rest), 1.0 = saw (regenerating), 2.0 = square (display),
+    /// 3.0 = noise (dissolved into reef).
+    std::atomic<float> morphPosition { 0.0f };
+
+    /// True during the sustain phase of any active voice.
+    /// Rising edge → state machine "noteOn" trigger.
+    std::atomic<bool> voiceActive { false };
+
+    /// Peak amplitude of the current block (post-filter, pre-clip).
+    /// Used to drive subtle body-swell on loud chords.
+    /// Range 0.0–1.0.
+    std::atomic<float> outputLevel { 0.0f };
+
+    //--------------------------------------------------------------------------
+    // Written by the game/level layer (main thread)
+    //--------------------------------------------------------------------------
+
+    /// 0 = hatchling, 1 = juvenile, 2 = adolescent, 3 = adult, 4 = ancient,
+    /// 5 = elder. Maps to Rive blend state "evolutionLevel".
+    std::atomic<int> evolutionLevel { 0 };
+
+    /// Triggers CELEBRATION state for ~3 seconds. Set to true on level clear,
+    /// OscarRiveComponent resets to false after firing the trigger.
+    std::atomic<bool> celebrationTrigger { false };
+
+    /// Triggers ALERT state. Held true while boss phase is active.
+    std::atomic<bool> bossMode { false };
+
+    //--------------------------------------------------------------------------
+    // Helpers for the UI thread
+    //--------------------------------------------------------------------------
+
+    /// Snapshot all values in one consistent read sweep.
+    /// The UI timer calls this once per frame; tolerates torn reads since
+    /// none of these values require atomicity across fields.
+    struct Snapshot
+    {
+        float gillSpeed      = 0.25f;
+        float morphPosition  = 0.0f;
+        bool  voiceActive    = false;
+        float outputLevel    = 0.0f;
+        int   evolutionLevel = 0;
+        bool  celebration    = false;
+        bool  bossMode       = false;
+    };
+
+    Snapshot snapshot() const
+    {
+        Snapshot s;
+        s.gillSpeed      = gillSpeed.load (std::memory_order_relaxed);
+        s.morphPosition  = morphPosition.load (std::memory_order_relaxed);
+        s.voiceActive    = voiceActive.load (std::memory_order_relaxed);
+        s.outputLevel    = outputLevel.load (std::memory_order_relaxed);
+        s.evolutionLevel = evolutionLevel.load (std::memory_order_relaxed);
+        s.celebration    = celebrationTrigger.load (std::memory_order_relaxed);
+        s.bossMode       = bossMode.load (std::memory_order_relaxed);
+        return s;
+    }
+};
+
+} // namespace xomnibus

--- a/Source/UI/OddOscar/OscarJuceRenderer.h
+++ b/Source/UI/OddOscar/OscarJuceRenderer.h
@@ -1,0 +1,258 @@
+#pragma once
+
+// Rive C++ runtime — add rive-cpp to Libs/ and link in CMakeLists.txt
+#include <rive/renderer.hpp>
+#include <rive/math/mat2d.hpp>
+#include <rive/math/vec2d.hpp>
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <vector>
+#include <stack>
+
+namespace xomnibus {
+
+//==============================================================================
+// OscarJucePath — implements rive::RenderPath using juce::Path.
+//
+// Rive calls moveTo / lineTo / cubicTo / close to build each shape.
+// We accumulate those into a juce::Path and return it for painting.
+//==============================================================================
+class OscarJucePath : public rive::RenderPath
+{
+public:
+    void rewind() override                      { path.clear(); }
+    void fillRule (rive::FillRule rule) override { fillEvenOdd = (rule == rive::FillRule::evenOdd); }
+
+    void moveTo (float x, float y) override     { path.startNewSubPath (x, y); }
+    void lineTo (float x, float y) override     { path.lineTo (x, y); }
+    void close()  override                      { path.closeSubPath(); }
+
+    void cubicTo (float ox, float oy,
+                  float ix, float iy,
+                  float x,  float y) override
+    {
+        path.cubicTo (ox, oy, ix, iy, x, y);
+    }
+
+    void addPath (rive::CommandPath* source, const rive::Mat2D& xform) override
+    {
+        auto* juceSource = static_cast<OscarJucePath*> (source);
+        auto affine = toJuce (xform);
+        path.addPath (juceSource->path, affine);
+    }
+
+    const juce::Path& getPath() const   { return path; }
+    bool   isEvenOdd()          const   { return fillEvenOdd; }
+
+private:
+    juce::Path path;
+    bool fillEvenOdd = false;
+
+    static juce::AffineTransform toJuce (const rive::Mat2D& m)
+    {
+        // rive::Mat2D is stored as [m00, m01, m10, m11, tx, ty]
+        return { m[0], m[2], m[4],
+                 m[1], m[3], m[5] };
+    }
+};
+
+//==============================================================================
+// OscarJucePaint — implements rive::RenderPaint.
+//
+// Collects fill/stroke style, color, and gradient info from Rive.
+// OscarJuceRenderer calls applyTo() when drawing a path.
+//==============================================================================
+class OscarJucePaint : public rive::RenderPaint
+{
+public:
+    enum class Kind { Solid, LinearGradient, RadialGradient };
+
+    void style (rive::RenderPaintStyle s) override
+    {
+        isStroke = (s == rive::RenderPaintStyle::stroke);
+    }
+
+    void color (unsigned int argb) override
+    {
+        kind = Kind::Solid;
+        juce::uint8 a = (argb >> 24) & 0xFF;
+        juce::uint8 r = (argb >> 16) & 0xFF;
+        juce::uint8 g = (argb >>  8) & 0xFF;
+        juce::uint8 b = (argb >>  0) & 0xFF;
+        solidColor = juce::Colour (r, g, b, a);
+    }
+
+    void thickness (float t) override          { strokeWidth = t; }
+    void join (rive::StrokeJoin j) override    { strokeJoin = j; }
+    void cap  (rive::StrokeCap  c) override    { strokeCap  = c; }
+    void blendMode (rive::BlendMode) override  { /* normal blend only for now */ }
+
+    void linearGradient (float x0, float y0, float x1, float y1) override
+    {
+        kind = Kind::LinearGradient;
+        gx0 = x0; gy0 = y0; gx1 = x1; gy1 = y1;
+        stops.clear();
+    }
+
+    void radialGradient (float x0, float y0, float x1, float y1) override
+    {
+        kind = Kind::RadialGradient;
+        gx0 = x0; gy0 = y0; gx1 = x1; gy1 = y1;
+        stops.clear();
+    }
+
+    void addStop (unsigned int argb, float position) override
+    {
+        juce::uint8 a = (argb >> 24) & 0xFF;
+        juce::uint8 r = (argb >> 16) & 0xFF;
+        juce::uint8 g = (argb >>  8) & 0xFF;
+        juce::uint8 b = (argb >>  0) & 0xFF;
+        stops.push_back ({ juce::Colour (r, g, b, a), position });
+    }
+
+    void applyTo (juce::Graphics& gc, const juce::Path& p, bool evenOdd) const
+    {
+        if (kind == Kind::Solid)
+            gc.setColour (solidColor);
+        else
+            gc.setGradientFill (buildGradient (p));
+
+        if (isStroke)
+        {
+            auto joinStyle = toJuceJoin (strokeJoin);
+            auto capStyle  = toJuceCap  (strokeCap);
+            gc.strokePath (p, juce::PathStrokeType (strokeWidth, joinStyle, capStyle));
+        }
+        else
+        {
+            if (evenOdd)
+                gc.fillPath (p, juce::AffineTransform(), juce::FillType::evenOdd());
+            else
+                gc.fillPath (p);
+        }
+    }
+
+private:
+    struct GradStop { juce::Colour color; float position; };
+
+    bool isStroke   = false;
+    Kind kind       = Kind::Solid;
+    juce::Colour solidColor { juce::Colours::white };
+    float strokeWidth = 1.0f;
+    rive::StrokeJoin strokeJoin = rive::StrokeJoin::miter;
+    rive::StrokeCap  strokeCap  = rive::StrokeCap::butt;
+    float gx0 = 0, gy0 = 0, gx1 = 0, gy1 = 0;
+    std::vector<GradStop> stops;
+
+    juce::ColourGradient buildGradient (const juce::Path& p) const
+    {
+        bool isRadial = (kind == Kind::RadialGradient);
+        juce::ColourGradient grad (
+            stops.empty() ? juce::Colours::white : stops.front().color,
+            gx0, gy0,
+            stops.empty() ? juce::Colours::black : stops.back().color,
+            gx1, gy1,
+            isRadial);
+
+        for (size_t i = 1; i + 1 < stops.size(); ++i)
+            grad.addColour (stops[i].position, stops[i].color);
+
+        return grad;
+    }
+
+    static juce::PathStrokeType::JointStyle toJuceJoin (rive::StrokeJoin j)
+    {
+        switch (j) {
+            case rive::StrokeJoin::round: return juce::PathStrokeType::curved;
+            case rive::StrokeJoin::bevel: return juce::PathStrokeType::beveled;
+            default:                      return juce::PathStrokeType::mitered;
+        }
+    }
+
+    static juce::PathStrokeType::EndCapStyle toJuceCap (rive::StrokeCap c)
+    {
+        switch (c) {
+            case rive::StrokeCap::round:  return juce::PathStrokeType::rounded;
+            case rive::StrokeCap::square: return juce::PathStrokeType::square;
+            default:                      return juce::PathStrokeType::butt;
+        }
+    }
+};
+
+//==============================================================================
+// OscarJuceRenderer — implements rive::Renderer against a juce::Graphics
+// context. Handles save/restore stack, transform accumulation, and routing
+// draw calls to OscarJucePath + OscarJucePaint.
+//
+// Usage: construct fresh each frame inside paint(), pass to artboard->draw().
+//==============================================================================
+class OscarJuceRenderer : public rive::Renderer
+{
+public:
+    explicit OscarJuceRenderer (juce::Graphics& g) : gc (g) {}
+
+    //--------------------------------------------------------------------------
+    // Transform stack
+    //--------------------------------------------------------------------------
+
+    void save() override
+    {
+        gc.saveState();
+        transformStack.push (currentTransform);
+    }
+
+    void restore() override
+    {
+        gc.restoreState();
+        if (!transformStack.empty())
+        {
+            currentTransform = transformStack.top();
+            transformStack.pop();
+        }
+    }
+
+    void transform (const rive::Mat2D& matrix) override
+    {
+        auto juceXform = toJuce (matrix);
+        currentTransform = currentTransform.followedBy (juceXform);
+        gc.addTransform (juceXform);
+    }
+
+    //--------------------------------------------------------------------------
+    // Draw calls
+    //--------------------------------------------------------------------------
+
+    void drawPath (rive::RenderPath* renderPath, rive::RenderPaint* renderPaint) override
+    {
+        auto* juceP = static_cast<OscarJucePath*> (renderPath);
+        auto* juceR = static_cast<OscarJucePaint*> (renderPaint);
+
+        juceR->applyTo (gc, juceP->getPath(), juceP->isEvenOdd());
+    }
+
+    void clipPath (rive::RenderPath* renderPath) override
+    {
+        auto* juceP = static_cast<OscarJucePath*> (renderPath);
+        gc.reduceClipRegion (juceP->getPath());
+    }
+
+    //--------------------------------------------------------------------------
+    // Factory
+    //--------------------------------------------------------------------------
+
+    rive::RenderPaint* makeRenderPaint() override { return new OscarJucePaint(); }
+    rive::RenderPath*  makeRenderPath()  override { return new OscarJucePath();  }
+
+private:
+    juce::Graphics& gc;
+    juce::AffineTransform currentTransform;
+    std::stack<juce::AffineTransform> transformStack;
+
+    static juce::AffineTransform toJuce (const rive::Mat2D& m)
+    {
+        return { m[0], m[2], m[4],
+                 m[1], m[3], m[5] };
+    }
+};
+
+} // namespace xomnibus

--- a/Source/UI/OddOscar/OscarRiveComponent.h
+++ b/Source/UI/OddOscar/OscarRiveComponent.h
@@ -1,0 +1,508 @@
+#pragma once
+
+// Rive C++ runtime
+#include <rive/file.hpp>
+#include <rive/artboard.hpp>
+#include <rive/animation/state_machine_instance.hpp>
+#include <rive/animation/state_machine_input_instance.hpp>
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "OscarAnimState.h"
+#include "OscarJuceRenderer.h"
+
+#include <memory>
+
+namespace xomnibus {
+
+//==============================================================================
+// OscarRiveComponent — Oscar the axolotl, animated via Rive state machine.
+//
+// Runs at 60 Hz on the UI thread. Reads OscarAnimState (lock-free atomics
+// written by MorphEngine). Advances the Rive state machine and repaints.
+//
+// Accent: Axolotl Gill Pink  #E8839B
+// State machine name in oscar.riv: "OscarBehavior"
+//
+// State machine inputs:
+//   gillSpeed      (number)  — 0.0–1.0, drives gill oscillation rate
+//   morphPosition  (number)  — 0.0–3.0, shifts body color/opacity
+//   evolutionLevel (number)  — 0–5, blend state for age morphing
+//   noteOn         (trigger) — fires on voiceActive rising edge
+//   celebration    (trigger) — fires on celebrationTrigger rising edge
+//   bossMode       (boolean) — held true during boss phase
+//   levelPct       (number)  — 0.0–1.0, output level for body swell
+//==============================================================================
+class OscarRiveComponent : public juce::Component, private juce::Timer
+{
+public:
+
+    //--------------------------------------------------------------------------
+    // Construction
+    //--------------------------------------------------------------------------
+
+    OscarRiveComponent()
+    {
+        setOpaque (false);  // Oscar floats over the Gallery Model shell
+        setTitle ("Oscar");
+        setDescription ("Oscar the axolotl — animated companion for OddOscar engine. "
+                        "Reacts to synthesis parameters and performance events.");
+    }
+
+    /// Load oscar.riv from memory (call once after construction).
+    /// Pass the raw .riv file bytes and their length.
+    /// Returns true on success.
+    bool loadRiv (const void* data, size_t sizeBytes)
+    {
+        auto result = rive::File::import (
+            { static_cast<const uint8_t*> (data), sizeBytes }, &factory);
+
+        if (result.errorCode != rive::ImportResult::success)
+            return false;
+
+        riveFile = std::move (result.file);
+
+        artboard = riveFile->artboardDefault();
+        if (artboard == nullptr)
+            return false;
+
+        auto* sm = artboard->stateMachine ("OscarBehavior");
+        if (sm == nullptr)
+            return false;
+
+        stateMachine = sm->createInstance (artboard.get());
+
+        // Cache input pointers — avoids string lookup each frame
+        inputGillSpeed      = stateMachine->getNumber  ("gillSpeed");
+        inputMorphPosition  = stateMachine->getNumber  ("morphPosition");
+        inputEvolutionLevel = stateMachine->getNumber  ("evolutionLevel");
+        inputLevelPct       = stateMachine->getNumber  ("levelPct");
+        inputNoteOn         = stateMachine->getTrigger ("noteOn");
+        inputCelebration    = stateMachine->getTrigger ("celebration");
+        inputBossMode       = stateMachine->getBool    ("bossMode");
+
+        return true;
+    }
+
+    /// Wire to MorphEngine's anim state. Call from the main thread before start().
+    void setAnimState (OscarAnimState* state) { animState = state; }
+
+    /// Begin ticking at 60 Hz.
+    void start() { startTimerHz (60); }
+    void stop()  { stopTimer(); }
+
+    //--------------------------------------------------------------------------
+    // WCAG 2.3.3 — reduced motion support
+    //--------------------------------------------------------------------------
+
+    void setReducedMotion (bool enabled)
+    {
+        reducedMotion = enabled;
+        if (isTimerRunning())
+        {
+            stopTimer();
+            startTimerHz (reducedMotion ? 10 : 60);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Rendering
+    //--------------------------------------------------------------------------
+
+    void paint (juce::Graphics& g) override
+    {
+        if (artboard == nullptr)
+        {
+            paintProcedural (g);
+            return;
+        }
+
+        auto bounds = getLocalBounds().toFloat();
+
+        // Scale artboard to fit, preserving aspect ratio.
+        // Oscar's artboard is designed at 200x200 px in the Rive editor.
+        constexpr float kArtboardSize = 200.0f;
+        float scale = std::min (bounds.getWidth(), bounds.getHeight()) / kArtboardSize;
+
+        float offsetX = (bounds.getWidth()  - kArtboardSize * scale) * 0.5f;
+        float offsetY = (bounds.getHeight() - kArtboardSize * scale) * 0.5f;
+
+        OscarJuceRenderer renderer (g);
+        renderer.save();
+        renderer.transform (rive::Mat2D { scale, 0.0f, 0.0f, scale, offsetX, offsetY });
+
+        artboard->draw (&renderer);
+
+        renderer.restore();
+    }
+
+    void resized() override
+    {
+        // No child layout — Oscar is one Rive canvas.
+    }
+
+    //--------------------------------------------------------------------------
+    // Timer — 60 Hz tick
+    //--------------------------------------------------------------------------
+
+    void timerCallback() override
+    {
+        frameCount++;
+
+        // Snapshot state from engine (lock-free)
+        if (animState != nullptr)
+            lastSnapshot = animState->snapshot();
+
+        if (artboard != nullptr && stateMachine != nullptr)
+        {
+            pushInputs (lastSnapshot);
+            const float deltaSeconds = 1.0f / (reducedMotion ? 10.0f : 60.0f);
+            stateMachine->advance (deltaSeconds);
+            artboard->advance (deltaSeconds);
+        }
+
+        repaint();
+    }
+
+private:
+
+    //--------------------------------------------------------------------------
+    // Input mapping — the key translation layer
+    //
+    // TODO: This is where you define how Oscar's synthesis parameters
+    // become animation inputs. See design notes below.
+    //--------------------------------------------------------------------------
+
+    void pushInputs (const OscarAnimState::Snapshot& s)
+    {
+        // --- Gill speed ---
+        // morph_drift (0–1) → gill oscillation rate (0–1).
+        // This is the soul of the animation. How does drift map to gill energy?
+        //
+        // TODO: implement mapGillSpeed() below — the relationship between
+        // Perlin drift amount and gill flicker rate is yours to define.
+        if (inputGillSpeed != nullptr)
+            inputGillSpeed->value (mapGillSpeed (s.gillSpeed, s.outputLevel));
+
+        // --- Morph position → body tint ---
+        // 0.0 = sine (soft pink, gills barely moving)
+        // 3.0 = noise (translucent, reef-dissolved)
+        if (inputMorphPosition != nullptr)
+            inputMorphPosition->value (s.morphPosition);
+
+        // --- Evolution ---
+        if (inputEvolutionLevel != nullptr)
+            inputEvolutionLevel->value (static_cast<float> (s.evolutionLevel));
+
+        // --- Output level swell ---
+        if (inputLevelPct != nullptr)
+            inputLevelPct->value (s.outputLevel);
+
+        // --- Note-on trigger (rising edge detection) ---
+        if (inputNoteOn != nullptr && s.voiceActive && !wasVoiceActive)
+            inputNoteOn->fire();
+        wasVoiceActive = s.voiceActive;
+
+        // --- Celebration trigger ---
+        if (inputCelebration != nullptr && s.celebration)
+        {
+            inputCelebration->fire();
+            if (animState != nullptr)
+                animState->celebrationTrigger.store (false, std::memory_order_relaxed);
+        }
+
+        // --- Boss mode ---
+        if (inputBossMode != nullptr)
+            inputBossMode->value (s.bossMode);
+    }
+
+    //--------------------------------------------------------------------------
+    // mapGillSpeed — YOUR contribution
+    //
+    // The gill oscillation rate is the single most expressive visual element.
+    // Six bezier curves, oscillating independently — this function decides
+    // how fast they move based on what the synthesis is doing.
+    //
+    // Inputs:
+    //   driftAmount  — morph_drift parameter (0.0–1.0)
+    //                  0 = imperceptible breathing, 1 = obvious wandering
+    //   outputLevel  — instantaneous signal amplitude (0.0–1.0)
+    //                  loud chords should make the gills react
+    //
+    // Returns: Rive input value "gillSpeed" (0.0–1.0)
+    //   0.0 = dead still (Oscar isn't breathing, something is wrong)
+    //   0.15 = resting idle (the floor — Oscar is always alive)
+    //   0.5  = interested / active playing
+    //   1.0  = excited (celebration, boss mode, high drift + loud output)
+    //
+    // Design question: is this linear? Exponential? Does loudness add to drift,
+    // or multiply it? Does Oscar have a minimum resting gill rate even at
+    // drift=0? (He should — gills stop for dead creatures, not living ones.)
+    //--------------------------------------------------------------------------
+    float mapGillSpeed (float driftAmount, float outputLevel) const
+    {
+        constexpr float kFloor = 0.12f;  // Oscar is always alive
+
+        // Exponential curve: pow(x, 0.6) bows upward — small drift still
+        // registers visually, but large drift doesn't feel 3x more than medium.
+        // Biological systems respond this way: sensitive at rest, saturating
+        // at excitation. pow(0.1, 0.6) ≈ 0.25, pow(0.5, 0.6) ≈ 0.66.
+        float driftCurved = std::pow (driftAmount, 0.6f);
+
+        // Loud chords stir the water around Oscar — sympathetic flutter.
+        // Scaled so amplitude alone can't fully drive the gills; drift leads.
+        float levelStir = outputLevel * 0.20f;
+
+        float raw = kFloor + (1.0f - kFloor) * driftCurved + levelStir;
+        return juce::jlimit (kFloor, 1.0f, raw);
+    }
+
+    //--------------------------------------------------------------------------
+    // Procedural Oscar — drawn entirely with JUCE paths.
+    // No .riv file required. This IS Oscar, not a fallback.
+    // Scales from 24 px (header indicator) to 200 px (full panel).
+    //--------------------------------------------------------------------------
+
+    void paintProcedural (juce::Graphics& g)
+    {
+        auto bounds  = getLocalBounds().toFloat();
+        const float cx = bounds.getCentreX();
+        const float cy = bounds.getCentreY() + bounds.getHeight() * 0.04f;
+        const float R  = std::min (bounds.getWidth(), bounds.getHeight()) * 0.42f;
+
+        if (R < 4.0f) return;
+
+        const float time = static_cast<float> (frameCount) / 60.0f;
+
+        // -- Color palette ---------------------------------------------------
+        const float morphT   = lastSnapshot.morphPosition / 3.0f;
+        const float bodyAlpha = 1.0f - morphT * 0.20f;
+        const float bodySat   = 1.0f - morphT * 0.60f;
+
+        const auto gillPink  = juce::Colour (0xFFE8839B);
+        const auto bellyPink = juce::Colour (0xFFF2B3C1);
+        const auto deepPink  = juce::Colour (0xFFC45E7A);
+        const auto gillTipHi = juce::Colour (0xFFFFD6E0);
+        const auto eyeDark   = juce::Colour (0xFF3D2B3D);
+        const auto pupilBlk  = juce::Colour (0xFF1A1A2E);
+
+        const auto bodyColor = gillPink
+            .withMultipliedSaturation (bodySat)
+            .withAlpha (bodyAlpha);
+
+        // Body swell from output amplitude (max 4% expansion)
+        const float swell = 1.0f + lastSnapshot.outputLevel * 0.04f;
+
+        // -- Gills (drawn first — behind body) --------------------------------
+        // 6 stalks: 3 left, 3 right. Each oscillates independently.
+        struct GillDef { float phase; float rate; float side; int rank; };
+        static constexpr GillDef kGills[6] = {
+            { 0.0f, 1.00f, -1.0f, 0 },
+            { 0.4f, 0.87f, -1.0f, 1 },
+            { 1.1f, 1.13f, -1.0f, 2 },
+            { 0.2f, 0.95f, +1.0f, 0 },
+            { 0.8f, 1.07f, +1.0f, 1 },
+            { 1.5f, 0.91f, +1.0f, 2 },
+        };
+
+        const float gillLen    = R * 0.60f;
+        const float gillHz     = lastSnapshot.gillSpeed * 1.8f; // full oscillations per second
+        const float swingRad   = juce::degreesToRadians (12.0f + lastSnapshot.gillSpeed * 16.0f);
+        const float gillThick  = std::max (1.5f, R * 0.075f);
+
+        for (auto& gd : kGills)
+        {
+            // Three stalks per side, spread slightly apart
+            const float spread = (gd.rank - 1.0f) * R * 0.16f;
+            const float baseX  = cx + gd.side * R * 0.50f + spread * gd.side;
+            const float baseY  = cy - R * 0.32f;
+
+            // Oscillation: sine with per-gill phase and rate offset
+            const float swing = std::sin (time * gillHz * juce::MathConstants<float>::twoPi
+                                          * gd.rate + gd.phase) * swingRad;
+
+            // Base direction: angled upward and outward, then swing applied
+            const float lean   = gd.side * 0.45f;              // lean outward ~26°
+            const float angle  = -juce::MathConstants<float>::halfPi + lean + swing;
+
+            const float tipX = baseX + std::cos (angle) * gillLen;
+            const float tipY = baseY + std::sin (angle) * gillLen;
+
+            // Quadratic bezier gives stalk a natural S-curve
+            const float ctrlAngle = -juce::MathConstants<float>::halfPi + lean * 0.5f + swing * 0.3f;
+            const float ctrlX = baseX + std::cos (ctrlAngle) * gillLen * 0.55f;
+            const float ctrlY = baseY + std::sin (ctrlAngle) * gillLen * 0.55f;
+
+            juce::Path stalk;
+            stalk.startNewSubPath (baseX, baseY);
+            stalk.quadraticTo (ctrlX, ctrlY, tipX, tipY);
+
+            g.setGradientFill (juce::ColourGradient (
+                bodyColor, baseX, baseY,
+                gillTipHi.withAlpha (bodyAlpha * 0.8f), tipX, tipY, false));
+            g.strokePath (stalk, juce::PathStrokeType (
+                gillThick, juce::PathStrokeType::curved, juce::PathStrokeType::rounded));
+
+            // Feathery branches at tip — only when large enough to see
+            if (R > 14.0f)
+            {
+                const float bLen = gillLen * 0.28f;
+                juce::Path branches;
+                branches.startNewSubPath (tipX, tipY);
+                branches.lineTo (tipX + std::cos (angle + 0.45f) * bLen,
+                                 tipY + std::sin (angle + 0.45f) * bLen);
+                branches.startNewSubPath (tipX, tipY);
+                branches.lineTo (tipX + std::cos (angle - 0.45f) * bLen,
+                                 tipY + std::sin (angle - 0.45f) * bLen);
+
+                g.setColour (gillTipHi.withAlpha (bodyAlpha * 0.65f));
+                g.strokePath (branches, juce::PathStrokeType (
+                    gillThick * 0.45f, juce::PathStrokeType::curved,
+                    juce::PathStrokeType::rounded));
+            }
+        }
+
+        // -- Body -------------------------------------------------------------
+        const float bw = R * 1.55f * swell;
+        const float bh = R * 1.15f * swell;
+        g.setColour (bodyColor);
+        g.fillEllipse (cx - bw * 0.5f, cy - bh * 0.5f, bw, bh);
+
+        // Outline
+        g.setColour (deepPink.withAlpha (bodyAlpha * 0.35f));
+        g.drawEllipse (cx - bw * 0.5f, cy - bh * 0.5f, bw, bh, 1.2f);
+
+        // -- Belly highlight --------------------------------------------------
+        const float bellyw = R * 0.85f * swell;
+        const float bellyh = R * 0.60f * swell;
+        g.setColour (bellyPink.withAlpha (bodyAlpha * 0.55f));
+        g.fillEllipse (cx - bellyw * 0.5f,
+                       cy - bellyh * 0.5f + R * 0.18f,
+                       bellyw, bellyh);
+
+        // -- Legs (only at ≥ 32 px effective radius) --------------------------
+        if (R >= 32.0f)
+        {
+            const float legW = R * 0.22f;
+            const float legH = R * 0.32f;
+            const float legY = cy + R * 0.52f;
+
+            g.setColour (bodyColor.darker (0.08f));
+            g.fillRoundedRectangle (cx - R * 0.52f - legW * 0.5f, legY, legW, legH, legW * 0.4f);
+            g.fillRoundedRectangle (cx + R * 0.52f - legW * 0.5f, legY, legW, legH, legW * 0.4f);
+        }
+
+        // -- Eyes -------------------------------------------------------------
+        if (R >= 8.0f)
+        {
+            const float eyeR = R * 0.175f;
+            const float eyeY = cy - R * 0.08f;
+            const float eLx  = cx - R * 0.26f;
+            const float eRx  = cx + R * 0.26f;
+
+            // Iris
+            g.setColour (eyeDark);
+            g.fillEllipse (eLx - eyeR, eyeY - eyeR, eyeR * 2.0f, eyeR * 2.0f);
+            g.fillEllipse (eRx - eyeR, eyeY - eyeR, eyeR * 2.0f, eyeR * 2.0f);
+
+            // Pupils — shift slightly at high morph (Oscar notices the timbral change)
+            const float pupilR  = eyeR * 0.55f;
+            const float pupilOx = morphT * eyeR * 0.25f;
+
+            g.setColour (pupilBlk);
+            g.fillEllipse (eLx - pupilR + pupilOx, eyeY - pupilR, pupilR * 2.0f, pupilR * 2.0f);
+            g.fillEllipse (eRx - pupilR + pupilOx, eyeY - pupilR, pupilR * 2.0f, pupilR * 2.0f);
+
+            // Specular dot (makes eyes feel wet and alive)
+            if (R >= 14.0f)
+            {
+                const float specR = pupilR * 0.3f;
+                g.setColour (juce::Colours::white.withAlpha (0.7f));
+                g.fillEllipse (eLx - pupilR * 0.3f, eyeY - pupilR * 0.3f, specR * 2.0f, specR * 2.0f);
+                g.fillEllipse (eRx - pupilR * 0.3f, eyeY - pupilR * 0.3f, specR * 2.0f, specR * 2.0f);
+            }
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Rive runtime objects
+    //--------------------------------------------------------------------------
+
+    // Minimal Rive factory for JUCE — constructs RenderPath/RenderPaint via
+    // OscarJuceRenderer's factory methods. The factory itself is stateless.
+    struct JuceRiveFactory : public rive::Factory
+    {
+        rive::rcp<rive::RenderBuffer> makeRenderBuffer (
+            rive::RenderBufferType, rive::RenderBufferFlags, size_t) override
+        { return nullptr; }
+
+        rive::rcp<rive::RenderShader> makeLinearGradient (
+            float, float, float, float,
+            const rive::ColorInt*, const float*, int) override
+        { return nullptr; }
+
+        rive::rcp<rive::RenderShader> makeRadialGradient (
+            float, float, float,
+            const rive::ColorInt*, const float*, int) override
+        { return nullptr; }
+
+        rive::rcp<rive::RenderPath> makeRenderPath (
+            rive::RawPath& rawPath, rive::FillRule fill) override
+        {
+            auto p = rive::make_rcp<OscarJucePath>();
+            // Convert RawPath to OscarJucePath
+            for (auto [verb, pts] : rawPath)
+            {
+                switch (verb)
+                {
+                    case rive::PathVerb::move:  p->moveTo (pts[0].x, pts[0].y); break;
+                    case rive::PathVerb::line:  p->lineTo (pts[0].x, pts[0].y); break;
+                    case rive::PathVerb::cubic:
+                        p->cubicTo (pts[0].x, pts[0].y, pts[1].x, pts[1].y, pts[2].x, pts[2].y);
+                        break;
+                    case rive::PathVerb::close: p->close(); break;
+                    default: break;
+                }
+            }
+            if (fill == rive::FillRule::evenOdd)
+                p->fillRule (rive::FillRule::evenOdd);
+            return p;
+        }
+
+        rive::rcp<rive::RenderPath> makeEmptyRenderPath() override
+        { return rive::make_rcp<OscarJucePath>(); }
+
+        rive::rcp<rive::RenderPaint> makeRenderPaint() override
+        { return rive::make_rcp<OscarJucePaint>(); }
+
+        rive::rcp<rive::RenderImage> decodeImage (rive::Span<const uint8_t>) override
+        { return nullptr; }
+    };
+
+    JuceRiveFactory factory;
+
+    std::unique_ptr<rive::File>                 riveFile;
+    std::unique_ptr<rive::ArtboardInstance>     artboard;
+    std::unique_ptr<rive::StateMachineInstance> stateMachine;
+
+    // Cached state machine input pointers (no string lookup per frame)
+    rive::SMINumber*  inputGillSpeed      = nullptr;
+    rive::SMINumber*  inputMorphPosition  = nullptr;
+    rive::SMINumber*  inputEvolutionLevel = nullptr;
+    rive::SMINumber*  inputLevelPct       = nullptr;
+    rive::SMITrigger* inputNoteOn         = nullptr;
+    rive::SMITrigger* inputCelebration    = nullptr;
+    rive::SMIBool*    inputBossMode       = nullptr;
+
+    //--------------------------------------------------------------------------
+    // State
+    //--------------------------------------------------------------------------
+
+    OscarAnimState*              animState      = nullptr;
+    OscarAnimState::Snapshot     lastSnapshot;       // last read from animState
+    bool                         reducedMotion  = false;
+    bool                         wasVoiceActive = false;
+    uint64_t                     frameCount     = 0;
+};
+
+} // namespace xomnibus

--- a/Source/UI/XOmnibusEditor.h
+++ b/Source/UI/XOmnibusEditor.h
@@ -2,6 +2,8 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include "../XOmnibusProcessor.h"
 #include "../Core/EngineRegistry.h"
+#include "../Engines/Morph/MorphEngine.h"
+#include "OddOscar/OscarRiveComponent.h"
 
 namespace xomnibus {
 
@@ -2068,6 +2070,18 @@ public:
         addAndMakeVisible(masterFXStrip);
         addAndMakeVisible(presetBrowser);
 
+        // Oscar — transparent until OddOscar engine is loaded in a slot
+        addAndMakeVisible(oscarComponent);
+        oscarComponent.setAlpha(0.0f);
+        oscarComponent.setInterceptsMouseClicks(false, false);
+
+        // Load oscar.riv from embedded binary data
+        {
+            int rivDataSize = 0;
+            if (const void* rivData = BinaryData::getNamedResource("oscar_riv", rivDataSize))
+                oscarComponent.loadRiv(rivData, static_cast<size_t>(rivDataSize));
+        }
+
         detail.setVisible(false);
         detail.setAlpha(0.0f);
         chordPanel.setVisible(false);
@@ -2123,7 +2137,11 @@ public:
             if (slot >= 0 && slot < XOmnibusProcessor::MaxSlots)
                 tiles[slot]->refresh();
             overview.refresh();
+            refreshOscar();
         };
+
+        // Wire Oscar to any OddOscar engine that may already be loaded
+        refreshOscar();
 
         setSize(880, 562);
         setResizable(true, true);
@@ -2139,6 +2157,15 @@ public:
     {
         stopTimer();
         processor.onEngineChanged = nullptr; // prevent callback after editor is destroyed
+
+        // Detach Oscar from any MorphEngine before the component is destroyed.
+        // Without this, a live renderBlock() could write to the now-dead oscarAnimState.
+        oscarComponent.stop();
+        oscarComponent.setAnimState(nullptr);
+        for (int i = 0; i < XOmnibusProcessor::MaxSlots; ++i)
+            if (auto* eng = dynamic_cast<MorphEngine*>(processor.getEngine(i)))
+                eng->setOscarAnimState(nullptr);
+
         setLookAndFeel(nullptr);
     }
 
@@ -2234,6 +2261,12 @@ public:
         themeToggleBtn.setBounds(header.removeFromRight(32).reduced(2, 12));
         cmToggleBtn.setBounds(header.removeFromRight(42).reduced(4, 12));
 
+        // Oscar — lives in the header gap between title and coupling text.
+        // Title occupies x=16..176; Oscar sits immediately right at x=185.
+        // Square: kHeaderH minus vertical padding on each side.
+        const int oscarSize = kHeaderH - 8;
+        oscarComponent.setBounds(185, 4, oscarSize, oscarSize);
+
         // Bottom strips (from bottom up)
         masterFXStrip.setBounds(area.removeFromBottom(kMasterFXH).reduced(6, 3));
         macros.setBounds(area.removeFromBottom(kMacroH).reduced(6, 4));
@@ -2251,6 +2284,31 @@ public:
     }
 
 private:
+    // Scan all engine slots for a MorphEngine (OddOscar). If found, wire the
+    // animState so the engine writes to it and Oscar's component reads from it.
+    // Called on construction and every time onEngineChanged fires.
+    void refreshOscar()
+    {
+        MorphEngine* found = nullptr;
+        for (int i = 0; i < XOmnibusProcessor::MaxSlots; ++i)
+            if (auto* eng = dynamic_cast<MorphEngine*>(processor.getEngine(i)))
+                { found = eng; break; }
+
+        if (found != nullptr)
+        {
+            found->setOscarAnimState(&oscarAnimState);
+            oscarComponent.setAnimState(&oscarAnimState);
+            oscarComponent.start();
+            oscarComponent.setAlpha(1.0f);
+        }
+        else
+        {
+            oscarComponent.stop();
+            oscarComponent.setAnimState(nullptr);
+            oscarComponent.setAlpha(0.0f);
+        }
+    }
+
     void selectSlot(int slot)
     {
         // Deselect all tiles
@@ -2404,6 +2462,10 @@ private:
     juce::TextButton   themeToggleBtn;
 
     int selectedSlot = -1;
+
+    // Oscar animation — state bridge (owned here, engine holds raw pointer)
+    OscarAnimState     oscarAnimState;
+    OscarRiveComponent oscarComponent;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(XOmnibusEditor)
 };


### PR DESCRIPTION
## Summary

- **OscarAnimState** — lock-free atomic bridge between MorphEngine (audio thread) and OscarRiveComponent (UI thread at 60 Hz), following the OpticModOutputs pattern
- **OscarJuceRenderer** — implements `rive::Renderer` against `juce::Graphics` (save/restore stack, fill/stroke/gradient, JUCE path bridge) for future Rive file support
- **OscarRiveComponent** — JUCE component with procedural Oscar drawing: 15 shapes, 6 independent bezier gill stalks with per-gill phase offsets and rate multipliers; exponential gill speed curve `pow(drift, 0.6) + 0.20 * outputLevel`
- **MorphEngine** — writes `gillSpeed`, `morphPosition`, `voiceActive`, `outputLevel` atomics at end of every `renderBlock()`; exposes `setOscarAnimState()`
- **XOmnibusEditor** — Oscar lives in header gap at x=185 (between title and coupling text), ~36px square; `refreshOscar()` scans all slots via `dynamic_cast<MorphEngine*>`, fades in/out when OddOscar loads/unloads
- **CMakeLists** — Rive runtime stub (`Libs/rive-cpp`), `OscarRivData` binary target, Oscar UI sources linked
- **Docs/oscar_rive_spec.md** — complete state machine spec (artboard, 15 shapes, 6 states, all input names, gill oscillation parameters, evolution blend states) for when a `.riv` file is authored
- **Resources/Oscar/** — placeholder directory for `oscar.riv`

## How Oscar works

Oscar breathes at the drift rate of whatever pad OddOscar is playing. His 6 gill stalks oscillate independently (incommensurable phase offsets ensure they never sync). Gill speed uses an exponential response curve — small drift values register visually, large drift saturates naturally. Output level adds sympathetic flutter so loud chords stir the water. He appears in the editor header when OddOscar is loaded in any slot, disappears when it's unloaded.

## Test plan

- [ ] Load OddOscar in any slot → Oscar appears in header (Axolotl Gill Pink `#E8839B`)
- [ ] Unload OddOscar → Oscar fades to invisible
- [ ] Adjust `morph_drift` → gill oscillation rate changes
- [ ] Adjust `morph_morph` → body desaturates at high values, pupils shift
- [ ] Play loud chord → body swells slightly, gills flutter faster
- [ ] Resize editor window → Oscar maintains position at x=185, scales proportionally
- [ ] Build without `Libs/rive-cpp` present → comment out `add_subdirectory(Libs/rive-cpp)` and `rive` link target; procedural drawing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)