### PR TITLE
fix(assets): OKEANOS — repoint to existing King Crab sprite

### DIFF
--- a/site/data/engine-creature-map.json
+++ b/site/data/engine-creature-map.json
@@ -879,14 +879,14 @@
     },
     {
       "id": "OKEANOS",
-      "creature": "Horseshoe Crab",
-      "sprite": "saltwater/Horseshoe Crab.png",
-      "spriteOutline": null,
+      "creature": "King Crab",
+      "sprite": "saltwater/Crab - King.png",
+      "spriteOutline": "saltwater/Crab - King Outline.png",
       "fallback": "beowulf-32/spr_fish_47_x.png",
       "zone": "Twilight",
       "accentColor": "#C49B3F",
       "status": "matched",
-      "notes": "Rhodes Spice Route FUSION engine — horseshoe crab: ancient living fossil traversing cultural trade routes; cardamom gold; Horseshoe Crab from saltwater pack"
+      "notes": "Rhodes Spice Route FUSION engine — King Crab: ancient sea-god monarch, crustacean royalty presiding over Aegean trade lanes; cardamom gold; King Crab from saltwater pack"
     },
     {
       "id": "OLLOTRON",


### PR DESCRIPTION
## Summary

PR #1216 introduced an OKEANOS map entry pointing at \`saltwater/Horseshoe Crab.png\` — that sprite does not exist in the saltwater pack. The aquarium will 404 on OKEANOS as merged.

This PR repoints OKEANOS to \`saltwater/Crab - King.png\` (and matching outline), which exists. Mythologically: OKEANOS is the Greek sea-god encircling the world; King Crab as crustacean royalty fits the Rhodes Spice Route FUSION engine framing better than horseshoe crab anyway.

## Changes

- One-line sprite + outline + creature-name + notes change in \`site/data/engine-creature-map.json\`
- \`status\` stays \`matched\`; \`_meta.statusCounts\` unchanged
- No new sprites added — repointing to existing assets

## Test plan

- [ ] Aquarium UI loads OKEANOS without 404
- [ ] King Crab sprite visible at OKEANOS slot
- [ ] No statusCounts drift (matched: 56, adaptable: 32, needs_custom: 5)