### PR TITLE
feat(outwit): tempo-sync step rate via SharedTransport (closes #1154)

### DIFF
--- a/Source/Core/SynthEngine.h
+++ b/Source/Core/SynthEngine.h
@@ -9,6 +9,8 @@
 namespace xoceanus
 {
 
+class SharedTransport;
+
 //==============================================================================
 // Coupling types supported by the MegaCouplingMatrix.
 // Each defines how one engine's output modulates another engine's parameter.
@@ -193,6 +195,16 @@ public:
     // Called once during engine setup. Engines use this to look up per-channel
     // pitch bend, pressure, and slide values in their renderBlock().
     virtual void setMPEManager(MPEManager* manager) { mpeManager = manager; }
+
+    //-- Host Transport --------------------------------------------------------
+
+    // Shared transport pointer for tempo-synced engines. The processor owns
+    // a single SharedTransport instance that it updates from the host PlayHead
+    // once per block, then exposes here. Engines that do not tempo-sync may
+    // leave this as the base-class no-op; engines that do (Outwit, Organon,
+    // Orrery) override to cache the pointer for later audio-thread reads.
+    // Called once per engine after prepare() and before the first renderBlock().
+    virtual void setSharedTransport(const SharedTransport* /*transport*/) noexcept {}
 
     //-- SRO: SilenceGate — Zero-Idle Bypass -----------------------------------
     //

--- a/Source/Engines/Organon/OrganonEngine.h
+++ b/Source/Engines/Organon/OrganonEngine.h
@@ -983,7 +983,7 @@ public:
 
     // Called by the processor to give Organon access to SharedTransport.
     // Must be called before the first renderBlock().
-    void setSharedTransport(const SharedTransport* transport) noexcept { sharedTransport = transport; }
+    void setSharedTransport(const SharedTransport* transport) noexcept override { sharedTransport = transport; }
 
     // Reverb send level — read by the processor to route to shared reverb bus.
     // Updated once per block in renderBlock(), driven by the membrane parameter

--- a/Source/Engines/Orrery/OrreryEngine.h
+++ b/Source/Engines/Orrery/OrreryEngine.h
@@ -555,7 +555,7 @@ public:
 
     // Called by the processor to give Orrery access to SharedTransport.
     // Must be called before the first renderBlock().
-    void setSharedTransport(const SharedTransport* transport) noexcept { sharedTransport = transport; }
+    void setSharedTransport(const SharedTransport* transport) noexcept override { sharedTransport = transport; }
 
     //==========================================================================
     // renderBlock

--- a/Source/Engines/Outwit/XOutwitAdapter.h
+++ b/Source/Engines/Outwit/XOutwitAdapter.h
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include "../../Core/SynthEngine.h"
+#include "../../Core/SharedTransport.h"
 
 // XOutwit DSP — included via target_include_directories in CMakeLists.txt
 // (path: XOutwit/Source/DSP/)
@@ -28,6 +29,7 @@
 #include "DSP/ParamSnapshot.h"
 #include "DSP/FastMath.h"
 #include "../../DSP/SRO/SilenceGate.h"
+#include <algorithm>
 #include <array>
 #include <cmath>
 
@@ -69,6 +71,13 @@ public:
     }
 
     void releaseResources() override {}
+
+    // #1154: Cache the processor's SharedTransport so renderBlock() can read
+    // host BPM + playing state when stepSync is enabled.
+    void setSharedTransport(const SharedTransport* transport) noexcept override
+    {
+        sharedTransport = transport;
+    }
 
     void reset() override
     {
@@ -137,7 +146,41 @@ public:
         }
 
         // 3. Working copies — LFO + macro + expression modulation
-        float modStepRate = snap.stepRate * (1.0f + snap.huntRate); // huntRate scales CA search speed
+        //
+        // #1154: Tempo-sync base rate. When snap.stepSync is on AND the host
+        // transport provides a valid BPM (> 0), the base rate is locked to
+        // bpm / (60 * div_beats). Coupling, LFO, and huntRate modulation still
+        // layer on top, so the tempo-locked rate can still wobble musically.
+        // When stepSync is off, BPM is unavailable, or the host is not yet
+        // attached, the engine free-runs from snap.stepRate (preserves
+        // back-compat for every existing preset).
+        float baseStepRate = snap.stepRate;
+        if (snap.stepSync && sharedTransport != nullptr)
+        {
+            const double hostBpm = sharedTransport->getBPM();
+            if (hostBpm > 0.0)
+            {
+                // Division table matches the AudioParameterChoice enum order:
+                // "1/32", "1/16T", "1/16", "1/8T", "1/8", "1/4T", "1/4", "1/2", "1/1", "2/1"
+                // values are in beats (quarter note = 1.0 beat).
+                static constexpr std::array<float, 10> kDivBeats{
+                    0.125f,         // 1/32
+                    1.0f / 6.0f,    // 1/16T  (triplet)
+                    0.25f,          // 1/16
+                    1.0f / 3.0f,    // 1/8T   (triplet)
+                    0.5f,           // 1/8
+                    2.0f / 3.0f,    // 1/4T   (triplet)
+                    1.0f,           // 1/4
+                    2.0f,           // 1/2
+                    4.0f,           // 1/1
+                    8.0f            // 2/1
+                };
+                const int idx = std::clamp(snap.stepDiv, 0, static_cast<int>(kDivBeats.size()) - 1);
+                const float divBeats = kDivBeats[static_cast<size_t>(idx)];
+                baseStepRate = static_cast<float>(hostBpm) / (60.0f * divBeats);
+            }
+        }
+        float modStepRate = baseStepRate * (1.0f + snap.huntRate); // huntRate scales CA search speed
         float modChromAmount = snap.chromAmount;
         float modSynapse = snap.synapse;
         float modDenSize = snap.denSize;
@@ -419,11 +462,13 @@ public:
         // Global: Step/Clock
         params.push_back(std::make_unique<juce::AudioParameterFloat>(
             "owit_stepRate", "Step Rate", juce::NormalisableRange<float>(0.01f, 40.0f, 0.0f, 0.4f), 4.0f));
-        // TODO(#1154): owit_stepSync + owit_stepDiv are registered for preset-load compatibility
-        // but NOT wired to DSP. PlayHead BPM read + stepDiv → samples-per-step conversion is
-        // pending. These controls have no audio effect until #1154 is implemented.
-        // Kept in parameter layout to avoid breaking existing preset files; hidden from UI
-        // until wired (refs #1144 → #1154).
+        // Tempo-sync (#1154): when owit_stepSync is on, the base step rate is
+        // driven by host BPM via SharedTransport and owit_stepDiv chooses the
+        // division. owit_stepRate is ignored while synced. All modulation
+        // (huntRate, LFO→StepRate, coupling) still applies on top of the
+        // tempo-locked base. When the host provides no BPM, renderBlock falls
+        // back to the free-running owit_stepRate. Default stepSync=false keeps
+        // every existing preset sounding identical.
         params.push_back(std::make_unique<juce::AudioParameterBool>("owit_stepSync", "Step Sync", false));
         params.push_back(std::make_unique<juce::AudioParameterChoice>(
             "owit_stepDiv", "Step Division",
@@ -558,6 +603,12 @@ private:
     xoutwit::ParamSnapshot snap;
 
     double sr = 0.0;  // Sentinel: must be set by prepare() before use
+
+    // #1154: Host transport pointer — nullptr when no processor has attached
+    // one (e.g., tests, engine sandbox). renderBlock() falls back to free-run
+    // when null or when BPM is unavailable.
+    const SharedTransport* sharedTransport = nullptr;
+
     bool noteHeld = false;
     int currentNote = -1;
     int targetNote = -1;     // Seance P1: glide target note

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1190,6 +1190,7 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
         {
             eng->prepare(sampleRate, samplesPerBlock);
             eng->prepareSilenceGate(sampleRate, samplesPerBlock, silenceGateHoldMs(eng->getEngineId()));
+            eng->setSharedTransport(&hostTransport);
         }
     }
 
@@ -1480,19 +1481,30 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         midiClockBlockOffset_ += numSamples;
     }
 
-    // DAW host transport sync
-    if (auto* playHead = getPlayHead())
+    // DAW host transport sync — read PlayHead once, feed both hostTransport
+    // (consumed by tempo-synced engines via SharedTransport) and ChordMachine.
     {
-        if (auto pos = playHead->getPosition())
+        juce::AudioPlayHead::PositionInfo posSnapshot;
+        const juce::AudioPlayHead::PositionInfo* posPtr = nullptr;
+        if (auto* playHead = getPlayHead())
         {
-            if (auto ppq = pos->getPpqPosition())
+            if (auto pos = playHead->getPosition())
             {
-                double hostBPM = 122.0;
-                if (auto bpmOpt = pos->getBpm())
-                    hostBPM = *bpmOpt;
-                bool hostPlaying = pos->getIsPlaying();
-                chordMachine.syncToHost(*ppq, hostBPM, hostPlaying);
+                posSnapshot = *pos;
+                posPtr = &posSnapshot;
             }
+        }
+        hostTransport.processBlock(numSamples,
+                                   currentSampleRate.load(std::memory_order_relaxed),
+                                   posPtr);
+        if (posPtr != nullptr && posPtr->getPpqPosition().hasValue())
+        {
+            const double ppq = *posPtr->getPpqPosition();
+            double hostBPM = 122.0;
+            if (posPtr->getBpm().hasValue())
+                hostBPM = *posPtr->getBpm();
+            const bool hostPlaying = posPtr->getIsPlaying();
+            chordMachine.syncToHost(ppq, hostBPM, hostPlaying);
         }
     }
 
@@ -2339,6 +2351,10 @@ void XOceanusProcessor::loadEngine(int slot, const std::string& engineId)
             newEngine->prepareSilenceGate(sr, currentBlockSize.load(std::memory_order_relaxed),
                                           silenceGateHoldMs(newEngine->getEngineId()));
         }
