### PR TITLE
Fleet DSP audit — session 2 (silence-gate + P1s + deferred trio)

### DIFF
--- a/Source/Core/SynthEngine.h
+++ b/Source/Core/SynthEngine.h
@@ -182,6 +182,11 @@ public:
     // Override in analysis engines (Osmosis) to receive external audio without RTTI.
     virtual bool isAnalysisEngine() const { return false; }
 
+    // External audio injection hook for analysis / vocoder / sidechain engines.
+    // Base-class no-op; engines that consume external audio (Osmosis, Obstruent)
+    // override. Called from the audio thread when an external buffer is present.
+    virtual void setExternalInput(const float* /*left*/, const float* /*right*/, int /*numSamples*/) {}
+
     //-- MPE Expression --------------------------------------------------------
 
     // Set the MPE manager reference for per-note expression queries.
@@ -204,7 +209,7 @@ public:
     // CRITICAL INTEGRATION ORDER in renderBlock():
     //   1. Parse MIDI → call wakeSilenceGate() on note-on
     //   2. Check isSilenceGateBypassed()
-    //   3. If bypassed: clear buffer, return early (zero CPU)
+    //   3. If bypassed: return early (zero CPU) — do NOT clear buffer (additive-mix semantics)
     //   4. If active: run DSP, then call analyzeForSilenceGate()
     //
 

--- a/Source/Engines/Oaken/OakenEngine.h
+++ b/Source/Engines/Oaken/OakenEngine.h
@@ -491,7 +491,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oasis/OasisEngine.h
+++ b/Source/Engines/Oasis/OasisEngine.h
@@ -699,7 +699,6 @@ public:
         // 2. Silence gate bypass
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Obbligato/ObbligatoEngine.h
+++ b/Source/Engines/Obbligato/ObbligatoEngine.h
@@ -351,7 +351,6 @@ public:
         // SilenceGate: skip all DSP when the engine has been silent long enough
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buf.clear();
             return;
         }
 

--- a/Source/Engines/Obelisk/ObeliskEngine.h
+++ b/Source/Engines/Obelisk/ObeliskEngine.h
@@ -683,7 +683,6 @@ public:
         // Step 2: Silence gate bypass
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Obiont/ObiontEngine.h
+++ b/Source/Engines/Obiont/ObiontEngine.h
@@ -333,6 +333,95 @@ struct ObiontLFO
 };
 
 // ---------------------------------------------------------------------------
