### PR TITLE
DSP deep-review round 11: Orbweave, Overworld, Octopus

### DIFF
--- a/Source/Engines/Octopus/OctopusEngine.h
+++ b/Source/Engines/Octopus/OctopusEngine.h
@@ -230,6 +230,13 @@ struct OctoVoice
     // Per-voice RNG for drift
     uint32_t driftRng = 0u;
 
+    // OCT-04 P19: delta-guards for block-rate filter coefficient updates
+    float lastSuckerFreq = -1.0f;
+    float lastSuckerReso = -1.0f;
+
+    // OCT-14: delta-guard for per-block ink cloud decay updates
+    float lastInkDecay = -1.0f;
+
     void reset() noexcept
     {
         active = false;
@@ -237,12 +244,17 @@ struct OctoVoice
         velocity = 0.0f;
         currentFreq = 440.0f;
         targetFreq = 440.0f;
+        glideCoeff = 1.0f;          // OCT-06 P14: glideCoeff was not reset
+        driftRng = 0u;              // OCT-06 P14: driftRng was not reset
         fadeGain = 1.0f;
         fadingOut = false;
         microtonalOffset = 0.0f;
         pitchDriftPhase = 0.0f;
         envFollower = 0.0f;
         inkTriggered = false;
+        lastSuckerFreq = -1.0f;     // OCT-04: force coefficient refresh on next block
+        lastSuckerReso = -1.0f;
+        lastInkDecay = -1.0f;       // OCT-14: force ink decay refresh on next block
         ampEnv.reset();
         modEnv.reset();
         suckerEnv.reset();
@@ -345,6 +357,11 @@ public:
         couplingArmRateMod = 0.0f;
         couplingRingModSrc = 0.0f;
         couplingPitchMod = 0.0f;
+
+        // OCT-07 P14: mod wheel and pitch bend state were not cleared on reset,
+        // causing stale expression values to persist across stop/start cycles.
+        modWheelAmount_ = 0.0f;
+        pitchBendNorm = 0.0f;
 
         smoothedWTPos = 0.0f;
         smoothedChromaDepth = 0.0f;
@@ -471,7 +488,7 @@ public:
         float effectiveChromaDepth =
             clamp(pChromaDepth + macroCoup * 0.4f + couplingChromaMod + modWheelAmount_ * 0.4f, 0.0f, 1.0f);
         float effectiveWTPos = clamp(pWTPos + couplingWTPosMod + macroMove * 0.2f, 0.0f, 1.0f);
-        float effectiveCutoff = clamp(pCutoff + macroChar * 4000.0f, 20.0f, 20000.0f);
+        float effectiveCutoff = clamp(pCutoff + macroChar * 4000.0f, 20.0f, srf * 0.49f); // OCT-01 P17: Nyquist ceiling now srf*0.49
         float effectiveReso = clamp(pReso + macroChar * 0.2f, 0.0f, 1.0f);
         float effectiveInkMix = clamp(pInkMix + macroCoup * 0.3f, 0.0f, 1.0f);
         float effectiveSuckerMix = clamp(pSuckerMix + macroChar * 0.3f, 0.0f, 1.0f);
@@ -543,8 +560,17 @@ public:
             if (!voice.active)
                 continue;
 
-            // Set sucker filter default for this block (overridden per-sample when sucker is active)
-            voice.suckerFilter.setCoefficients(clamp(pSuckerFreq, 200.0f, 8000.0f), pSuckerReso, srf);
+            // Set sucker filter default for this block — OCT-04 P19: delta-guard so
+            // setCoefficients (fastTan inside) is only called when freq/reso actually changed.
+            {
+                const float sf = clamp(pSuckerFreq, 200.0f, 8000.0f);
+                if (sf != voice.lastSuckerFreq || pSuckerReso != voice.lastSuckerReso)
+                {
+                    voice.suckerFilter.setCoefficients(sf, pSuckerReso, srf);
+                    voice.lastSuckerFreq = sf;
+                    voice.lastSuckerReso = pSuckerReso;
+                }
+            }
 
             // Set arm LFO rates per voice
             for (int a = 0; a < 8; ++a)
@@ -557,8 +583,13 @@ public:
                 voice.arms[a].setShape(a % 5);
             }
 
