### PR TITLE
fix(a11y): focus rings (#1099) + WCAG AA contrast (#1112)

### DIFF
--- a/Source/UI/CouplingVisualizer/CouplingVisualizer.h
+++ b/Source/UI/CouplingVisualizer/CouplingVisualizer.h
@@ -180,6 +180,9 @@ public:
 
         // Legend strip at bottom
         paintLegend(g, bounds);
+
+        if (hasKeyboardFocus(false))
+            A11y::drawFocusRing(g, getLocalBounds().toFloat(), 4.0f);
     }
 
     void resized() override

--- a/Source/UI/Gallery/AdvancedFXPanel.h
+++ b/Source/UI/Gallery/AdvancedFXPanel.h
@@ -48,7 +48,7 @@ public:
     {
         using namespace GalleryColors;
         g.fillAll(get(shellWhite()));
-        g.setColour(get(textMid()).withAlpha(0.40f));
+        g.setColour(get(textMid()));
         g.setFont(GalleryFonts::heading(10.0f)); // (#885: 8pt→10pt legibility floor)
         g.drawText(titleText, getLocalBounds().removeFromTop(14).reduced(8, 0), juce::Justification::centredLeft);
     }

--- a/Source/UI/Gallery/ChordMachinePanel.h
+++ b/Source/UI/Gallery/ChordMachinePanel.h
@@ -229,7 +229,7 @@ public:
             // Beat marker (steps 0, 4, 8, 12)
             if ((s & 3) == 0)
             {
-                g.setColour(get(textMid()).withAlpha(0.4f));
+                g.setColour(get(textMid()).withAlpha(0.75f));
                 g.fillRect(stepR.getX(), stepR.getY() - 3, stepW, 2);
             }
 

--- a/Source/UI/Gallery/CouplingPopover.h
+++ b/Source/UI/Gallery/CouplingPopover.h
@@ -171,7 +171,7 @@ public:
         const float centreAngle = juce::MathConstants<float>::pi; // straight down in JUCE rotary coords
         float tickX = knobCx + (knobR + 2.0f) * std::sin(centreAngle);
         float tickY = knobCy - (knobR + 2.0f) * std::cos(centreAngle);
-        g.setColour(get(textMid()).withAlpha(0.45f));
+        g.setColour(get(textMid()));
         g.fillEllipse(tickX - 2.0f, tickY - 2.0f, 4.0f, 4.0f);
 
         // Amount label above the knob

--- a/Source/UI/Gallery/DrumPadGrid.h
+++ b/Source/UI/Gallery/DrumPadGrid.h
@@ -188,6 +188,9 @@ public:
             g.drawHorizontalLine(stripY - kParamHeaderH - 2,
                                  (float)kPadGap, (float)(getWidth() - kPadGap));
         }
+
+        if (hasKeyboardFocus(false))
+            A11y::drawFocusRing(g, getLocalBounds().toFloat(), 4.0f);
     }
 
     void resized() override

--- a/Source/UI/Gallery/ModMatrixDrawer.h
+++ b/Source/UI/Gallery/ModMatrixDrawer.h
@@ -399,6 +399,9 @@ private:
                 g.setColour(juce::Colour(0xFF7FDBCA).withAlpha(0.75f));
                 g.fillRect(b.reduced(2.0f));
             }
+
+            if (hasKeyboardFocus(false))
+                A11y::drawFocusRing(g, getLocalBounds().toFloat(), 4.0f);
         }
 
         void mouseDown(const juce::MouseEvent&) override

--- a/Source/UI/Gallery/PlayControlPanel.h
+++ b/Source/UI/Gallery/PlayControlPanel.h
@@ -460,7 +460,7 @@ private:
 
         // Center detent line
         float centreY = y + h * 0.5f;
-        g.setColour(get(textMid()).withAlpha(0.45f));
+        g.setColour(get(textMid()).withAlpha(0.75f));
         g.drawHorizontalLine((int)centreY, x + 3.0f, x + w - 3.0f);
 
         // Fill from centre toward current position
@@ -588,7 +588,7 @@ private:
         if (xyXParam == nullptr && xyYParam == nullptr)
         {
             g.setFont(GalleryFonts::label(10.0f)); // (#885: 9pt→10pt legibility floor)
-            g.setColour(get(textMid()).withAlpha(0.35f));
+            g.setColour(get(textMid()).withAlpha(0.75f));
             g.drawText("XY", bf, juce::Justification::centred, false);
         }
 

--- a/Source/UI/Gallery/StatusBar.h
+++ b/Source/UI/Gallery/StatusBar.h
@@ -153,8 +153,8 @@ public:
 
         // ── Status label colours ──────────────────────────────────────────────
         bpmLabel.setColour(juce::Label::textColourId, get(t2()));   // T2
