### PR TITLE
rescue: Orbital drawbar tuning — Psychedelic Charismatic Church in Jamaica

### DIFF
--- a/Source/Engines/Orbital/OrbitalEngine.h
+++ b/Source/Engines/Orbital/OrbitalEngine.h
@@ -1355,24 +1355,27 @@ private:
     }
 
     // -------------------------------------------------------------------------
-    // NOTE: Alternative drawbar registrations considered — current values are final.
-    // Rock Hammond registration (8' heavy, 4' strong) defines ORBITAL's organ character.
-    // Each element corresponds to one drawbar partial; all un-set partials remain silent.
+    // DECIDED (2026-03-19): Psychedelic Charismatic Church in Jamaica
+    // Warm foundation (church) + shimmering upper harmonics (psychedelic) +
+    // soulful character. A reverent, expressive instrument with reggae spirit.
+    //
+    // Drawbar target: 5-4-5-7-4-6-3-5-8 (16' through 1')
+    // Mapped to available harmonics:
+    //   Warm bass foundation: moderate fundamental (0.625)
+    //   Psychedelic shimmer: strong 4' (0.875), boosted 2' (0.75)
+    //   Expressive character: full 1' sparkle (1.0), rich mid-range
     // -------------------------------------------------------------------------
     static std::array<float, kNumPartials> buildOrgan()
     {
-        // Hammond B3 drawbar registration (rock preset).
-        // Drawbar footages map to harmonic numbers:
-        //   16'=sub, 8'=fundamental, 5-1/3'=3rd, 4'=2nd, 2-2/3'=3rd,
-        //   2'=4th, 1-3/5'=5th, 1-1/3'=6th, 1'=8th
+        // Psychedelic Charismatic Church in Jamaica registration.
         std::array<float, kNumPartials> amplitudes{};
-        amplitudes[0] = 1.0f;  // 8'    -- fundamental
-        amplitudes[1] = 0.8f;  // 4'    -- 2nd harmonic (one octave up)
-        amplitudes[2] = 0.4f;  // 2-2/3' -- 3rd harmonic (octave + fifth)
-        amplitudes[3] = 0.7f;  // 2'    -- 4th harmonic (two octaves up)
-        amplitudes[4] = 0.3f;  // 1-3/5' -- 5th harmonic (two octaves + major third)
-        amplitudes[5] = 0.2f;  // 1-1/3' -- 6th harmonic (two octaves + fifth)
-        amplitudes[7] = 0.15f; // 1'    -- 8th harmonic (three octaves up)
+        amplitudes[0]  = 0.625f;   // 8'    -- warm fundamental (not dominant)
+        amplitudes[1]  = 0.875f;   // 4'    -- strong psychedelic shimmer
+        amplitudes[2]  = 0.5f;     // 2-2/3' -- mid-range warmth
+        amplitudes[3]  = 0.75f;    // 2'    -- psychedelic edge
+        amplitudes[4]  = 0.375f;   // 1-3/5' -- harmonic character touch
+        amplitudes[5]  = 0.625f;   // 1-1/3' -- extended shimmer (boosted from 0.2)
+        amplitudes[7]  = 1.0f;     // 1'    -- full sparkle cap (boosted from 0.15)
         return amplitudes;
     }
 


### PR DESCRIPTION
## What this PR does

Cherry-picks **one** stranded commit (`a439c2605`) from the local `main` that was never merged to `origin/main`.

### Commit landed

**`a439c2605` — DECIDED: Orbital drawbar tuning — Psychedelic Charismatic Church in Jamaica**

Replaces the placeholder rock Hammond drawbar values in `OrbitalEngine.h::buildOrgan()` with the finalized "Psychedelic Charismatic Church in Jamaica" registration:

| Partial | Footage | Old value | New value | Character |
|---------|---------|-----------|-----------|-----------|
| 0 | 8' | 1.0f | 0.625f | Warm fundamental (not dominant) |
| 1 | 4' | 0.8f | 0.875f | Strong psychedelic shimmer |
| 2 | 2-2/3' | 0.4f | 0.5f | Mid-range warmth |
| 3 | 2' | 0.7f | 0.75f | Psychedelic edge |
| 4 | 1-3/5' | 0.3f | 0.375f | Harmonic character touch |
| 5 | 1-1/3' | 0.2f | 0.625f | Extended shimmer |
| 7 | 1' | 0.15f | 1.0f | Full sparkle cap |

Drawbar target: **5-4-5-7-4-6-3-5-8** (16' through 1'). This is the sonic pillar for all Orbital preset authoring and Guru Bin retreat sessions.

---

## Commits dropped (with rationale)

**`9f861480a` — Ocelot + Owlfish coupling routing** — DROPPED. The fleet DSP sprint (#1128, commit `f83683c63`) already landed full `applyCouplingInput` implementations for both engines on `origin/main`. The upstream versions are more refined (better sensitivity tuning, additional routing cases like `AudioToRing`, proper clamp bounds). The no-op stub intent is already satisfied.

**`82f0bfe40` — technical_debt_catalog update** — DROPPED. `Docs/technical_debt_catalog.md` does not exist on `origin/main` (the sprint reorganized docs). Cherry-pick would fail with a path error; the update would also be redundant since the coupling stubs were resolved by the sprint.

---

## Conflict resolution

The fleet DSP sprint substantially refactored `OrbitalEngine.h` (namespace `xomnibus` → `xoceanus`, added includes, reformatted). The cherry-pick conflicted in exactly one block: the `buildOrgan()` function comment + values. Resolution: kept the stranded commit's finalized drawbar values and DECIDED comment verbatim; used `origin/main`'s surrounding formatting (brace style, include list). No DSP logic was touched outside the drawbar values.

## Build check

No `build/` directory in worktree — compile check skipped per task instructions.

---

Related: #1130 (preset picker rescue), #1131 (doc rescue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)