-            // Ink cloud decay
-            voice.inkCloud.setDecay(effectiveInkDecay, srf);
+            // Ink cloud decay — OCT-14: delta-guard so setDecay (division + std::max inside)
+            // is only recomputed when the decay time actually changes.
+            if (effectiveInkDecay != voice.lastInkDecay)
+            {
+                voice.inkCloud.setDecay(effectiveInkDecay, srf);
+                voice.lastInkDecay = effectiveInkDecay;
+            }
         }
 
         float peakEnv = 0.0f;
@@ -708,9 +739,14 @@ public:
                     voice.envFollower = flushDenormal(voice.envFollower);
 
                     // Map envelope to filter frequency modulation
-                    [[maybe_unused]] float chromaFreqMod = clamp(pChromaFreq + voice.envFollower * pChromaSens * 4000.0f +
+                    // OCT-02 P17: ceiling was hardcoded 16000Hz; now srf*0.49 for 96kHz safety
+                    // OCT-03/OCT-11 D004: was [[maybe_unused]] — chromaFilter coefficients were never
+                    // updated during render, so the envelope follower had zero audible effect.
+                    float chromaFreqMod = clamp(pChromaFreq + voice.envFollower * pChromaSens * 4000.0f +
                                                     armMods[ArmChromaFreq] * 2000.0f,
-                                                100.0f, 16000.0f);
+                                                100.0f, srf * 0.49f);
+                    // Apply computed frequency to the chroma filter (uses neutral Q = 0.5)
+                    voice.chromaFilter.setCoefficients(chromaFreqMod, 0.5f, srf);
 
                     // Morph filter type: LP → BP → HP → Notch
                     // We process through LP and HP, then blend
@@ -747,6 +783,14 @@ public:
 
                 // --- Main filter with arm modulation ---
                 // D001: continuous velocity→timbre — higher velocity opens the filter further
+                // OCT-15 D004: ArmFilterCutoff (arm 0) was computed but never applied —
+                // the arm's modulation had zero effect on the main filter frequency.
+                // F10 comment described per-sample update but code was absent; restored here.
+                {
+                    float armCutoff = clamp(effectiveCutoff * fastPow2(armMods[ArmFilterCutoff] * 0.5f),
+                                            20.0f, srf * 0.49f);
+                    voice.mainFilter.setCoefficients_fast(armCutoff, effectiveReso, srf);
+                }
                 voiceSignal = voice.mainFilter.processSample(voiceSignal);
 
                 // =====================================================