+// Precomputed sinusoidal seed lookup tables — eliminates std::sin calls on the
+// audio thread inside ObiontCA1D::doSeed() and ObiontCA2D::doSeed().
+//
+// 1D table: kObiontSeedLUT1D[freq-1][i] = 0.5 + 0.5*sin(2π*freq*i/256)
+//   freqs 1–12 (index 0–11), 256 cells → 12*256 = 3072 floats (12 KB)
+// 2D column table: kObiontSeedColLUT2D[freq-1][col] = sin(2π*freq*col/64)
+//   freqs 1–12, 64 cols → 12*64 = 768 floats (3 KB)
+// 2D row table: kObiontSeedRowLUT2D[row] = sin(π*row/64)
+//   64 rows → 64 floats (256 B)
+// Combined 2D val = 0.5 + 0.4 * colLUT * rowLUT  (same math as original)
+// ---------------------------------------------------------------------------
+namespace ObiontSeedLUT
+{
+    static constexpr int kFreqs  = 12;
+    static constexpr int kN1D    = 256;
+    static constexpr int kW2D    = 64;
+    static constexpr int kH2D    = 64;
+
+    // Build the 1D table at compile time (C++14 constexpr).
+    struct LUT1D
+    {
+        float v[kFreqs][kN1D];
+        constexpr LUT1D() : v{}
+        {
+            for (int f = 0; f < kFreqs; ++f)
+                for (int i = 0; i < kN1D; ++i)
+                {
+                    // constexpr-friendly Bhaskara I sin approximation for table build.
+                    // Full precision std::sin cannot be used in a constexpr context on
+                    // all compilers, so we use a float approximation here (error <0.2%).
+                    // The noise term added in doSeed() (±0.05 range) is >> this error.
+                    float x = 6.28318530718f * (f + 1) * i / (float)kN1D;
+                    // Range-reduce x to [0, 2π] (already is) then to [0, π]
+                    // Using Bhaskara I: sin(x) ≈ 16x(π-x) / (5π²-4x(π-x)) for x∈[0,π]
+                    // Map x into [0, π] by reflecting
+                    bool neg = false;
+                    if (x > 6.28318530718f) x -= 6.28318530718f;
+                    if (x > 3.14159265359f) { x -= 3.14159265359f; neg = true; }
+                    const float pi = 3.14159265359f;
+                    float xpi = x * (pi - x);
+                    float s = 16.f * xpi / (5.f * pi * pi - 4.f * xpi);
+                    if (neg) s = -s;
+                    v[f][i] = 0.5f + 0.5f * s;
+                }
+        }
+    };
+    static constexpr LUT1D lut1D{};
+
+    struct ColLUT2D
+    {
+        float v[kFreqs][kW2D];
+        constexpr ColLUT2D() : v{}
+        {
+            for (int f = 0; f < kFreqs; ++f)
+                for (int col = 0; col < kW2D; ++col)
+                {
+                    float x = 6.28318530718f * (f + 1) * col / (float)kW2D;
+                    bool neg = false;
+                    if (x > 6.28318530718f) x -= 6.28318530718f;
+                    if (x > 3.14159265359f) { x -= 3.14159265359f; neg = true; }
+                    const float pi = 3.14159265359f;
+                    float xpi = x * (pi - x);
+                    float s = 16.f * xpi / (5.f * pi * pi - 4.f * xpi);
+                    if (neg) s = -s;
+                    v[f][col] = s;
+                }
+        }
+    };
+    static constexpr ColLUT2D colLut2D{};
+
+    struct RowLUT2D
+    {
+        float v[kH2D];
+        constexpr RowLUT2D() : v{}
+        {
+            for (int row = 0; row < kH2D; ++row)
+            {
+                float x = 3.14159265359f * row / (float)kH2D;
+                // x is already in [0, π]
+                const float pi = 3.14159265359f;
+                float xpi = x * (pi - x);
+                v[row] = 16.f * xpi / (5.f * pi * pi - 4.f * xpi);
+            }
+        }
+    };
+    static constexpr RowLUT2D rowLut2D{};
+} // namespace ObiontSeedLUT
+
+// ---------------------------------------------------------------------------
 // ObiontCA1D — 1D Elementary Cellular Automaton (256-cell ring, triple-buffered)
 //
 // Thread model:
