### PR TITLE
fix(build): correct case-mismatched OceanDeep include

### DIFF
--- a/Source/Engines/OceanDeep/OceanDeepEngine.cpp
+++ b/Source/Engines/OceanDeep/OceanDeepEngine.cpp
@@ -1,1 +1,1 @@
-#include "OceandeepEngine.h"
+#include "OceanDeepEngine.h"


### PR DESCRIPTION
`OceanDeepEngine.cpp` was `#include`-ing `"OceandeepEngine.h"` (lowercase `d`), which silently resolves on case-insensitive macOS HFS+ but causes a fatal compile error on the case-sensitive Linux filesystem used in CI.

This one-line fix corrects the include to `"OceanDeepEngine.h"`, matching the canonical filename on disk. Originally recovered on `rescue/worktree-fragments-2026-04-21`; landed here as a clean minimal PR against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)