@@ -757,8 +801,15 @@ public:
                 {
                     // arm mod spans -1..+1 → shift F1 down/up by up to 250 Hz, F2 up/down by up to 850 Hz
                     float fShift = armMods[ArmFormantShift]; // -1..+1, already depth-scaled
-                    [[maybe_unused]] float f1Freq = clamp(550.0f + fShift * 250.0f, 200.0f, 900.0f);
-                    [[maybe_unused]] float f2Freq = clamp(1650.0f - fShift * 850.0f, 600.0f, 3000.0f);
+                    // OCT-10 D004: f1Freq/f2Freq were [[maybe_unused]] — formant filters ran at default
+                    // coefficients regardless of ArmFormantShift, making the vowel-shift inaudible.
+                    float f1Freq = clamp(550.0f + fShift * 250.0f, 200.0f, 900.0f);
+                    float f2Freq = clamp(1650.0f - fShift * 850.0f, 600.0f, 3000.0f);
+                    // Q≈3 gives a focused formant band without excessive ringing.
+                    // Resonance [0,1] maps to k=2-2*res; Q≈3 → k=1/3 → res≈0.833.
+                    // Use fast path since arm mods update these every sample.
+                    voice.formant1.setCoefficients_fast(f1Freq, 0.833f, srf);
+                    voice.formant2.setCoefficients_fast(f2Freq, 0.833f, srf);
                     float formantSig = voice.formant1.processSample(voiceSignal) * 0.6f +
                                        voice.formant2.processSample(voiceSignal) * 0.4f;
                     // Blend at a modest level — more pronounced when arm depth is high
@@ -1398,6 +1449,9 @@ private:
         voice.modEnv.noteOn();
 
         // Sucker — ultra-fast transient
+        // OCT-08: explicit reset before retrigger (voice.reset() clears it, but
+        // being explicit matches the mono path and guards against future refactors).
+        voice.suckerEnv.reset();
         voice.suckerEnv.setParams(0.001f, suckerDecay, 0.0f, suckerDecay, srf);
         voice.suckerEnv.noteOn();
 

--- a/Source/Engines/Orbweave/OrbweaveEngine.h
+++ b/Source/Engines/Orbweave/OrbweaveEngine.h
@@ -93,10 +93,12 @@ struct OrbweaveFXState
         std::fill(chorusBufL.begin(), chorusBufL.end(), 0.0f);
         std::fill(chorusBufR.begin(), chorusBufR.end(), 0.0f);
         chorusWritePos = 0;
+        chorusLFOPhase = 0.0f; // OW-02: restore chorus LFO continuity on reset
         for (int i = 0; i < 4; ++i)
         {
             std::fill(reverbBuf[i].begin(), reverbBuf[i].end(), 0.0f);
             reverbFilt[i] = 0.0f;
+            reverbPos[i] = 0; // OW-01: reset reverb read/write positions on FX reset
         }
     }
 };
@@ -220,6 +222,7 @@ struct OrbweaveVoice
         pan = 0.0f;
         stealFadeGain = 0.0f;
         stealFadeStep = 0.0f;
+        startTime = 0; // OW-04: reset startTime so voice-steal ordering is correct after full reset
     }
 };
 
@@ -260,6 +263,9 @@ public:
         matrixDirty = true; // invalidate cached matrix on reset
         couplingPitchMod = 0.0f;
         couplingCutoffMod = 0.0f;
+        modWheel_ = 0.0f;    // OW-03: clear stale expression state on engine reset
+        pitchBend_ = 0.0f;   // OW-03
+        voiceCounter = 0;    // OW-09: reset voice counter to avoid uint64 wrap and ordering artifacts
     }
 
     //==========================================================================
@@ -536,11 +542,13 @@ public:
 
                 // === Filter ===
                 // Filter mode was set once per block above (blockFilterMode).
-                // setCoefficients() is called per-sample because cutoffMod varies
-                // with LFO output; mode is param-rate only.
-                float effCut = clamp(filterCutoff + cutoffMod + velTimbre, 20.0f, 20000.0f);
+                // setCoefficients_fast() is used per-sample (OW-05): all 3 filter modes
+                // (LP/HP/BP) are non-shelf, so the fast path is safe and avoids the
+                // full coefficient path's extra work.  Mode never changes mid-block.
+                // OW-06: clamp ceiling is sr*0.49f (not hardcoded 20000) for 48/96kHz users.
+                float effCut = clamp(filterCutoff + cutoffMod + velTimbre, 20.0f, sr * 0.49f);
                 float effRes = clamp(filterReso + resoMod, 0.0f, 1.0f);
-                voice.filter.setCoefficients(effCut, effRes, sr);
+                voice.filter.setCoefficients_fast(effCut, effRes, sr);
                 signal = voice.filter.processSample(signal);
 
                 // === Amp envelope ===
@@ -1073,6 +1081,11 @@ private:
         int slot = -1;
         uint64_t oldest = UINT64_MAX;
         int oldestSlot = 0;