@@ -402,10 +491,14 @@ struct ObiontCA1D
     {
         const int frequency = pendingSeedFreq_.load(std::memory_order_relaxed);
         const float density = pendingSeedDensity_.load(std::memory_order_relaxed);
+        // Clamp frequency to table range (1–12). Caller always passes 1–12
+        // via (midiNote%12)+1, but guard against edge cases.
+        const int freqIdx = juce::jlimit(0, ObiontSeedLUT::kFreqs - 1, frequency - 1);
+        const float* sinRow = ObiontSeedLUT::lut1D.v[freqIdx];
         for (int i = 0; i < kObiontGridWidth1D; ++i)
         {
-            // Sinusoidal envelope: sin(2π * freq * i / N) → 0..1
-            float val = 0.5f + 0.5f * std::sin(6.28318530718f * frequency * i / (float)kObiontGridWidth1D);
+            // Sinusoidal envelope from precomputed LUT — no std::sin on audio thread
+            float val = sinRow[i];
             // Add small chaos from RNG
             rng = rng * 1664525u + 1013904223u;
             float noise = (float)(rng & 0xFFFF) / 65535.f * 0.1f;
@@ -576,15 +669,16 @@ struct ObiontCA2D
         const int readIdx = readyBuf.load(std::memory_order_relaxed);
         uint8_t* dst = (readIdx == 0) ? gridB : gridA;
 
+        // Clamp frequency to table range (1–12).
+        const int freqIdx2D = juce::jlimit(0, ObiontSeedLUT::kFreqs - 1, seedFreq - 1);
+        const float* colSin = ObiontSeedLUT::colLut2D.v[freqIdx2D];
         for (int row = 0; row < kH; ++row)
         {
+            // Row envelope from precomputed LUT — no std::sin on audio thread
+            const float rowSin = ObiontSeedLUT::rowLut2D.v[row];
             for (int col = 0; col < kW; ++col)
             {
-                // Column-varying sinusoidal probability envelope
-                float colPhase = 6.28318530718f * seedFreq * col / (float)kW;
-                // Row-varying envelope: slow half-wave across height
-                float rowPhase = 3.14159265358979f * row / (float)kH;
-                float val = 0.5f + 0.4f * std::sin(colPhase) * std::sin(rowPhase);
+                float val = 0.5f + 0.4f * colSin[col] * rowSin;
                 // Small RNG perturbation
                 rng = rng * 1664525u + 1013904223u;
                 float noise = (float)(rng & 0xFFFF) / 65535.f * 0.15f;

--- a/Source/Engines/Obiont/ObiontEngine.h
+++ b/Source/Engines/Obiont/ObiontEngine.h
@@ -1273,7 +1273,6 @@ public:
         // 2. SilenceGate bypass
         if (isSilenceGateBypassed())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Obrix/ObrixEngine.h
+++ b/Source/Engines/Obrix/ObrixEngine.h
@@ -530,7 +530,6 @@ public:
             }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             couplingPitchMod.store(0.0f);
             couplingCutoffMod.store(0.0f);
             couplingWtPosMod.store(0.0f);

--- a/Source/Engines/Observandum/ObservandumEngine.h
+++ b/Source/Engines/Observandum/ObservandumEngine.h
@@ -551,7 +551,6 @@ public:
 
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/OceanDeep/OceandeepEngine.h
+++ b/Source/Engines/OceanDeep/OceandeepEngine.h
@@ -675,7 +675,6 @@ public:
 
         // 2. Check SilenceGate bypass
         if (isSilenceGateBypassed()) {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Ochre/OchreEngine.h
+++ b/Source/Engines/Ochre/OchreEngine.h
@@ -585,7 +585,6 @@ public:
         // SilenceGate bypass
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Octant/OctantEngine.h
+++ b/Source/Engines/Octant/OctantEngine.h
@@ -679,7 +679,6 @@ public:
         }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Octave/OctaveEngine.h
+++ b/Source/Engines/Octave/OctaveEngine.h
@@ -418,7 +418,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oddfellow/OddfellowEngine.h
+++ b/Source/Engines/Oddfellow/OddfellowEngine.h
@@ -349,7 +349,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Offering/OfferingEngine.h
+++ b/Source/Engines/Offering/OfferingEngine.h
@@ -284,7 +284,6 @@ public:
         // ── 2. SilenceGate bypass ──────────────────────────────────────
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL_ = couplingCacheR_ = 0.0f;
             // Reset coupling accumulators on bypass path too — coupling inputs
             // may still arrive even when engine is silent; discard them cleanly.

--- a/Source/Engines/Ogive/OgiveEngine.h
+++ b/Source/Engines/Ogive/OgiveEngine.h
@@ -401,7 +401,6 @@ public:
         // Silence gate bypass: if idle and no MIDI, clear and return
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Ogre/OgreEngine.h
+++ b/Source/Engines/Ogre/OgreEngine.h
@@ -255,7 +255,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Okeanos/OkeanosEngine.h
+++ b/Source/Engines/Okeanos/OkeanosEngine.h
@@ -414,7 +414,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Olate/OlateEngine.h
+++ b/Source/Engines/Olate/OlateEngine.h
@@ -250,7 +250,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oleg/OlegEngine.h
+++ b/Source/Engines/Oleg/OlegEngine.h
@@ -757,7 +757,6 @@ public:
         // Step 2: bypass check
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Olvido/OlvidoEngine.h
+++ b/Source/Engines/Olvido/OlvidoEngine.h
@@ -366,6 +366,23 @@ public:
             actualCrossover[i] = juce::jlimit(20.0f, 20000.0f,
                 kOlvidoCrossoverBase[i] * shorelineShift);
 
+        // ---- Hoist crossover filter coefficients (block-constant) ----
+        // actualCrossover[] depends only on paramShoreline (block-constant).
+        // Q=0.7071 and sampleRateFloat are also block-constant.
+        // Computing setCoefficients_fast once per block per voice saves
+        // ~10 trig calls per active voice per sample (5 LP + 5 HP).
+        for (auto& v : voices)
+        {
+            if (!v.active) continue;
+            for (int ci = 0; ci < 5; ++ci)
+            {
+                v.crossoverLP[ci].setMode(CytomicSVF::Mode::LowPass);
+                v.crossoverLP[ci].setCoefficients_fast(actualCrossover[ci], 0.7071f, sampleRateFloat);
+                v.crossoverHP[ci].setMode(CytomicSVF::Mode::HighPass);
+                v.crossoverHP[ci].setCoefficients_fast(actualCrossover[ci], 0.7071f, sampleRateFloat);
+            }
+        }
+
         // ---- Pitch bend ratio (±2 semitones) ----
         const float pitchBendRatio = std::pow(2.0f, pitchBendNorm * 2.0f / 12.0f);
 
@@ -567,14 +584,11 @@ public:
 
                 for (int ci = 0; ci < 5; ++ci)
                 {
+                    // Coefficients already set at block level (block-constant).
                     // Low-pass at this crossover → goes into band ci
-                    voice.crossoverLP[ci].setMode(CytomicSVF::Mode::LowPass);
-                    voice.crossoverLP[ci].setCoefficients_fast(actualCrossover[ci], 0.7071f, sampleRateFloat);
                     bandSignal[ci] = voice.crossoverLP[ci].processSample(residual);
 
                     // High-pass continues to next band
-                    voice.crossoverHP[ci].setMode(CytomicSVF::Mode::HighPass);
-                    voice.crossoverHP[ci].setCoefficients_fast(actualCrossover[ci], 0.7071f, sampleRateFloat);
                     residual = voice.crossoverHP[ci].processSample(residual);
 
                     bandSignal[ci] = flushDenormal(bandSignal[ci]);

--- a/Source/Engines/Olvido/OlvidoEngine.h
+++ b/Source/Engines/Olvido/OlvidoEngine.h
@@ -422,7 +422,6 @@ public:
         // Silence gate bypass: if idle and no MIDI, clear and return
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Omega/OmegaEngine.h
+++ b/Source/Engines/Omega/OmegaEngine.h
@@ -312,7 +312,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Omega/OmegaEngine.h
+++ b/Source/Engines/Omega/OmegaEngine.h
@@ -358,6 +358,7 @@ public:
         float effectiveModIndex = std::clamp(pModIndex + macroChar * 3.0f + modWheelAmount * 4.0f, 0.0f, 20.0f);
         float effectiveFeedback = std::clamp(pFeedback + aftertouchAmount * 0.3f + macroMove * 0.2f, 0.0f, 1.0f);
         float effectiveBright = std::clamp(pBrightness + macroChar * 4000.0f + couplingFilterMod, 200.0f, 20000.0f);
+        const float blockCouplingPitchMod = couplingPitchMod;
 
         smoothModIndex.set(effectiveModIndex);
         smoothRatio.set(effectiveRatio);
@@ -436,7 +437,7 @@ public:
                 // panL/panR precomputed before sample loop (CPU fix 2 — block-constant).
 
                 float freq = voice.glide.process();
-                freq *= PitchBendUtil::semitonesToFreqRatio(bendSemitones + couplingPitchMod);
+                freq *= PitchBendUtil::semitonesToFreqRatio(bendSemitones + blockCouplingPitchMod);
 
                 float lfo1Val = voice.lfo1.process() * lfo1Depth;
                 float lfo2Val = voice.lfo2.process() * lfo2Depth;

--- a/Source/Engines/Ondine/OndineEngine.h
+++ b/Source/Engines/Ondine/OndineEngine.h
@@ -601,7 +601,6 @@ public:
         }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Onkolo/OnkoloEngine.h
+++ b/Source/Engines/Onkolo/OnkoloEngine.h
@@ -406,7 +406,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oobleck/OobleckEngine.h
+++ b/Source/Engines/Oobleck/OobleckEngine.h
@@ -699,7 +699,6 @@ public:
         // ── Step 2: Silence gate bypass check ────────────────────────────────
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Oort/OortEngine.h
+++ b/Source/Engines/Oort/OortEngine.h
@@ -852,7 +852,6 @@ public:
         }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Ooze/OozeEngine.h
+++ b/Source/Engines/Ooze/OozeEngine.h
@@ -676,7 +676,6 @@ public:
         // ── Step 2: Silence gate bypass ───────────────────────────────────────
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Opaline/OpalineEngine.h
+++ b/Source/Engines/Opaline/OpalineEngine.h
@@ -520,7 +520,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Opcode/OpcodeEngine.h
+++ b/Source/Engines/Opcode/OpcodeEngine.h
@@ -361,7 +361,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/OpenSky/OpenSkyEngine.h
+++ b/Source/Engines/OpenSky/OpenSkyEngine.h
@@ -607,7 +607,6 @@ public:
             }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Opera/OperaAdapter.h
+++ b/Source/Engines/Opera/OperaAdapter.h
@@ -48,7 +48,6 @@ public:
 
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Opsin/OpsinEngine.h
+++ b/Source/Engines/Opsin/OpsinEngine.h
@@ -640,7 +640,6 @@ public:
         // Check silence gate
         if (isSilenceGateBypassed())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Orbweave/OrbweaveEngine.h
+++ b/Source/Engines/Orbweave/OrbweaveEngine.h
@@ -277,7 +277,6 @@ public:
             }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Orchard/OrchardEngine.h