+        // Give the new engine access to the shared host transport regardless
+        // of whether prepare() has run yet — the engine caches the pointer and
+        // reads from it in renderBlock(), which only runs after prepareToPlay().
+        newEngine->setSharedTransport(&hostTransport);
     }
 
     // Wake the silence gate so the new engine renders its first block immediately.

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -16,6 +16,7 @@
 #include "Core/CouplingPresetManager.h"
 #include "Core/MacroSystem.h"
 #include "Core/BrothCoordinator.h"
+#include "Core/SharedTransport.h"
 #include "DSP/EngineProfiler.h"
 #include "DSP/SRO/SROAuditor.h"
 #include <atomic>
@@ -363,6 +364,11 @@ private:
     MasterFXChain masterFX;
     xoceanus::EpicChainSlotController epicSlots;  // 3-slot Epic Chains FX router
     ChordMachine chordMachine;
+
+    // Unified host transport — the processor updates this from the PlayHead
+    // once per audio block, then engines that tempo-sync (Outwit, Organon,
+    // Orrery) read bpm/beat/isPlaying here during their renderBlock().
+    xoceanus::SharedTransport hostTransport;
     MPEManager mpeManager;
     MIDILearnManager midiLearnManager;
     PresetManager presetManager;


### PR DESCRIPTION
## Summary

