### PR TITLE
fix(build): close remaining 4 engine headers (Ochre, Osier, Overwash, Oto)

### DIFF
--- a/Source/Engines/Ochre/OchreEngine.h
+++ b/Source/Engines/Ochre/OchreEngine.h
@@ -787,6 +787,7 @@ public:
                     {
                         voice.hfNoiseShaper.setCoefficients(hfCutoff, 0.3f, srf);
                         voice.lastHFCutoff = hfCutoff;
+                    }
                     // Shape noise through body-tuned SVF (coeff refresh decimated)
                     if (updateFilter)
                     {
@@ -839,6 +840,7 @@ public:
                     voice.lpf.setMode(CytomicSVF::Mode::LowPass);
                     voice.lpf.setCoefficients(cutoff, 0.4f, srf);
                     voice.lastFilterCutoff = cutoff;
+                }
                 if (updateFilter)
                 {
                     float cutoff = std::clamp(brightNow + envMod + lfo1Val * 3000.0f, 200.0f, 20000.0f);

--- a/Source/Engines/Osier/OsierEngine.h
+++ b/Source/Engines/Osier/OsierEngine.h
@@ -540,6 +540,7 @@ public:
                     voice.toneShaper.setMode(CytomicSVF::Mode::LowPass);
                     voice.toneShaper.setCoefficients(roleCutoff, 0.2f, srf);
                     voice.lastToneShaperCutoff = roleCutoff;
+                }
                 // (coeff refresh decimated; cutNow + cfg constants change slowly).
                 if (updateFilter)
                 {
@@ -560,6 +561,7 @@ public:
                     voice.filter.setCoefficients(fCut, std::clamp(pResonance + l2 * 0.15f, 0.0f, 1.0f),
                                                  srf); // l2 → resonance shimmer
                     voice.lastFilterCutoff = fCut;
+                }
                 if (updateFilter)
                 {
                     float fCut = std::clamp(cutNow + envLevel * pFilterEnvAmt * 5000.0f + l1 * 2500.0f, 200.0f, 20000.0f);

--- a/Source/Engines/Oto/OtoEngine.h
+++ b/Source/Engines/Oto/OtoEngine.h
@@ -632,7 +632,6 @@ public:
                 if (voice.active)
                     voice.ampEnv.setADSR(attack, decay, sustain, release);
             }
-        }
 
         // Hoist per-voice LFO config. pLFO1Rate is block-rate; D005 floor enforced.
         {

--- a/Source/Engines/Overwash/OverwashEngine.h
+++ b/Source/Engines/Overwash/OverwashEngine.h
@@ -382,6 +382,7 @@ public:
                 voices[v].ampEnv.setADSR(pAmpA, pAmpD, pAmpS, pAmpR);
                 voices[v].filterEnv.setADSR(pFiltA, pFiltD, pFiltS, pFiltR);
             }
+        }
         // Hoist envelope setADSR out of the per-sample loop — setADSR internally
         // calls two std::exp()s for decay/release coefficients; ADSR knob values
         // are block-rate so per-sample recomputation was pure waste.
@@ -446,6 +447,7 @@ public:
                 {
                     voice.viscosityFilter.setCoefficients_fast(voiceCutoff, pFilterRes, srF);
                     voice.lastCutoff = voiceCutoff;
+                }
                 // SVF coeff refresh decimated to every 16 samples.
                 if (updateFilter)
                 {


### PR DESCRIPTION
## Summary

Continuation of #1137 — fixes the remaining 4 engine headers with unbalanced braces. Same root cause: the P19 guard pattern (`if (fabs(x) > 1.0f) { set coeff; } if (updateFilter) { set coeff again; }`) was written without closing the outer `if` block before the inner one, leaving later class members inside function scope.

- **OchreEngine.h** — 2 missing `}` at lines 789 and 841 (two P19-guard `if` blocks not closed before nested `if (updateFilter)`)
- **OsierEngine.h** — 2 missing `}` at lines 542 and 562 (same P19-guard pattern, toneShaper and main filter)
- **OverwashEngine.h** — 2 missing `}`: one for a `for` loop (L384) whose body was replaced by a duplicate loop without closing the original, and one P19-guard `if` (L449)
- **OtoEngine.h** — 1 extra `}` at line 635, orphaned from a for-loop refactor that switched from a block body to a single-statement form

All 4 files verified after fix: `final_depth == 0`, `private:` at depth 2. `XOceanusProcessor.cpp` (which #includes Ochre, Overwash, and Oto headers) compiled with `-fsyntax-only` and produced zero errors. Pre-existing failures in `OwareEngine.h` and `OxytocinAdapter.cpp` are out of scope for this PR.

## Test plan

- [x] Brace-depth script confirms `final_depth=0` and `private:` at depth 2 for all 4 engines
- [x] `XOceanusProcessor.cpp` compiles clean with `-fsyntax-only` (covers Ochre, Overwash, Oto)
- [x] `OsierEngine.cpp` compiles to `-fsyntax-only` clean of the brace error (pre-existing `filterBiasCents` typo unrelated to this PR remains)
- [ ] Full build: blocked by pre-existing failures in Oware + Oxytocin (out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)