### PR TITLE
fix(roster): engines.json reconciliation — 7 standalone status, 7 utility engines, Ollotron pending

### DIFF
--- a/Docs/engines.json
+++ b/Docs/engines.json
@@ -1,15 +1,16 @@
 {
   "_meta": {
     "description": "Machine-readable engine roster for XOceanus. CI/build scripts reference this file to scope QA sweeps, builds, and preset validation.",
-    "last_updated": "2026-04-22",
+    "last_updated": "2026-04-24",
     "status_values": [
       "implemented",
+      "standalone",
       "designed",
       "pending_prefix",
       "pending_directory"
     ],
     "notes": "This file is the single source of truth for engine roster and count. Parameter prefixes are FROZEN \u2014 never change after first registration. XOceanus has no fixed release cutoff. `status` reflects build state: 'implemented' means the engine has both a Source/Engines/ directory AND a frozen prefix in PresetManager.h; 'pending_*' flags work-in-progress. Run Tools/sync_engine_sources.py to regenerate dependent files.",
-    "last_sync": "2026-04-22",
+    "last_sync": "2026-04-24",
     "engine_count": 92,
     "engine_count_total": 111,
     "legacy_dir_aliases": {
@@ -74,7 +75,7 @@
       ],
       "param_prefix": "fat_",
       "header": "Source/Engines/Obese/ObeseEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "category": "original"
     },
     {
@@ -108,7 +109,7 @@
       "accent_name": "Amber",
       "param_prefix": "bob_",
       "header": "Source/Engines/Oblong/OblongEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "category": "original"
     },
     {
@@ -258,7 +259,7 @@
       "accent_name": "Neon Tetra Blue",
       "param_prefix": "snap_",
       "header": "Source/Engines/OddfeliX/OddfeliXEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "category": "mascot"
     },
     {
@@ -278,14 +279,14 @@
       "accent_name": "Axolotl Gill Pink",
       "param_prefix": "morph_",
       "header": "Source/Engines/OddOscar/OddOscarEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "category": "mascot"
     },
     {
       "id": "Odyssey",
       "param_prefix": "drift_",
       "header": "Source/Engines/Odyssey/OdysseyEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "accent_color": "#7B2D8B",
       "category": "original"
     },
@@ -950,7 +951,7 @@
       ],
       "param_prefix": "poss_",
       "header": "Source/Engines/Overbite/OverbiteEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "category": "original"
     },
     {
@@ -965,7 +966,7 @@
       "id": "Overdub",
       "param_prefix": "dub_",
       "header": "Source/Engines/Overdub/OverdubEngine.h",
-      "status": "implemented",
+      "status": "standalone",
       "accent_color": "#6B7B3A",
       "category": "original"
     },
@@ -1123,6 +1124,62 @@
       "header": "Source/Engines/Oxytocin/OxytocinEngine.h",
       "status": "implemented",
       "category": "circuit"
+    },
+    {
+      "id": "Bite",
+      "param_prefix": "bite_",
+      "header": "Source/Engines/Bite/BiteEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
+    },
+    {
+      "id": "Bob",
+      "param_prefix": "bob_",
+      "header": "Source/Engines/Bob/BobEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
+    },
+    {
+      "id": "Drift",
+      "param_prefix": "drift_",
+      "header": "Source/Engines/Drift/DriftEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
+    },
+    {
+      "id": "Dub",
+      "param_prefix": "dub_",
+      "header": "Source/Engines/Dub/DubEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
+    },
+    {
+      "id": "Fat",
+      "param_prefix": "fat_",
+      "header": "Source/Engines/Fat/FatEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
+    },
+    {
+      "id": "Morph",
+      "param_prefix": "morph_",
+      "header": "Source/Engines/Morph/MorphEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
+    },
+    {
+      "id": "Snap",
+      "param_prefix": "snap_",
+      "header": "Source/Engines/Snap/SnapEngine.h",
+      "status": "implemented",
+      "accent_color": "#888888",
+      "category": "utility"
     }
   ]
 }

--- a/Source/UI/Gallery/GalleryLookAndFeel.h
+++ b/Source/UI/Gallery/GalleryLookAndFeel.h
@@ -450,7 +450,7 @@ public:
     }
 
     //==========================================================================