+        // OW-07: prefer stealing a releasing voice to minimise audible clicks.
+        // Scan for a release-stage voice with the oldest startTime first; only
+        // fall back to oldest-overall if none are in release.
+        int relSlot = -1;
+        uint64_t relOldest = UINT64_MAX;
 
         if (isLegato)
         {
@@ -1093,6 +1106,13 @@ private:
                     slot = i;
                     break;
                 }
+                // OW-07: track oldest releasing voice separately
+                if (voices[i].ampEnv.getStage() == StandardADSR::Stage::Release
+                    && voices[i].startTime < relOldest)
+                {
+                    relOldest = voices[i].startTime;
+                    relSlot   = i;
+                }
                 if (voices[i].startTime < oldest)
                 {
                     oldest = voices[i].startTime;
@@ -1100,7 +1120,7 @@ private:
                 }
             }
             if (slot < 0)
-                slot = oldestSlot;
+                slot = (relSlot >= 0) ? relSlot : oldestSlot; // OW-07: releasing preferred
         }
 
         auto& v = voices[slot];

--- a/Source/Engines/Overworld/OverworldEngine.h
+++ b/Source/Engines/Overworld/OverworldEngine.h
@@ -100,6 +100,22 @@ public:
         eraPhase = 0.0f;
         lastSample = 0.0f;
         filterEnvLevel = 0.0f;
+        // OVW-02/OVW-03/OVW-06/OVW-08/OVW-09/OVW-10 fix: reset all expression, mod matrix,
+        // ghost ERA, filter delta-guard sentinel, and coupling accumulator state on
+        // preset change to prevent bleed across presets.
+        pitchBendNorm       = 0.0f;
+        lastFilterCutoffHz  = -1.0f; // force coefficient recompute on first block
+        modWheelAmount    = 0.0f;
+        owModEraOffset    = 0.0f;
+        owModGlitchOffset = 0.0f;
+        owModPitchOffset  = 0.0f;
+        owModLevelOffset  = 0.0f;
+        ghostEraLast      = 0.0f;
+        ghostEraYLast     = 0.0f;
+        eraDriftSHValue   = 0.0f;
+        externalFilterMod = 0.0f;
+        externalEraMod    = 0.0f;
+        externalEraYMod   = 0.0f;
         // Wrap haasWritePos to prevent int overflow on long sessions
         haasWritePos = 0;
         if (!haasDelayBuf.empty())
@@ -313,11 +329,54 @@ public:
 
         const float effectiveCrushMix = juce::jlimit(0.0f, 1.0f, snap.crushMix + macCrush * 0.85f);
         const float effectiveGlitchAmt = juce::jlimit(0.0f, 1.0f, snap.glitchAmount + macGlitch * 0.9f);
+        const float effectiveEchoMix = juce::jlimit(0.0f, 1.0f, snap.echoMix + macSpace * 0.7f);
+
+        // OVW-07 fix: apply mod matrix HERE — before filter/glitch setters — so that
+        // owModPitchOffset and owModGlitchOffset reflect the current block's aftertouch
+        // and mod wheel, not last block's stale values. Previously the mod matrix ran
+        // ~130 lines later (after the silence-gate return path) causing one-block lag
+        // on all mod destinations including filter pitch and glitch mix.
+        //
+        // Pre-scan MIDI for expression messages (mod wheel, aftertouch, pitch bend)
+        // so these take effect in the current block's mod matrix. Note-on/off are
+        // processed in the second MIDI pass below (after silence-gate check).
+        for (const auto meta : midi)
+        {
+            const auto msg = meta.getMessage();
+            if (msg.isChannelPressure())
+                aftertouch.setChannelPressure(msg.getChannelPressureValue() / 127.0f);
+            else if (msg.isController() && msg.getControllerNumber() == 1)
+                modWheelAmount = msg.getControllerValue() / 127.0f;
+            else if (msg.isPitchWheel())
+                pitchBendNorm = PitchBendUtil::parsePitchWheel(msg.getPitchWheelValue());
+        }
+        {
+            // Aftertouch must be updated before mod matrix (needs smoothed pressure).
+            aftertouch.updateBlock(numSamples);
+            const float atPressureForMod = aftertouch.getSmoothedPressure(0);
+
+            // D002 mod matrix — apply per-block.
+            // Destinations: 0=Off, 1=ERA_X, 2=GlitchMix, 3=Pitch, 4=AmpLevel
+            ModMatrix<4>::Sources mSrc;
+            mSrc.lfo1       = 0.0f;
+            mSrc.lfo2       = 0.0f;
+            mSrc.env        = 0.0f;
+            mSrc.velocity   = 0.0f;
+            mSrc.keyTrack   = 0.0f;
+            mSrc.modWheel   = modWheelAmount;
+            mSrc.aftertouch = atPressureForMod;
+            float mDst[5]   = {};
+            modMatrix.apply(mSrc, mDst);
+            owModEraOffset    = mDst[1] * 0.5f;
+            owModGlitchOffset = mDst[2] * 0.4f;
+            owModPitchOffset  = mDst[3] * 12.0f;
+            owModLevelOffset  = mDst[4] * 0.5f;
+        }
+
         // D006: mod wheel adds up to +0.4 to glitch mix (CC#1 introduces chip artifacts progressively)