+++ b/Source/Engines/Orchard/OrchardEngine.h
@@ -269,7 +269,6 @@ public:
 
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Organism/OrganismEngine.h
+++ b/Source/Engines/Organism/OrganismEngine.h
@@ -634,7 +634,6 @@ public:
         // 2. Check SilenceGate bypass
         if (isSilenceGateBypassed())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Orrery/OrreryEngine.h
+++ b/Source/Engines/Orrery/OrreryEngine.h
@@ -870,7 +870,11 @@ private:
         const float orbitPhaseInc = effectiveOrbitSpeed / sampleRateFloat;
         const float kTwoPi = 6.28318530718f;
 
-        // Set up LFO configs for all voices (block-rate)
+        // Set up LFO configs and envelope params for all voices (block-rate)
+        // Hoisted per-block (was incorrectly per-sample — fix 2026-04-19): setParams fires once per
+        // block, not per sample. ampAtk/Dec/Sus/Rel and fltAtk/Dec/Sus/Rel are block-constant atomic
+        // loads already captured above; recomputing envelope coefficients numSamples× per block was
+        // wasteful and could cause zipper noise if params changed mid-block.
         for (auto& v : voices)
         {
             if (!v.active) continue;
@@ -878,6 +882,8 @@ private:
             v.lfo1.setShape(lfo1Shape);
             v.lfo2.setRate(lfo2Rate, sampleRateFloat);
             v.lfo2.setShape(lfo2Shape);
+            v.ampEnv.setParams(ampAtk, ampDec, ampSus, ampRel, sampleRateFloat);
+            v.filterEnv.setParams(fltAtk, fltDec, fltSus, fltRel, sampleRateFloat);
         }
 
         for (int s = startSample; s < endSample; ++s)
