### PR TITLE
fix(build): remove unused couplingMorphIn in Ostracon

### DIFF
--- a/Source/Engines/Ostracon/OstraconEngine.h
+++ b/Source/Engines/Ostracon/OstraconEngine.h
@@ -359,9 +359,6 @@ public:
         // Aftertouch → effective oxide
         const float oxideWithAT = juce::jlimit(0.0f, 1.0f, effectiveOxide + aftertouchValue * 0.3f);
 
-        // Capture coupling morph before it gets zeroed later
-        const float couplingMorphIn = couplingMorphAccum;
-
         // Expression (CC11) + coupling morph → effective bias
         const float biasWithExpr = juce::jlimit(0.0f, 1.0f,
             effectiveBias + expressionValue * 0.5f - 0.25f + couplingMorphAccum * 0.5f);


### PR DESCRIPTION
Re-introduced by PR #1149. Trivial one-line removal — couplingMorphIn at line 363 is assigned from couplingMorphAccum but never used. couplingMorphAccum is used directly elsewhere.

Fixes -Werror compile failure.