-        voiceLabel.setColour(juce::Label::textColourId, get(t3())); // T3
-        cpuLabel.setColour(juce::Label::textColourId, get(t3()));   // T3
+        voiceLabel.setColour(juce::Label::textColourId, get(t2())); // T2 (WCAG AA, #1112)
+        cpuLabel.setColour(juce::Label::textColourId, get(t2()));   // T2 (WCAG AA, #1112)
 
         // ── Lock button ───────────────────────────────────────────────────────
         lockBtn.setColour(juce::TextButton::buttonColourId, get(emptySlot()));
@@ -308,7 +308,7 @@ public:
         {
             juce::String badge = cockpitBypassed_ ? "COCKPIT: OFF" : "COCKPIT: ON";
             juce::Colour badgeColour = cockpitBypassed_ ? juce::Colour(0xFFFF6B6B) // red when bypassed (full bright)
-                                                        : get(t3());               // T3 gray when active (dimming on)
+                                                        : get(t2());               // T2 gray when active (WCAG AA, #1112)
             g.setColour(badgeColour);
             g.setFont(GalleryFonts::value(10.0f)); // (#885: 8pt→10pt legibility floor)
             const int badgeW = 72; // slightly wider to accommodate 10pt text

--- a/Source/UI/Ocean/DnaMapBrowser.h
+++ b/Source/UI/Ocean/DnaMapBrowser.h
@@ -915,7 +915,7 @@ private:
     {
         const juce::Font f = GalleryFonts::label(10.0f);
         g.setFont(f);
-        g.setColour(juce::Colour(GalleryColors::Ocean::plankton));
+        g.setColour(juce::Colour(GalleryColors::Ocean::salt));
 
         const int w = getWidth();
         const int h = getHeight();
@@ -1001,7 +1001,7 @@ private:
         }
         else
         {
-            g.setColour(juce::Colour(GalleryColors::Ocean::plankton));
+            g.setColour(juce::Colour(GalleryColors::Ocean::salt));
             g.drawText("Search presets…",
                        searchBarBounds_.reduced(kSearchBarPadH, 0),
                        juce::Justification::centredLeft,

--- a/Source/UI/Outshine/OutshineZoneMap.h
+++ b/Source/UI/Outshine/OutshineZoneMap.h
@@ -97,12 +97,6 @@ public:
                 g.fillRect(x, 0.0f, w, (bounds.getHeight() - 18.0f) * 0.6f);
             }
         }
-
-        if (hasKeyboardFocus(false))
-        {
-            g.setColour(GalleryColors::get(GalleryColors::xoGold));
-            g.drawRect(getLocalBounds(), 1);
-        }
     }
 
     void mouseDown(const juce::MouseEvent& e) override


### PR DESCRIPTION
## Summary

Two focused a11y fixes landed as separate commits on origin/main:

- **#1099** — Draw focus rings on 4 interactive components that opt into keyboard focus. `A11y::drawFocusRing()` was already the canonical helper (used at `EngineOrbit.h:472`); these just needed the call at the end of each `paint()`.
- **#1112** — Raise contrast on 7 sites of functional text from ~2.3–2.7:1 to WCAG AA (4.5:1).

## In-flight adjustments to the issue bodies

**#1099** was filed for 5 components; only **4 actually opt into keyboard focus**. `StatusBar.h`'s `keyPressed` lives on a nested `ShortcutListener : juce::KeyListener`, not the `Component` itself — the outer `StatusBar` never calls `setWantsKeyboardFocus(true)`, so there is no focusable surface to ring. No-op for StatusBar.

**OutshineZoneMap** had `setWantsKeyboardFocus(false)` + a dead `hasKeyboardFocus` branch at line 101. Since no `keyPressed` override exists, keeping focus off and **removing the unreachable branch** was the right call rather than flipping focus on.

**#1112** line 301 → actual site at line **311** (`COCKPIT: ON` badge). `DnaMapBrowser.h` is at `Source/UI/Ocean/` not `Source/UI/Gallery/` (issue body said Gallery).

## Pattern-level follow-up (not in either issue)

`StatusBar.h:139` and `:145` set `TextButton::textColourOffId` to `t3()` on `xoSendBtn` and `echoCutBtn`. Same visual class as #1112 but button text contrast depends on the button fill, so a deliberate measurement pass is the right move — not a unilateral bump.

## Test plan

- [x] Local build: the 10 changed files compile clean (`cmake --build build -j 8`). Unrelated Ollotron `-Wunused-variable` broke the build of an orphan branch but does not attribute to this PR.
- [ ] Tab through each affected component with keyboard, confirm visible focus ring
- [ ] Inspect each of the 7 contrast sites against a WCAG AA checker (target 4.5:1 for normal text)
- [ ] `auval -v aumu Xocn XoOx` after merge

Closes #1099
Closes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)