-        // D002: owModGlitchOffset adds mod matrix contribution
+        // D002: owModGlitchOffset adds mod matrix contribution (now current-block values)
         const float effectiveGlitchMix =
             juce::jlimit(0.0f, 1.0f, snap.glitchMix + macGlitch * 0.8f + modWheelAmount * 0.4f + owModGlitchOffset);
-        const float effectiveEchoMix = juce::jlimit(0.0f, 1.0f, snap.echoMix + macSpace * 0.7f);
 
         // D001: filter envelope — simple one-pole decay tracks note-on velocity.
         // filterEnvLevel is set to lastNoteOnVelocity on noteOn (detected below),
@@ -351,10 +410,22 @@ public:
 
             // Update FX units from snapshot (cheap, param-only, no alloc)
             filter.setMode(snap.filterType);
-            filter.setCutoff(
-                juce::jlimit(20.0f, 20000.0f,
-                             snap.filterCutoff * PitchBendUtil::semitonesToFreqRatio(pitchBendNorm * 2.0f + owModPitchOffset) +
-                                 externalFilterMod + filterEnvBoost));
+            // OVW-01 fix: clamp to sr*0.49 not 20000Hz — at 96kHz the old ceiling
+            // let the cutoff sit well below Nyquist; at 44.1kHz it was fine but users
+            // with 48kHz/96kHz interfaces got a 20kHz hard clip instead of Nyquist-safe.
+            {
+                const float newCutoff =
+                    juce::jlimit(20.0f, sr * 0.49f,
+                                 snap.filterCutoff * PitchBendUtil::semitonesToFreqRatio(pitchBendNorm * 2.0f + owModPitchOffset) +
+                                     externalFilterMod + filterEnvBoost);
+                // OVW-03 fix: delta-guard — skip recomputing TPT coefficients (fastTan)
+                // when the cutoff has not changed by more than 0.5 Hz since last block.
+                if (std::abs(newCutoff - lastFilterCutoffHz) > 0.5f)
+                {
+                    filter.setCutoff(newCutoff);
+                    lastFilterCutoffHz = newCutoff;
+                }
+            }
             filter.setResonance(snap.filterReso);
         }
 
@@ -376,6 +447,9 @@ public:
         voicePool.applyParams(snap);
 
         // Process MIDI