@@ -892,7 +898,6 @@ private:
                 if (!v.active) continue;
 
                 // ---- Amp envelope ----
-                v.ampEnv.setParams(ampAtk, ampDec, ampSus, ampRel, sampleRateFloat);
                 const float ampLevel = v.ampEnv.process();
 
                 // If envelope finished, deactivate voice
@@ -903,7 +908,6 @@ private:
                 }
 
                 // ---- Filter envelope ----
-                v.filterEnv.setParams(fltAtk, fltDec, fltSus, fltRel, sampleRateFloat);
                 const float fltEnvLevel = v.filterEnv.process();
 
                 // ---- LFO values (per-sample) ----

--- a/Source/Engines/Orrery/OrreryEngine.h
+++ b/Source/Engines/Orrery/OrreryEngine.h
@@ -574,7 +574,6 @@ public:
             }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Ortolan/OrtolanEngine.h
+++ b/Source/Engines/Ortolan/OrtolanEngine.h
@@ -748,7 +748,6 @@ public:
         }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Osier/OsierEngine.h
+++ b/Source/Engines/Osier/OsierEngine.h
@@ -342,7 +342,6 @@ public:
 
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Osmosis/OsmosisEngine.h
+++ b/Source/Engines/Osmosis/OsmosisEngine.h
@@ -137,7 +137,7 @@ public:
     }
 
     //-- External audio injection (called by XOceanusProcessor) ----------------