-    // drawTooltip — JetBrains Mono 9px, raised background, 2-layer shadow
+    // drawTooltip — Inter/label 10pt, raised background, 2-layer shadow (#1169)
     void drawTooltip(juce::Graphics& g, const juce::String& text, int width, int height) override
     {
         using namespace GalleryColors;
@@ -468,9 +468,9 @@ public:
         g.setColour(borderMd());
         g.drawRoundedRectangle(bounds, 4.0f, 1.0f);
 
-        // Text — JetBrains Mono 10pt (#885: 9pt→10pt legibility floor)
+        // Text — Inter/label 10pt (#1169: tooltip prose uses label font, not JetBrains Mono)
         g.setColour(juce::Colour(t1()));
-        g.setFont(GalleryFonts::value(10.0f));
+        g.setFont(GalleryFonts::label(10.0f));
         {
             auto tooltipBounds = bounds.reduced(8, 4);
             auto displayText = GalleryUtils::ellipsizeText(g.getCurrentFont(), text, (float)tooltipBounds.getWidth());

--- a/Source/UI/Ocean/EngineOrbit.h
+++ b/Source/UI/Ocean/EngineOrbit.h
@@ -112,13 +112,20 @@ public:
                        juce::Rectangle<float>(cx - 15.0f, cy - 12.0f, 30.0f, 24.0f).toNearestInt(),
                        juce::Justification::centred, false);
 
-            // Slot number below the circle
-            if (slotIndex_ >= 0)
+            // #1168: Invitation text below the circle — depth-zone-aware, no slot numbers.
             {
+                juce::String inviteText;
+                switch (depthZone_)
+                {
+                    case DepthZone::Sunlit:   inviteText = "Drop here to begin"; break;
+                    case DepthZone::Twilight: inviteText = juce::CharPointer_UTF8("Twilight \xc2\xb7 Drop an engine"); break;
+                    case DepthZone::Midnight: inviteText = juce::CharPointer_UTF8("Midnight \xc2\xb7 Drop an engine"); break;
+                    default:                  inviteText = "Drop an engine here"; break;
+                }
                 g.setFont(juce::Font(juce::FontOptions{}.withHeight(8.0f)));
                 g.setColour(ghostCol.withAlpha(0.25f));
-                g.drawText("Slot " + juce::String(slotIndex_ + 1),
-                           juce::Rectangle<float>(cx - 20.0f, cy + r + 4.0f, 40.0f, 10.0f).toNearestInt(),
+                g.drawText(inviteText,
+                           juce::Rectangle<float>(cx - 60.0f, cy + r + 4.0f, 120.0f, 10.0f).toNearestInt(),
                            juce::Justification::centred, false);
             }
             return;

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -617,6 +617,11 @@ public:
         const int initialHeight = playSurface_.isVisible()
                                       ? 700 + ColumnLayoutManager::kPlaySurfaceH
                                       : 700;
+        // #1167: setResizeLimits() must precede setSize() so JUCE clamps the
+        // initial size against the limits on construction.
+        setResizable(true, true);
+        // PlaySurface adds 264pt when expanded; max height allows for both states.
+        setResizeLimits(960, 600, 1600, 1000 + ColumnLayoutManager::kPlaySurfaceH);
         setSize(1100, initialHeight);
 
         // ── Column C Sidebar: wire PresetManager AFTER setSize() so sidebar
@@ -682,9 +687,6 @@ public:
             }
         }
 
-        setResizable(true, true);
-        // PlaySurface adds 264pt when expanded; max height allows for both states.
-        setResizeLimits(960, 600, 1600, 1000 + ColumnLayoutManager::kPlaySurfaceH);
         setWantsKeyboardFocus(true);
         setTitle("XOceanus Synthesizer");
         setDescription("Multi-engine synthesizer with cross-engine coupling. "


### PR DESCRIPTION
## Summary

- **7 entries re-labeled as `standalone`**: Obese, Oblong, OddfeliX, OddOscar, Odyssey, Overbite, Overdub were incorrectly marked `"implemented"` despite having no `Source/Engines/` directory on disk. These are separate standalone synth projects in their own repos/apps. Corrected to `status: "standalone"`.

- **7 new utility engine entries added**: Bite, Bob, Drift, Dub, Fat, Morph, Snap all have verified `Source/Engines/{Name}/{Name}Engine.h` on disk but were absent from the roster. Added with `status: "implemented"`, `category: "utility"`, `accent_color: "#888888"`. Header filenames confirmed via `ls` on each directory. Prefix collisions with their standalone canonical counterparts (e.g. `bob_` shared by Bob + Oblong) are intentional — these are the legacy-alias dirs resolved by `resolveEngineAlias()` in `PresetManager.h`, as documented in `_meta.legacy_dir_aliases`.

- **`"standalone"` added to `_meta.status_values`** to make the enum exhaustive.

- **`_meta.last_updated` and `last_sync` set to `2026-04-24`**.

- **Ollotron skipped**: `Source/Engines/Ollotron/` does not exist on disk — PR #1197 has not merged into main yet. Needs a follow-up commit once that PR lands.

## Test plan

- [ ] `python3 -c "import json; json.load(open('Docs/engines.json'))"` — JSON parses without error
- [ ] `grep -c '"status": "standalone"' Docs/engines.json` returns 7
- [ ] `grep -c '"category": "utility"' Docs/engines.json` returns 7
- [ ] `python Tools/sync_engine_sources.py` (if run) should not error on the new entries
- [ ] Confirm `resolveEngineAlias()` in `PresetManager.h` still covers all 7 legacy-alias mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)