+        // Second MIDI pass: note-on / note-off only.
+        // Expression messages (aftertouch, mod wheel, pitch bend) were already
+        // consumed by the pre-scan above so all mod destinations use current values.
         for (const auto meta : midi)
         {
             const auto msg = meta.getMessage();
@@ -388,13 +462,6 @@ public:
                 voicePool.noteOff(msg.getNoteNumber());
             else if (msg.isAllNotesOff() || msg.isAllSoundOff())
                 voicePool.allNotesOff();
-            else if (msg.isChannelPressure())
-                aftertouch.setChannelPressure(msg.getChannelPressureValue() / 127.0f);
-            // D006: CC#1 mod wheel → glitch mix boost (+0–0.4, introduces chip artifacts progressively)
-            else if (msg.isController() && msg.getControllerNumber() == 1)
-                modWheelAmount = msg.getControllerValue() / 127.0f;
-            else if (msg.isPitchWheel())
-                pitchBendNorm = PitchBendUtil::parsePitchWheel(msg.getPitchWheelValue());
         }
 
         if (silenceGate.isBypassed() && midi.isEmpty())
@@ -403,36 +470,15 @@ public:
             return;
         }
 
-        aftertouch.updateBlock(numSamples);
+        // OVW-07 fix: aftertouch.updateBlock() and mod matrix are now applied earlier
+        // (before the filter/glitch setup section) so all mod destinations use
+        // current-block values. Read the smoothed pressure computed there for ERA Y.
         const float atPressure = aftertouch.getSmoothedPressure(0);
 
         // D006: aftertouch raises ERA Y — more SNES chip character under pressure (sensitivity 0.2).
         // ERA Y drives the SNES vertex weight in the 3-chip barycentric blend.
         // Full pressure adds up to +0.2 to targetEraY, nudging the triangle toward SNES.
         // Clamped to [0.0, 1.0] so it never exceeds valid ERA range.
-
-        // D002 mod matrix — apply per-block.
-        // Destinations: 0=Off, 1=ERA_X, 2=GlitchMix, 3=Pitch, 4=AmpLevel
-        {
-            ModMatrix<4>::Sources mSrc;
-            mSrc.lfo1       = 0.0f;
-            mSrc.lfo2       = 0.0f;
-            mSrc.env        = 0.0f;
-            mSrc.velocity   = 0.0f;
-            mSrc.keyTrack   = 0.0f;
-            mSrc.modWheel   = modWheelAmount;
-            mSrc.aftertouch = atPressure;
-            float mDst[5]   = {};
-            modMatrix.apply(mSrc, mDst);
-            // dst 1: ERA X offset (chip blend position)
-            owModEraOffset   = mDst[1] * 0.5f;
-            // dst 2: glitch mix offset
-            owModGlitchOffset = mDst[2] * 0.4f;
-            // dst 3: pitch offset in semitones (applied via snap.pitchBend in voicePool)
-            owModPitchOffset = mDst[3] * 12.0f;
-            // dst 4: amplitude level offset
-            owModLevelOffset = mDst[4] * 0.5f;
-        }
 
         // D005 fix: advance ERA drift phase per block.
         // FIX-P1: removed redundant `if (eraPhase >= 1.0f) eraPhase -= 1.0f`
@@ -753,6 +799,11 @@ private:
     std::vector<float> outputCacheRight;
 
     float pitchBendNorm = 0.0f; // MIDI pitch wheel [-1, +1]; ±2 semitone range
+
+    // OVW-03 fix: last computed filter cutoff for delta-guard.
+    // setCutoff() calls computeCoefficients() which calls fastTan() — skipping this
+    // when the cutoff hasn't moved by >0.5 Hz saves a non-trivial fastTan per block.
+    float lastFilterCutoffHz = -1.0f; // sentinel: force first compute
 
     // Per-block coupling accumulators (reset each renderBlock)
     float externalFilterMod = 0.0f;