-    void setExternalInput(const float* left, const float* right, int numSamples)
+    void setExternalInput(const float* left, const float* right, int numSamples) override
     {
         externalBufferL_ = left;
         externalBufferR_ = right;
@@ -156,7 +156,6 @@ public:
         // SilenceGate: early-out when no external audio is present
         if (isSilenceGateBypassed())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Ostracon/OstraconEngine.h
+++ b/Source/Engines/Ostracon/OstraconEngine.h
@@ -403,7 +403,6 @@ public:
         // Silence gate bypass — if silent and no MIDI events, zero buffer and skip
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Otis/OtisEngine.h
+++ b/Source/Engines/Otis/OtisEngine.h
@@ -952,7 +952,6 @@ public:
         // Step 2: Silence gate bypass
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oto/OtoEngine.h
+++ b/Source/Engines/Oto/OtoEngine.h
@@ -474,7 +474,6 @@ public:
         // ---- SRO: silence gate bypass ----
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Ouie/OuieEngine.h
+++ b/Source/Engines/Ouie/OuieEngine.h
@@ -812,7 +812,6 @@ public:
             }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Outflow/OutflowEngine.h
+++ b/Source/Engines/Outflow/OutflowEngine.h
@@ -165,6 +165,7 @@ public:
             {
                 silenceGate.wake();
                 currentNote_ = msg.getNoteNumber();
+                noteFreqRatio_ = std::pow(2.0f, (currentNote_ - 69) / 12.0f); // cache once per note
                 currentVelocity_ = msg.getFloatVelocity();
                 exciterActive_ = true;
                 exciterEnv_ = 1.0f;
@@ -250,8 +251,8 @@ public:
         float excBrightness = 0.3f + currentVelocity_ * 0.7f;
         float excDecayCoeff = fastExp(-6.9078f / (pExcDecay * srF_));
 
-        // Pitch-bent exciter frequency
-        float exciterFreq = 440.0f * std::pow(2.0f, (currentNote_ - 69) / 12.0f) *
+        // Pitch-bent exciter frequency — noteFreqRatio_ is cached in noteOn; bend applied per-block
+        float exciterFreq = 440.0f * noteFreqRatio_ *
                             PitchBendUtil::semitonesToFreqRatio(pitchBendNorm_ * 2.0f);
 
         // Update wind LFO rate based on chaos
@@ -580,6 +581,7 @@ private:
     float exciterEnv_ = 0.0f;
     bool exciterActive_ = false;
     int currentNote_ = 60;
+    float noteFreqRatio_ = 1.0f; // cached: 2^((note-69)/12) — updated in noteOn, read per-block
     float currentVelocity_ = 0.0f;
     uint32_t noiseRng_ = 77u;
 

--- a/Source/Engines/Outlook/OutlookEngine.h
+++ b/Source/Engines/Outlook/OutlookEngine.h
@@ -170,7 +170,6 @@ public:
         // ---- Silence gate bypass ----
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Oven/OvenEngine.h
+++ b/Source/Engines/Oven/OvenEngine.h
@@ -604,7 +604,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Overgrow/OvergrowEngine.h
+++ b/Source/Engines/Overgrow/OvergrowEngine.h
@@ -390,7 +390,6 @@ public:
 
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Overtide/OvertideEngine.h
+++ b/Source/Engines/Overtide/OvertideEngine.h
@@ -651,7 +651,6 @@ public:
         }
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Overtone/OvertoneEngine.h
+++ b/Source/Engines/Overtone/OvertoneEngine.h
@@ -651,7 +651,6 @@ public:
         // 2. Check SilenceGate bypass
         if (isSilenceGateBypassed())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Overworn/OverwornEngine.h
+++ b/Source/Engines/Overworn/OverwornEngine.h
@@ -381,6 +381,17 @@ public:
                 ++activeVoiceCount;
         }
 
+        // Hoisted per-block (was incorrectly per-sample — fix 2026-04-19): setADSR fires once per
+        // block, not per sample. pAmpA/D/S/R and pFiltA/D/S/R are block-constant atomic loads
+        // already captured above; recomputing envelope coefficients 44100× per second was wasteful.
+        for (int v = 0; v < kMaxVoices; ++v)
+        {
+            if (!voices[v].active)
+                continue;
+            voices[v].ampEnv.setADSR(pAmpA, pAmpD, pAmpS, pAmpR);
+            voices[v].filterEnv.setADSR(pFiltA, pFiltD, pFiltS, pFiltR);
+        }
+
         for (int i = 0; i < numSamples; ++i)
         {
             float lfo1Val = lfo1.process();
@@ -452,10 +463,6 @@ public:
                 voice.holdDuration += inverseSr;
                 if (voice.velocity < 0.3f && voice.holdDuration > 8.0f)
                     voice.isInfusion = true;
-
-                // Update envelopes
-                voice.ampEnv.setADSR(pAmpA, pAmpD, pAmpS, pAmpR);
-                voice.filterEnv.setADSR(pFiltA, pFiltD, pFiltS, pFiltR);
 
                 float ampLevel = voice.ampEnv.process();
                 float filtLevel = voice.filterEnv.process();

--- a/Source/Engines/Oware/OwareEngine.h
+++ b/Source/Engines/Oware/OwareEngine.h
@@ -573,7 +573,6 @@ public:
 
         if (isSilenceGateBypassed())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oxalis/OxalisEngine.h
+++ b/Source/Engines/Oxalis/OxalisEngine.h
@@ -351,7 +351,6 @@ public:
 
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear(0, numSamples);
             couplingCacheL = couplingCacheR = 0.0f;
             return;
         }

