### PR TITLE
Add Figma MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Configures the official Figma remote MCP server (https://mcp.figma.com/mcp) at project scope so the team can reference Figma designs from Claude Code.

https://claude.ai/code/session_01Xq1ttLUMYTWaFJHchsPBNM