--- a/Source/Engines/Overworld/engine/VoicePool.h
+++ b/Source/Engines/Overworld/engine/VoicePool.h
@@ -873,10 +873,29 @@ public:
         {
             v.sqPhase = 0.0f;
             v.triPhase = 0.0f;
+            v.triStep = 0;
             v.wtPhase = 0.0f;
             v.modPhase = 0.0f;
             v.carPhase = 0.0f;
+            v.modFeedbk = 0.0f;
+            // OVW-11 fix: reset all envelope coefficients and FM envelope state.
+            // allNotesOff() zeroes envLevel/fmEnvLevel and sets stages to Idle, but
+            // the per-voice rate/coeff members retain stale values from the previous
+            // preset, which could cause an incorrect attack rate to fire immediately
+            // on the first noteOn after a preset change.
+            v.attackRate = 0.0f;
+            v.decayCoeff = 0.0f;
+            v.sustainLvl = 0.0f;
+            v.releaseCoeff = 0.0f;
+            v.fmAttackRate = 0.0f;
+            v.fmDecayCoeff = 0.0f;
+            v.fmSustainLvl = 0.0f;
+            v.fmReleaseCoeff = 0.0f;
+            v.noisePhase = 0.0f;
+            v.noiseOut = 0.0f;
+            v.lfsr.reset();
         }
+        stealIdx = 0;
     }
 
     void noteOn(int midiNote, float velocity)


### PR DESCRIPTION
## Round 11 — DSP deep-review: Orbweave, Overworld, Octopus

Three parallel worktree reviews. 28 fixes total across 3 engines.

### OrbweaveEngine (8 fixes)
- P17: hardcoded 20kHz ceiling → `sr * 0.49f`
- P14: `reverbPos[4]` and `chorusLFOPhase` not reset in `OrbweaveFXState::reset()` — reverb artifacts + chorus pitch jump after reset
- P14: `modWheel_` and `pitchBend_` not cleared in engine `reset()` — stale expression across All Notes Off
- P14: `voiceCounter` not reset (uint64 wrap risk over long sessions)
- P14: `startTime` not reset in `OrbweaveVoice::reset()` — corrupted oldest-voice steal ordering
- P19 → `setCoefficients_fast()`: LP/HP/BP modes never use shelf path; fast variant skips that branch
- P5: voice-steal now prefers releasing voices (reduces clicks on busy passages)

### OverworldEngine (11 fixes, 2 files)
- **OVW-07 (CRITICAL)**: mod matrix ran one full block after filter/glitch setters — mod wheel, pitch bend, aftertouch all one block stale on every parameter. Moved expression pre-scan + mod matrix before all FX setters.
- P14: 12 reset() gaps — `pitchBendNorm`, `modWheelAmount`, all 4 `owMod*Offset`, `ghostEraLast`, `ghostEraYLast`, `eraDriftSHValue`, 3 coupling accumulators. Ghost ERA shimmer, stale bend/wheel, S&H contamination on preset change.
- P14: `VoicePool::reset()` missing envelope coefficients (attack rate, decay/release coeff, sustain level, FM equivalents), `noisePhase`, `noiseOut`, `lfsr.reset()`, `triStep`, `modFeedbk`, `stealIdx`
- P19: `filter.setCutoff()` delta-guard (0.5Hz threshold)
- P17: `jlimit(20.0f, 20000.0f, ...)` → `sr * 0.49f`
- Deferred: 7 dead parameters (FM ops 3+4, SNES ADSR, DPCM, brrInterp, fmAlgorithm, voiceMode) — design decisions required

### OctopusEngine (9 fixes)
- **OCT-03/11 (CRITICAL)**: Chromatophore subsystem was tonally frozen — `chromaFreqMod` computed via envelope follower then discarded via `[[maybe_unused]]`; filter ran at default coefficients forever. Entire Chromatophore mechanism was sonically inert.
- **OCT-10/15 (CRITICAL)**: Two of eight arm targets (ArmFormantShift arm-7, ArmFilterCutoff arm-0) computed modulation values but never called filter coefficient updates — vowel-shift and arm→filter-cutoff paths completely absent from audio output.
- P17×2: hardcoded 20kHz and 16kHz → `srf * 0.49f`
- P19: `suckerFilter.setCoefficients()` delta-guard (freq + reso)
- P14: `glideCoeff` and `driftRng` not in `OctoVoice::reset()`; `modWheelAmount_` and `pitchBendNorm` not in engine `reset()`
- P27: `suckerEnv.reset()` added to poly noteOn path
- P14: `inkCloud.setDecay()` delta-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)