--- a/Source/Engines/Oxidize/OxidizeAdapter.h
+++ b/Source/Engines/Oxidize/OxidizeAdapter.h
@@ -83,7 +83,6 @@ public:
         // Zero-idle bypass (SRO — eliminates idle CPU when engine is silent)
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 

--- a/Source/Engines/Oxytocin/OxytocinAdapter.h
+++ b/Source/Engines/Oxytocin/OxytocinAdapter.h
@@ -87,7 +87,6 @@ public:
         // Zero-idle bypass
         if (isSilenceGateBypassed() && midi.isEmpty())
         {
-            buffer.clear();
             return;
         }
 


### PR DESCRIPTION
## Summary

Session 2 of the fleet DSP audit. Three commits, ~55 engines touched, all pattern-level correctness/CPU wins. No API changes, no behavior changes for first-in-chain cases — only fixes additive-mix semantics, hoists hot-path waste out of per-sample loops, and caches transcendentals.

- **Bulk Fix 7 (`df3d1a233`) — silence-gate `buffer.clear()` sweep, 51 engines.** Sibling of Bulk Fix 4 (`af9b0e869`). Silenced engines running after another engine in the slot chain were wiping prior audio via destructive `buffer.clear()` on their silence-gate bypass path. Changed to bare `return`. Bonus: `SynthEngine.h` integration-order comment updated — that comment was the root-cause propagator of the pattern fleet-wide.
- **Tier 1 P1s (`191660fd9`) — Omega, Obiont, Overworn.**
  - Omega (OMG-W2-01): coupling pitch was hardwired to zero; `LFOToPitch`/`AmpToPitch` routes now actually reach the oscillator.
  - Obiont (OBN-W4-01): 256× `std::sin` per note-on/steal/anti-extinction → static `constexpr` Bhaskara I LUT. 2D grid (4096 sins/event) also tabled. ~15KB `.rodata`, zero runtime cost.
  - Overworn (WRN-W2-01): `setADSR` hoisted out of per-sample loop for both envelopes. Pattern 1 recurrence that Wave 1 grep missed.
- **Deferred trio (`e0e976591`) — Orrery, Olvido, Outflow.** Closes the "Also deferred" queue from Bulk Fixes 5/6.
  - Orrery: `setParams` hoisted block → per-block voice loop.
  - Olvido: crossover bank `setCoefficients_fast` hoisted to per-block. ~512× fewer coefficient computations (8 voices × 10 coefs × 44.1kHz → per-block).
  - Outflow: MIDI-note→freq-ratio `std::pow` cached on note-on; pitch bend still live per-block.

## Test plan

- [ ] `cmake --build build -j` succeeds (no API changes expected, but verify)
- [ ] `auval -v aumu Xocn XoOx` passes
- [ ] Smoke-test multi-slot chains with an idle engine in slot 2+ — prior-slot audio should survive (Bulk Fix 7 correctness)
- [ ] Load Omega preset with a coupling route into `*ToPitch` — confirm pitch modulates (Omega fix)
- [ ] Obiont note-on / voice-steal stress test — confirm no audible artifacts (LUT replaces live sins)
- [ ] CPU profile Olvido under load — expect measurable reduction in filter-coef time
- [ ] No regressions in engines previously on the silence-gate pattern (the 51 listed in commit message)

## Out of scope / deferred

- Tier 3 #1 — `SynthEngine::isModulationOnly()` interface (architectural, separate PR)
- Ooze waveguide bidirectional physics (needs design call)
- `CLAUDE.md` stale merge-conflict markers at lines ~9-15, ~164-183

🤖 Generated with [Claude Code](https://claude.com/claude-code)