### PR TITLE
docs: residual 92-count normalization on og-image.svg (refs #1142)

### DIFF
--- a/site/assets/og-image.svg
+++ b/site/assets/og-image.svg
@@ -27,7 +27,7 @@
         fill="#F0EDE8" text-anchor="middle" opacity="0.85">for all</text>
   <!-- Descriptor line -->
   <text x="600" y="400" font-family="'Inter', system-ui, sans-serif" font-size="20" font-weight="400"
-        fill="#A0A8B8" text-anchor="middle">77 engines · Couple anything · Free &amp; open-source</text>
+        fill="#A0A8B8" text-anchor="middle">92 engines · Couple anything · Free &amp; open-source</text>
   <!-- XO_OX brand -->
   <text x="600" y="545" font-family="'Inter', system-ui, sans-serif" font-size="16" font-weight="400"
         fill="#E9C46A" text-anchor="middle" opacity="0.6">XO_OX Designs · xo-ox.org</text>


### PR DESCRIPTION
Tail cleanup after #1192 — fixes remaining og-image.svg with stale "77 engines" text.

#1192 normalized most 90→92 references after #1140 bumped ENGINE_COUNT. This PR catches the og:image asset which still had outdated "77 engines" (likely an older snapshot). Updated to canonical "92 engines".

1 file, 1 line changed.