Closes **#1154**. Wires Outwit's `owit_stepSync` + `owit_stepDiv` parameters to host BPM so the 8-arm cellular-automaton step rate can lock to the DAW clock.

Also activates the long-orphaned `SharedTransport` infrastructure — Organon's `lockIn` and Orrery's `TempoSync` orbit speed start actually working as a side effect of this PR (both had `setSharedTransport()` hooks that were never called from the processor).

## What changed

### SharedTransport — properly wired fleet-wide

- `XOceanusProcessor`: new `hostTransport` member, fed from PlayHead once per audio block (`hostTransport.processBlock(numSamples, sr, posInfo)`). Distributed to every engine via `eng->setSharedTransport(&hostTransport)` in both `prepareToPlay` and `loadEngine` after `prepare()`.
- The ad-hoc PlayHead read previously done just for `ChordMachine` now reuses the single `PositionInfo` snapshot — one `getPlayHead()` call per block instead of two.
- `SynthEngine` base: new `virtual setSharedTransport(const SharedTransport*) noexcept {}` (no-op). Organon + Orrery existing methods marked `override`.

### Outwit tempo-sync

- `XOutwitEngine::setSharedTransport()` caches the pointer.
- In `renderBlock()`, when `snap.stepSync` is true and `sharedTransport->getBPM() > 0`, the base step rate becomes `bpm / (60 * div_beats)` using a 10-entry table matching the existing `AudioParameterChoice` enum (includes triplets).
- Modulation composes on top: LFO→StepRate (case 0), `huntRate`, and coupling `extStepRateMod` still layer onto the tempo-locked base — music still wobbles, just locked to grid.
- Free-run fallbacks: stepSync off, BPM unavailable, or no processor attached (tests, sandbox) all keep using `owit_stepRate` — every existing preset sounds identical because default `stepSync = false`.
- Stale "hidden from UI" comment replaced with live documentation.

