### PR TITLE
docs: normalize engine count 90 → 92 after #1140 (post-#1142 follow-up)

### DIFF
--- a/Docs/design/ecological-interface-component-spec-v1.md
+++ b/Docs/design/ecological-interface-component-spec-v1.md
@@ -238,7 +238,7 @@ void paintEcologicalKnob(juce::Graphics& g, float cx, float cy, float totalRadiu
 ## Component 2: Engine Slot Panel
 
 ### Overview
-The porthole container. Each of the 90 engines lives in one of up to 8 active engine slots. The slot is styled as a porthole — you are looking through rounded glass at the creature's habitat. Engine accent color anchors the header bar and all knob arcs within the slot.
+The porthole container. Each of the 92 engines lives in one of up to 8 active engine slots. The slot is styled as a porthole — you are looking through rounded glass at the creature's habitat. Engine accent color anchors the header bar and all knob arcs within the slot.
 
 ### Dimensions
 - Minimum slot size: 280px wide × 220px tall (compact layout, 3 engines visible)

--- a/Docs/design/obrix-pocket-scope-2026-03-26.md
+++ b/Docs/design/obrix-pocket-scope-2026-03-26.md
@@ -655,10 +655,10 @@ If a permission is denied:
 | Apple rejects location usage | Medium | High | Submit minimal music app first, add location in update. |
 | Battery drain from location | Medium | Medium | Significant-change only. Test on oldest supported device. |
 | Scope creep | HIGH | High | Each phase has a gate. Don't start next phase until gate passes. |
-| Binary size too large | Medium | Medium | Ship OBRIX only (not 90 engines). Target <80MB. |
+| Binary size too large | Medium | Medium | Ship OBRIX only (not 92 engines). Target <80MB. |
 
 ## 16. What This Does NOT Include
-- No 90 engines on iOS (desktop only)
+- No 92 engines on iOS (desktop only)
 - No DAW integration / AUv3
 - No preset library browser (desktop feature)
 - No coupling inspector UI (desktop feature)

--- a/Docs/design/ocean-ui-phase1-design.md
+++ b/Docs/design/ocean-ui-phase1-design.md
@@ -603,7 +603,7 @@ Every interactive element in the prototype must connect to a real parameter or a
 | # | Finding | Resolution |
 |---|---------|------------|
 | F1 | `WaveformRingBuffer` duplicates existing `WaveformFifo` in `XOceanusProcessor.h` (lines 39-93) | **CANCELLED.** Do not create `WaveformRingBuffer.h`. Wire `EngineOrbit` to read from `processor.getWaveformFifo(slot).readLatest()`. |
-| F2 | `SynthEngine` base class modification puts UI concerns in DSP interface, changes memory layout for 90 engines | **CANCELLED.** Do not touch `SynthEngine.h`. All visualization buffers live in the processor. |
+| F2 | `SynthEngine` base class modification puts UI concerns in DSP interface, changes memory layout for 92 engines | **CANCELLED.** Do not touch `SynthEngine.h`. All visualization buffers live in the processor. |
 | F3 | Proposed `write()` emits `memory_order_release` per sample — ARM performance bug (48K fences/sec) | **CANCELLED.** Using existing `WaveformFifo` which has correct fence pattern. |
 
 ### WARNINGS (addressed)

--- a/Docs/design/tidesigns-audit.md
+++ b/Docs/design/tidesigns-audit.md
@@ -1,7 +1,7 @@
 # TIDEsigns QDD Full-Fleet UI/UX Audit — 2026-03-29
 
 ## Overview
-- **Target:** XOceanus Desktop Plugin — 86 UI files, 90 engines, ~1.5MB source
+- **Target:** XOceanus Desktop Plugin — 86 UI files, 92 engines, ~1.5MB source
 - **Method:** RAC (Ringleader + Architect + Consultant) × TIDEsigns × QDD
 - **Phases:** 5 (Foundation → Core Components → Subsystems → Engine-Specific → Cross-Cutting)
 - **Subagent dispatches:** 34 parallel audits

--- a/Docs/design/tidesigns-spec.md
+++ b/Docs/design/tidesigns-spec.md
@@ -365,13 +365,13 @@ Keep the pills. 10 pills at 28px is the right call for this use case — the pop
 
 The search field is already auto-focused and 11px body font. Increase its visual weight:
 - Border color on focus: change `focusedOutlineColourId` from `border()` to `engineAccent` (or `xoGold` if no engine is loaded). This ties the search field to the current engine and makes the focused state obvious.
-- Placeholder text: change "Search engines..." to "Search 90 engines..." — the count gives users confidence in the scope.
+- Placeholder text: change "Search engines..." to "Search 92 engines..." — the count gives users confidence in the scope.
 - Height: increase from the current reduced(0,2) within a 32px row to 26px (remove the 2px vertical reduction).
 
 **File: `Source/UI/Gallery/EnginePickerPopup.h` lines 64–78**
 
 ```cpp
-searchField.setTextToShowWhenEmpty("Search 90 engines...",
+searchField.setTextToShowWhenEmpty("Search 92 engines...",
                                     GalleryColors::get(GalleryColors::t4()));
 // Focused outline: accent
 searchField.setColour(juce::TextEditor::focusedOutlineColourId,
@@ -646,7 +646,7 @@ Priority: NICE
 | A3-03 | MasterFX — chip pills | SHOULD | `MasterFXSection.h` | Per-section pill backgrounds replacing single fill |
 | A3-04 | MasterFX — indicator dots | SHOULD | `MasterFXSection.h` | 6px accent dot per section (active/bypassed states) |
 | A3-05 | MasterFX — SEQ toggle | SHOULD | `MasterFXSection.h` | Shrink SEQ toggle to 18px; dim chip when off |
-| A4-01 | Picker — search prominence | SHOULD | `EnginePickerPopup.h` | Focused border = accent; placeholder = "Search 90 engines..." |
+| A4-01 | Picker — search prominence | SHOULD | `EnginePickerPopup.h` | Focused border = accent; placeholder = "Search 92 engines..." |
 | A4-02 | Picker — pill active color | SHOULD | `EnginePickerPopup.h` | Active pill: gold text + gold-dim bg; hover: T2 |
 | A4-03 | Picker — row refinements | NICE | `EnginePickerPopup.h` | Row 28px; left border on selected; category badge T4 |
 | P5-01 | Polish — LnF comment | MUST | `GalleryLookAndFeel.h:9` | Update v04 → v05 reference |
@@ -673,7 +673,7 @@ After each batch of changes:
 3. Manual check: click each signal flow label → ParameterGrid scrolls to correct section
 4. Manual check: COUPLE tab → collapsed route cards show real engine names in accent colors
 5. Manual check: MasterFX strip fits within 68px with no overlapping knob labels
-6. Manual check: Engine picker search field shows "Search 90 engines..." placeholder and focused accent border
+6. Manual check: Engine picker search field shows "Search 92 engines..." placeholder and focused accent border
 
 ---
 

--- a/Docs/design/xoceanus-definitive-ui-spec.md
+++ b/Docs/design/xoceanus-definitive-ui-spec.md
@@ -32,7 +32,7 @@ Every synthesizer interface ever made has treated the UI as a **control surface*
 
 XOceanus is not a dashboard.
 
-XOceanus is an **aquarium**. A living, breathing, responsive environment that you inhabit rather than operate. The 90 engines are not modules in a rack — they are creatures in a water column. The coupling connections between them are not patch cables — they are ecological relationships. The performer does not "use" XOceanus. The performer enters it.
+XOceanus is an **aquarium**. A living, breathing, responsive environment that you inhabit rather than operate. The 92 engines are not modules in a rack — they are creatures in a water column. The coupling connections between them are not patch cables — they are ecological relationships. The performer does not "use" XOceanus. The performer enters it.
 
 This is the fundamental inversion that no synthesizer has attempted: **the mythology IS the interface**.
 
@@ -969,7 +969,7 @@ Several engine accent colors on dark backgrounds:
 
 ### 4.1.3 Color-Blind Safe Engine Differentiation
 
-90 engines cannot be differentiated by color alone. The system provides multiple redundant channels:
+92 engines cannot be differentiated by color alone. The system provides multiple redundant channels:
 
 **Channel 1 (Color)**: Engine accent color — unique per engine but NOT relied upon as sole identifier
 
@@ -1243,9 +1243,9 @@ This is embodied cognition applied to software design. It has never been attempt
 
 ### 5.2.4 The Constellation View — Seeing All 88 at Once
 
-Every synth forces you to look at one engine at a time. XOceanus has 90 engines. What if you could see ALL of them?
+Every synth forces you to look at one engine at a time. XOceanus has 92 engines. What if you could see ALL of them?
 
-The Constellation View is a full-window overlay (triggered by a button in the header or Cmd+Shift+A) that shows all 90 engines as stars in a constellation map. The map layout follows the water column (surface engines at top, abyss engines at bottom). Each star:
+The Constellation View is a full-window overlay (triggered by a button in the header or Cmd+Shift+A) that shows all 92 engines as stars in a constellation map. The map layout follows the water column (surface engines at top, abyss engines at bottom). Each star:
 - Size: proportional to preset count (popular engines are larger stars)
 - Color: engine accent color
 - Brightness: proportional to current activity (if the engine is making sound, its star is bright)
@@ -1370,7 +1370,7 @@ No synthesizer has ever shown its entire capability space in a single, beautiful
 
 ## A.8 All 88 Engine Accent Colors
 
-(Full table — see CLAUDE.md Engine Modules table for complete listing. All 90 engines with hex values are defined there and are the canonical reference.)
+(Full table — see CLAUDE.md Engine Modules table for complete listing. All 92 engines with hex values are defined there and are the canonical reference.)
 
 ---
 

--- a/Docs/design/xoceanus-spatial-architecture.md
+++ b/Docs/design/xoceanus-spatial-architecture.md
@@ -55,7 +55,7 @@ At 1100×700pt, our total area is **770,000 px²**. After chrome (header 52pt + 
 
 ### The Problem No Synth Has Solved
 
-Most synths have 2-3 sound sources (oscillators). XOceanus has **4 simultaneous engine slots** drawn from a pool of **90 engines**, each with different parameter structures. This is closer to a **DAW mixer** than a traditional synth. No existing synth UI paradigm handles this cleanly.
+Most synths have 2-3 sound sources (oscillators). XOceanus has **4 simultaneous engine slots** drawn from a pool of **92 engines**, each with different parameter structures. This is closer to a **DAW mixer** than a traditional synth. No existing synth UI paradigm handles this cleanly.
 
 ### What We Can Learn from Competitors
 
@@ -66,7 +66,7 @@ Most synths have 2-3 sound sources (oscillators). XOceanus has **4 simultaneous 
 | **Pigments** | Top tabs (ENGINE / SEQ / FX / MATRIX), full-width content per tab | 2 engines + seq | Full width per view, generous knob spacing | You see ONE thing at a time — lose context of the whole patch |
 | **Phase Plant** | Vertical generator stack (add/remove/reorder), FX chain right | N generators | Scalable to any number of sources | Very tall, lots of scrolling, no overview |
 | **Omnisphere** | Layer A/B tabs, massive browser, FX page | 2 layers | Deep browser, rich FX | Tabbed = you forget what the other layer is doing |
-| **OP-1 (TE)** | Single screen, mode-switching, same 4 knobs control different params | 1 engine | Radical simplicity, same physical gestures for everything | Too constrained for 90 engines with different structures |
+| **OP-1 (TE)** | Single screen, mode-switching, same 4 knobs control different params | 1 engine | Radical simplicity, same physical gestures for everything | Too constrained for 92 engines with different structures |
 
 ### The XOceanus Answer: Hybrid Stack + Context Strip
 

--- a/Docs/design/xoceanus-ui-blessing-session.md
+++ b/Docs/design/xoceanus-ui-blessing-session.md
@@ -242,9 +242,9 @@ The Spatial Preset Navigation (Section 5.2.1) transforms the browser from a list
 
 Yes, in two forms:
 1. The Depth-Zone Dial (Section 1.5) — circular 80pt dial navigating engines by water-column depth order. Clockwise/counterclockwise drag. Depth zone gradient (Sunlit/Twilight/Midnight/Abyss) encodes position. Engine name below. 50ms hot-swap crossfade.
-2. The Constellation View (Section 5.2.4) — full-window overlay showing all 90 engines as a star map, organized by water column depth. Click to load. Drag between stars to create coupling.
+2. The Constellation View (Section 5.2.4) — full-window overlay showing all 92 engines as a star map, organized by water column depth. Click to load. Drag between stars to create coupling.
 
-The 2D aspect is satisfied by the Constellation View, which gives a genuine X/Y navigable space across all 90 engines. The water column depth provides the Y axis; the left-right distribution provides genre/character grouping.
+The 2D aspect is satisfied by the Constellation View, which gives a genuine X/Y navigable space across all 92 engines. The water column depth provides the Y axis; the left-right distribution provides genre/character grouping.
 
 **Verdict**: FULLY SATISFIED by Constellation View (V1 if promoted from "Second 25%"). Depth-Zone Dial satisfies sequential navigation at V1.
 
@@ -327,7 +327,7 @@ Needs warm, imperfect, breathing sounds. OWARE (tuned percussion with material p
 
 **Film Composer**
 
-Needs complex evolving textures, atmospheric pads, tension-building sounds. The ETHEREAL and DEEP mood filters are dedicated to this territory. OXBOW (entangled reverb), OCEANDEEP (Darkness Filter ceiling at 800Hz), OPERA (autonomous dramatic arc) are the engines. The OperaConductor — autonomous narrative arc — actually writes the emotional arc for the composer. The coupling system creates emergent textures between engines. **30-second test: PASS.** Film composers benefit most from the Constellation View (all 90 engines visible at once for pairing).
+Needs complex evolving textures, atmospheric pads, tension-building sounds. The ETHEREAL and DEEP mood filters are dedicated to this territory. OXBOW (entangled reverb), OCEANDEEP (Darkness Filter ceiling at 800Hz), OPERA (autonomous dramatic arc) are the engines. The OperaConductor — autonomous narrative arc — actually writes the emotional arc for the composer. The coupling system creates emergent textures between engines. **30-second test: PASS.** Film composers benefit most from the Constellation View (all 92 engines visible at once for pairing).
 
 ---
 

--- a/Docs/specs/coupling-protocol-spec-v0.1.md
+++ b/Docs/specs/coupling-protocol-spec-v0.1.md
@@ -316,7 +316,7 @@ COUPLING_COMPLIANCE: Full-v0.1
 
 **XOceanus** (https://github.com/BertCalm/XO_OX-XOceanus) is the reference implementation of this protocol.
 
-XOceanus implements 90 engines across the original fleet, Kitchen Collection, and Singularity Collection. The three v0.1 public types are supported across the fleet; individual engine compliance declarations are available in engine metadata. The `SynthEngine` interface in `Source/Core/SynthEngine.h` defines the C++ contract:
+XOceanus implements 92 engines across the original fleet, Kitchen Collection, and Singularity Collection. The three v0.1 public types are supported across the fleet; individual engine compliance declarations are available in engine metadata. The `SynthEngine` interface in `Source/Core/SynthEngine.h` defines the C++ contract:
 
 ```cpp
 // Speaker interface — emit coupling signal

--- a/Docs/specs/xoceanus_master_specification.md
+++ b/Docs/specs/xoceanus_master_specification.md
@@ -160,7 +160,7 @@ Toggle between modes at any time. Preset data is identical — only UI visibilit
 
 ## 2.6 Design Doctrines
 
-The 6 Doctrines are the quality contract every XOceanus engine must satisfy. They emerged empirically from the Prism Sweep (2026-03-14 to 2026-03-20) — specific failure patterns found in real instruments and codified as non-negotiable requirements. All 6 doctrines are now resolved fleet-wide across all 90 engines.
+The 6 Doctrines are the quality contract every XOceanus engine must satisfy. They emerged empirically from the Prism Sweep (2026-03-14 to 2026-03-20) — specific failure patterns found in real instruments and codified as non-negotiable requirements. All 6 doctrines are now resolved fleet-wide across all 92 engines.
 
 | ID | Doctrine | Requirement |
 |----|----------|------------|

--- a/site/aquarium.html
+++ b/site/aquarium.html
@@ -1126,12 +1126,12 @@ footer {
 }
 </style>
 <meta property="og:title" content="The Aquarium — XO_OX Water Column Atlas">
-<meta property="og:description" content="90 engines. Thousands of presets. Free and open-source. By XO_OX Designs.">
+<meta property="og:description" content="92 engines. Thousands of presets. Free and open-source. By XO_OX Designs.">
 <meta property="og:image" content="https://xo-ox.org/assets/og-image.png">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="The Aquarium — XO_OX Water Column Atlas">
-<meta name="twitter:description" content="90 engines. Thousands of presets. Free and open-source.">
+<meta name="twitter:description" content="92 engines. Thousands of presets. Free and open-source.">
 <meta name="twitter:image" content="https://xo-ox.org/assets/og-image.png">
 <link rel="alternate" type="application/rss+xml" title="XOceanus Signal" href="feed.xml">
 <link rel="stylesheet" href="/design-tokens.css">

--- a/site/coupling-protocol.html
+++ b/site/coupling-protocol.html
@@ -854,7 +854,7 @@ COUPLING_COMPLIANCE: Full-v0.1   <span class="c-comment">// all 3 types, listen 
 <h2 class="reveal" id="reference">Reference Implementation</h2>
 
 <p class="reveal">
-<strong>XOceanus</strong> is the reference implementation of this protocol. All 90 engines are Level 3 compliant for the three public types. The C++ contract lives in <code>Source/Core/SynthEngine.h</code>:
+<strong>XOceanus</strong> is the reference implementation of this protocol. All 92 engines are Level 3 compliant for the three public types. The C++ contract lives in <code>Source/Core/SynthEngine.h</code>:
 </p>
 
 <div class="code-block reveal"><span class="c-comment">// Speaker interface — emit coupling signal</span>
@@ -959,7 +959,7 @@ Future packet extensions must preserve the 16-byte v0.1 header. Additional field
       <tr>
         <td>0.1</td>
         <td style="color:var(--text-dim); font-family:inherit; font-size:0.88rem; white-space:nowrap;">2026-03-22</td>
-        <td style="font-family:inherit; color:var(--text); font-size:0.88rem;">Initial public specification. Three core types (Sympathetic 0x01, Complementary 0x02, Responsive 0x03). 16-byte packet format. Three compliance levels. Reference implementation: XOceanus v1.x (90 engines, 15 types).</td>
+        <td style="font-family:inherit; color:var(--text); font-size:0.88rem;">Initial public specification. Three core types (Sympathetic 0x01, Complementary 0x02, Responsive 0x03). 16-byte packet format. Three compliance levels. Reference implementation: XOceanus v1.x (92 engines, 15 types).</td>
       </tr>
     </tbody>
   </table>

--- a/site/design-tokens.css
+++ b/site/design-tokens.css
@@ -6,7 +6,7 @@
  * Sections:
  *   1. Global Brand
  *   2. Ecological Depth Zones
- *   3. Engine Accent Colors (90 engines)
+ *   3. Engine Accent Colors (92 engines)
  *   4. Ecological Instrument Anatomy
  *   5. Glass / Porthole Formula
  *   6. PlaySurface Tokens
@@ -117,7 +117,7 @@
 
 
 /* ============================================================
-   SECTION 3 — Engine Accent Colors (90 engines)
+   SECTION 3 — Engine Accent Colors (92 engines)
    One custom property per registered engine.
    Property name matches the Engine ID (all-caps).
    Source: CLAUDE.md Engine Modules table.

--- a/site/field-guide/the-coupling-explainer.html
+++ b/site/field-guide/the-coupling-explainer.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The Coupling Explainer — What Happens When Engines Talk | XO_OX Field Guide</title>
-<meta name="description" content="The definitive guide to XOceanus's coupling system. 15 types. 90 engines. One idea: when synthesis engines can genuinely influence each other, sounds emerge that cannot be made any other way.">
+<meta name="description" content="The definitive guide to XOceanus's coupling system. 15 types. 92 engines. One idea: when synthesis engines can genuinely influence each other, sounds emerge that cannot be made any other way.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text x='4' y='24' font-size='24' fill='%23E9C46A'>X</text></svg>">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -760,7 +760,7 @@ footer {
 </style>
 
 <meta property="og:title" content="The Coupling Explainer — What Happens When Engines Talk | XO_OX">
-<meta property="og:description" content="15 coupling types. 90 engines. One idea: when synthesis engines can genuinely influence each other at the DSP level, sounds emerge that cannot be made any other way. The definitive guide.">
+<meta property="og:description" content="15 coupling types. 92 engines. One idea: when synthesis engines can genuinely influence each other at the DSP level, sounds emerge that cannot be made any other way. The definitive guide.">
 <meta property="og:image" content="https://xo-ox.org/assets/og-coupling-explainer.png">
 <meta property="og:type" content="article">
 <link rel="canonical" href="https://xo-ox.org/field-guide/the-coupling-explainer.html">
@@ -847,7 +847,7 @@ XOceanus's coupling system traces directly to the mythology at the heart of the 
 </p>
 
 <p class="reveal">
-When feliX and Oscar coupled for the first time &mdash; transient met sustain, surface met depth, X met O &mdash; the XO_OX universe was born. Every one of the 90 engines in XOceanus is a species that evolved from that primordial coupling. OddfeliX (feliX himself) and OddOscar (Oscar himself) are still in the fleet, still coupled to each other by default, still producing sounds that neither engine makes alone. The brand mark &mdash; <strong>XO_OX</strong> &mdash; is their names interleaved.
+When feliX and Oscar coupled for the first time &mdash; transient met sustain, surface met depth, X met O &mdash; the XO_OX universe was born. Every one of the 92 engines in XOceanus is a species that evolved from that primordial coupling. OddfeliX (feliX himself) and OddOscar (Oscar himself) are still in the fleet, still coupled to each other by default, still producing sounds that neither engine makes alone. The brand mark &mdash; <strong>XO_OX</strong> &mdash; is their names interleaved.
 </p>
 
 <p class="reveal">
@@ -929,7 +929,7 @@ The 15 types organize into four natural categories. Control-rate types (10) run 
 
 <h3 class="reveal">Control-Rate: Amplitude-Driven</h3>
 
-<p class="reveal">These types extract Engine A's instantaneous amplitude and use it to modulate a parameter in Engine B. They are the most universally supported types &mdash; compatible with nearly all 90 engines.</p>
+<p class="reveal">These types extract Engine A's instantaneous amplitude and use it to modulate a parameter in Engine B. They are the most universally supported types &mdash; compatible with nearly all 92 engines.</p>
 
 <div class="coupling-grid reveal">
 
@@ -1363,7 +1363,7 @@ Each of these is a different conversation between engines. The first is a whispe
 <!-- ═══════════ CTA ═══════════ -->
 <div class="cta-block reveal" role="complementary" aria-label="Get XOceanus and join the community">
   <h3>Find Your Space Between</h3>
-  <p>XOceanus is free and open-source. 90 engines. 15 coupling types. ~19,500+ factory presets. Every coupling discovery you make is a sound that doesn't exist anywhere else. Share what you find.</p>
+  <p>XOceanus is free and open-source. 92 engines. 15 coupling types. ~19,500+ factory presets. Every coupling discovery you make is a sound that doesn't exist anywhere else. Share what you find.</p>
   <div class="cta-links">
     <a href="https://github.com/BertCalm/XO_OX-XOmnibus" class="cta-link primary">Download XOceanus &mdash; Free</a>
     <a href="../aquarium.html" class="cta-link secondary">Explore the Aquarium</a>

--- a/site/guide-coupling.html
+++ b/site/guide-coupling.html
@@ -997,7 +997,7 @@ XVC is not in the CouplingType enum because it is implemented entirely within ON
 <h2 class="reveal">Coupling Is the Instrument</h2>
 
 <p class="reveal">
-There is a convenient way to think about XOceanus, and it is incomplete. The convenient view is: 90 engines, pick four, mix together, enjoy. The engines are the instrument and the coupling is a modulation bonus.
+There is a convenient way to think about XOceanus, and it is incomplete. The convenient view is: 92 engines, pick four, mix together, enjoy. The engines are the instrument and the coupling is a modulation bonus.
 </p>
 
 <p class="reveal">

--- a/site/guide-guru-bin-vol2.html
+++ b/site/guide-guru-bin-vol2.html
@@ -748,7 +748,7 @@ footer {
 <article class="article" id="article-content">
 
 <p class="reveal">
-Before the fleet had 90 engines, it had six. They were not designed as a cohort. They did not share a mythology. They were designed in sequence, each one establishing a dimension of synthesis that XOceanus would later need: analog warmth, behavioral survival, temporal degradation, harmonic navigation, percussive surface energy, and the patient decomposition of sound into grain. They were the original six, and they knew what they were before anyone named them.
+Before the fleet had 92 engines, it had six. They were not designed as a cohort. They did not share a mythology. They were designed in sequence, each one establishing a dimension of synthesis that XOceanus would later need: analog warmth, behavioral survival, temporal degradation, harmonic navigation, percussive surface energy, and the patient decomposition of sound into grain. They were the original six, and they knew what they were before anyone named them.
 </p>
 
 <p class="reveal">

--- a/site/guide-sdk-engine.html
+++ b/site/guide-sdk-engine.html
@@ -1209,13 +1209,13 @@ The <code>Source/DSP/</code> directory contains six shared utilities extracted f
 <ul class="reveal">
   <li><strong>Coupling deep dive</strong> &mdash; <a href="guide-coupling.html" style="color: var(--teal); text-decoration: none;">The Space Between the Engines</a> covers all 15 coupling types with audio examples and signal flow diagrams.</li>
   <li><strong>Architecture overview</strong> &mdash; <a href="guide-coupling-obrix-pairs.html" style="color: var(--teal); text-decoration: none;">OBRIX Pairs</a> shows how a complex engine connects to three other engines through the coupling matrix, with full preset recipes.</li>
-  <li><strong>Engine table</strong> &mdash; <code>CLAUDE.md</code> in the repository root contains the full table of all 90 engines, parameter prefixes, and accent colours. Use it as a reference when choosing a prefix for your engine.</li>
+  <li><strong>Engine table</strong> &mdash; <code>CLAUDE.md</code> in the repository root contains the full table of all 92 engines, parameter prefixes, and accent colours. Use it as a reference when choosing a prefix for your engine.</li>
   <li><strong>Full integration process</strong> &mdash; <code>Docs/xoceanus_new_engine_process.md</code> walks through the complete post-build pipeline: Doc Lock, Guru Bin, Presets, and Seance.</li>
 </ul>
 
 <div class="callout reveal" style="margin-top: 3rem;">
   <span class="callout-label">The goal of the interface</span>
-  <p>XOceanus has 90 engines because each one started as an independent instrument. The interface is short by design. The constraint that matters is not the API surface &mdash; it is the doctrines. An engine that passes D001&ndash;D006 can be trusted to sound like it has a point of view. That is what makes a character instrument rather than a feature matrix.</p>
+  <p>XOceanus has 92 engines because each one started as an independent instrument. The interface is short by design. The constraint that matters is not the API surface &mdash; it is the doctrines. An engine that passes D001&ndash;D006 can be trusted to sound like it has a point of view. That is what makes a character instrument rather than a feature matrix.</p>
 </div>
 
 <!-- ═══════════ CONTINUE THE DIVE ═══════════ -->

--- a/site/guide.html
+++ b/site/guide.html
@@ -601,13 +601,13 @@ footer {
 }
 </style>
 <meta property="og:title" content="Field Guide — Dispatches from the Deep | XOceanus">
-<meta property="og:description" content="90 engines. Thousands of presets. Free and open-source. By XO_OX Designs.">
+<meta property="og:description" content="92 engines. Thousands of presets. Free and open-source. By XO_OX Designs.">
 <meta property="og:url" content="https://xo-ox.org/guide.html">
 <meta property="og:image" content="https://xo-ox.org/assets/og-image.png">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Field Guide — Dispatches from the Deep | XOceanus">
-<meta name="twitter:description" content="90 engines. Thousands of presets. Free and open-source.">
+<meta name="twitter:description" content="92 engines. Thousands of presets. Free and open-source.">
 <meta name="twitter:image" content="https://xo-ox.org/assets/og-image.png">
 <link rel="alternate" type="application/rss+xml" title="XOceanus Signal" href="feed.xml">
 <link rel="stylesheet" href="/design-tokens.css">
@@ -901,7 +901,7 @@ const archPosts = [
     subtitle: "Vision",
     engine: "Vision #1 — Product Philosophy",
     color: "#E9C46A",
-    excerpt: "XOceanus V1 gives you 90 engines and infinite combinations. Collections are the opposite: curated sets of 4–5 engines selected to work together, with a fifth fusion slot that blends their voices. The next chapter of XOceanus — coming Winter 2026.",
+    excerpt: "XOceanus V1 gives you 92 engines and infinite combinations. Collections are the opposite: curated sets of 4–5 engines selected to work together, with a fifth fusion slot that blends their voices. The next chapter of XOceanus — coming Winter 2026.",
     tags: ["Vision", "Collections", "V2", "Product"],
     url: "guide-collections.html",
   },

--- a/site/index.html
+++ b/site/index.html
@@ -3,15 +3,15 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="XOceanus — synthesis from the deepest place. 90 engines, each a creature from the aquatic deep. Couple anything. Make sounds nothing else makes. Free & open-source.">
+<meta name="description" content="XOceanus — synthesis from the deepest place. 92 engines, each a creature from the aquatic deep. Couple anything. Make sounds nothing else makes. Free & open-source.">
 <meta property="og:title" content="XOceanus — Synthesis from the Deepest Place">
-<meta property="og:description" content="90 engines. 15 coupling types. Sounds that only exist when creatures are in the same water. Free & open-source.">
+<meta property="og:description" content="92 engines. 15 coupling types. Sounds that only exist when creatures are in the same water. Free & open-source.">
 <meta property="og:image" content="https://xo-ox.org/assets/og-image.png">
 <meta property="og:url" content="https://xo-ox.org/">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="XOceanus — Synthesis from the Deepest Place">
-<meta name="twitter:description" content="90 engines. Couple anything. Sounds nothing else makes. Free & open-source. By XO_OX Designs.">
+<meta name="twitter:description" content="92 engines. Couple anything. Sounds nothing else makes. Free & open-source. By XO_OX Designs.">
 <meta name="twitter:image" content="https://xo-ox.org/assets/og-image.png">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text x='4' y='24' font-size='24' fill='%23E9C46A'>X</text></svg>">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
@@ -33,7 +33,7 @@
     "name": "XO_OX Designs",
     "url": "https://xo-ox.org"
   },
-  "description": "Multi-engine character synthesizer with 90 engines, thousands of presets, and cross-engine coupling. Free and open-source."
+  "description": "Multi-engine character synthesizer with 92 engines, thousands of presets, and cross-engine coupling. Free and open-source."
 }
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/manifesto.html
+++ b/site/manifesto.html
@@ -11,7 +11,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;700&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <meta property="og:title" content="Manifesto — XO_OX Designs">
-<meta property="og:description" content="90 engines. 15 coupling types. Free. MIT. We are building something that will outlast us.">
+<meta property="og:description" content="92 engines. 15 coupling types. Free. MIT. We are building something that will outlast us.">
 <meta property="og:image" content="https://xo-ox.org/assets/og-image.png">
 <meta property="og:url" content="https://xo-ox.org/manifesto.html">
 <meta property="og:type" content="website">

--- a/site/packs.html
+++ b/site/packs.html
@@ -701,13 +701,13 @@ footer {
 }
 </style>
 <meta property="og:title" content="Sound Packs — XO_OX Designs">
-<meta property="og:description" content="90 engines. Thousands of presets. Free and open-source. By XO_OX Designs.">
+<meta property="og:description" content="92 engines. Thousands of presets. Free and open-source. By XO_OX Designs.">
 <meta property="og:url" content="https://xo-ox.org/packs.html">
 <meta property="og:image" content="https://xo-ox.org/assets/og-image.png">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Sound Packs — XO_OX Designs">
-<meta name="twitter:description" content="90 engines. Thousands of presets. Free and open-source.">
+<meta name="twitter:description" content="92 engines. Thousands of presets. Free and open-source.">
 <meta name="twitter:image" content="https://xo-ox.org/assets/og-image.png">
 <link rel="alternate" type="application/rss+xml" title="XOceanus Signal" href="feed.xml">
 <link rel="stylesheet" href="/design-tokens.css">


### PR DESCRIPTION
## Summary

Post-#1140 count-drift follow-up flagged in the triage umbrella (#1142). #1140 bumped `ENGINE_COUNT` from 90 → 92 in `CLAUDE.md`, but ~46 current-state references in design docs, specs, and site pages still read "90 engines". This PR normalizes them all.

- **21 files changed, 46 occurrences** (1:1, +46/−46)
- `Tools/validate_docs.py` passes clean — this sweep doesn't touch any preset-count patterns the validator cares about
- `CLAUDE.md` / `Docs/reference/engine-color-table.md` / master spec header already at 92 from #1140 and #1148; this PR covers the residual drift

## Intentionally preserved at "90 engines" (historical audit snapshots, not current count)

- `Docs/design/xoceanus-spatial-architecture.md:386` — "Engine Classification (90 engines audited)"
- `Docs/design/xoceanus-spatial-architecture.md:482` — "Full Audit Complete (90 engines read)"
- `Docs/design/tidesigns-audit.md:156` — "7/90 engines have override tables (9.5%)"

These are point-in-time audit results where the denominator reflects the fleet size at audit time; leaving them accurate to the audit moment.

## Out of scope

- `Tools/project_stats.json` still lists `engine_count: 76`. The validator doesn't check it (only preset patterns), and nothing currently reads it for engine counts. Worth a separate cleanup pass alongside the preset-count refresh.
- `site/guide.html:904` excerpt still uses "V1" framing ("XOceanus V1 gives you …"); only the count was updated here, consistent with #1147's editorial retirement of V1 framing in the master spec — retiring V1 across site copy is a separate editorial PR.

## Test plan

- [x] `python3 Tools/validate_docs.py --verbose` — all 12 checked docs consistent
- [x] `grep -rn "90 engines" Docs/ site/` returns only the 3 preserved historical snapshots
- [x] `grep -rn "92 engines" Docs/ site/` returns 46 occurrences across 21 files

## Branch housekeeping

This branch was originally `claude/analyze-branch-strategy-0AgTR` — an analysis session spawned to decide what to do with 5 orphaned commits that duplicated Group F fixes already merged via #1146. Reset to `origin/main` and repurposed for this sweep. The original 5 commits are confirmed redundant (tree-identical to what's already on `main`).

Closes the post-#1140 follow-up noted in https://github.com/BertCalm/XO_OX-XOmnibus/issues/1142#issuecomment-4309434065.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc1qjdTdRmThpPGGxdsAbJ)_