## Division table

At 120 BPM:

| `stepDiv` | Label | div_beats | stepRate |
|:--:|:--|:--:|:--:|
| 0 | 1/32 | 0.125 | 16 Hz |
| 1 | 1/16T | 1/6 | ~12 Hz |
| 2 | 1/16 | 0.25 | 8 Hz |
| 3 | 1/8T | 1/3 | ~6 Hz |
| 4 | **1/8** *(default)* | 0.5 | **4 Hz** |
| 5 | 1/4T | 2/3 | ~3 Hz |
| 6 | 1/4 | 1.0 | 2 Hz |
| 7 | 1/2 | 2.0 | 1 Hz |
| 8 | 1/1 | 4.0 | 0.5 Hz |
| 9 | 2/1 | 8.0 | 0.25 Hz |

The `owit_stepRate` parameter default is already `4.0f`, so a user enabling sync at 120 BPM with the default division sees no perceptible change — a friendly on-boarding.

## Edge cases

| Case | Behaviour |
|------|-----------|
| stepSync off | Free-run from `owit_stepRate` (unchanged) |
| Host provides no PlayHead (sandbox, test) | `sharedTransport` nullptr → free-run |
| Host provides PlayHead but no BPM | `getBPM()` returns SharedTransport's internal default (120) — sync to 120 |
| BPM ≤ 0 | `if (hostBpm > 0.0)` gates out → free-run |
| Transport stopped | `getBPM()` returns last known value — sync continues ("music still wobbles") |
| BPM change mid-block | Block-rate resolution: caught at top of next `renderBlock()` |
| Existing presets | `stepSync` default false → identical behaviour |

## Test plan

- [x] Self-reviewed diff — localized, no API breaks
- [x] `std::array<float, 10>` with `constexpr` initialiser, bounds-checked via `std::clamp`
- [x] `const SharedTransport*` ownership: processor owns, engines hold non-owning pointer; pointer remains valid for processor lifetime
- [x] Audio-thread safety: `SharedTransport::getBPM()` is an atomic load; new code does no allocation, no blocking
- [ ] CI: build + asan + tsan + ubsan + ios-build + doc consistency
- [ ] Manual (post-merge): Outwit preset at 120 BPM / 1/8 should match free-run 4 Hz; changing DAW tempo moves the step rate at the next block boundary; turning `stepSync` off reverts to `owit_stepRate`

## Scope boundary

Not touched — explicitly out of scope and tracked separately:
- `Tools/project_stats.json` stale `engine_count: 76` (unrelated)
- V1/MVP spec editorial retirement on site pages (#1147 covered master spec only)

Umbrella: #1142.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc1qjdTdRmThpPGGxdsAbJ)_