### PR TITLE
Wave 5 B1: world voicing palette in ChordMachine

### DIFF
--- a/Source/Core/ChordMachine.h
+++ b/Source/Core/ChordMachine.h
@@ -47,11 +47,36 @@ enum class PaletteType : int
 
 enum class VoicingMode : int
 {
+    // ── Tertian family (original 5 — indices MUST remain 0-4 for preset compat) ──
     RootSpread = 0, // Root anchored low, others spread upward
     Drop2,          // 2nd-from-top dropped down an octave (jazz, neo-soul)
-    Quartal,        // Stacked perfect 4ths (modern house, techno)
+    Quartal,        // Stacked perfect 4ths (modern house, techno) [legacy 4-note]
     UpperStructure, // Root low + upper voices an octave up
     Unison,         // All slots play the same note
+
+    // ── Quartal family ──
+    Quartal3,       // root, +P4, +P4+P4               (0, 5, 10)       — 3-note stack, slot 4 doubles P4
+    Quartal4,       // root, +P4, +P4+P4, +P4+P4+P4   (0, 5, 10, 15)   — 4-note stack
+
+    // ── Quintal family ──
+    Quintal3,       // root, +P5, +P5+P5               (0, 7, 14)       — 3-note stack, slot 4 doubles P5
+    Quintal4,       // root, +P5, +P5+P5, +P5+P5+P5   (0, 7, 14, 21)   — 4-note stack
+
+    // ── Modal-world family ──
+    Hijaz,           // Hijaz scale tones: root, b2, M3, P5      (0, 1, 4, 7)
+    Bhairavi,        // Bhairavi scale tones: root, m3, P5, m7   (0, 3, 7, 10)
+    Yo,              // Japanese Yo pentatonic: root, P4, P5, m7 (0, 5, 7, 10)
+    In,              // Japanese In pentatonic: root, b2, P4, m6 (0, 1, 5, 8)
+    PhrygianDominant, // Phrygian Dominant tones: root, M3, P5, m7 (0, 4, 7, 10)
+
+    // ── Drone family ──
+    DroneP5,   // root + P5   (0, 7)  — slots 0/2=root, slots 1/3=P5
+    DroneP4,   // root + P4   (0, 5)  — slots 0/2=root, slots 1/3=P4
+    DroneM3,   // root + M3   (0, 4)  — slots 0/2=root, slots 1/3=M3
+    DroneMin3, // root + m3   (0, 3)  — slots 0/2=root, slots 1/3=m3
+    DroneM2,   // root + M2   (0, 2)  — slots 0/2=root, slots 1/3=M2
+    DroneMin2, // root + m2   (0, 1)  — slots 0/2=root, slots 1/3=m2
+
     NumModes
 };
 
@@ -289,6 +314,114 @@ private:
         case VoicingMode::Unison:
         {
             notes[0] = notes[1] = notes[2] = notes[3] = root;
+            break;
+        }
+
+        // ── Quartal family ─────────────────────────────────────────────────────
+        // Interval tables are static constexpr — no heap allocation on audio thread.
+
+        case VoicingMode::Quartal3:
+        {
+            // 3 unique tones: root, root+P4, root+2xP4. Slot 3 doubles slot 1.
+            static constexpr int kQ3[4] = { 0, 5, 10, 5 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kQ3[i];
+            break;
+        }
+        case VoicingMode::Quartal4:
+        {
+            static constexpr int kQ4[4] = { 0, 5, 10, 15 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kQ4[i];
+            break;
+        }
+
+        // ── Quintal family ─────────────────────────────────────────────────────
+
+        case VoicingMode::Quintal3:
+        {
+            // 3 unique tones: root, root+P5, root+2xP5. Slot 3 doubles slot 1.
+            static constexpr int kU3[4] = { 0, 7, 14, 7 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kU3[i];
+            break;
+        }
+        case VoicingMode::Quintal4:
+        {
+            static constexpr int kU4[4] = { 0, 7, 14, 21 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kU4[i];
+            break;
+        }
+
+        // ── Modal-world family ─────────────────────────────────────────────────
+        // All 4-note sets — directly replaces palette intervals with modal tones.
+
+        case VoicingMode::Hijaz:
+        {
+            static constexpr int kHijaz[4] = { 0, 1, 4, 7 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kHijaz[i];
+            break;
+        }
+        case VoicingMode::Bhairavi:
+        {
+            static constexpr int kBhairavi[4] = { 0, 3, 7, 10 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kBhairavi[i];
+            break;
+        }
+        case VoicingMode::Yo:
+        {
+            static constexpr int kYo[4] = { 0, 5, 7, 10 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kYo[i];
+            break;
+        }
+        case VoicingMode::In:
+        {
+            static constexpr int kIn[4] = { 0, 1, 5, 8 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kIn[i];
+            break;
+        }
+        case VoicingMode::PhrygianDominant:
+        {
+            static constexpr int kPhryDom[4] = { 0, 4, 7, 10 };
+            for (int i = 0; i < 4; ++i) notes[i] = root + kPhryDom[i];
+            break;
+        }
+
+        // ── Drone family ───────────────────────────────────────────────────────
+        // 2-note drones: slots 0+2 = root, slots 1+3 = interval.
+        // This spreads the pair across the 4 engine slots naturally.
+
+        case VoicingMode::DroneP5:
+        {
+            notes[0] = root;     notes[1] = root + 7;
+            notes[2] = root;     notes[3] = root + 7;
+            break;
+        }
+        case VoicingMode::DroneP4:
+        {
+            notes[0] = root;     notes[1] = root + 5;
+            notes[2] = root;     notes[3] = root + 5;
+            break;
+        }
+        case VoicingMode::DroneM3:
+        {
+            notes[0] = root;     notes[1] = root + 4;
+            notes[2] = root;     notes[3] = root + 4;
+            break;
+        }
+        case VoicingMode::DroneMin3:
+        {
+            notes[0] = root;     notes[1] = root + 3;
+            notes[2] = root;     notes[3] = root + 3;
+            break;
+        }
+        case VoicingMode::DroneM2:
+        {
+            notes[0] = root;     notes[1] = root + 2;
+            notes[2] = root;     notes[3] = root + 2;
+            break;
+        }
+        case VoicingMode::DroneMin2:
+        {
+            notes[0] = root;     notes[1] = root + 1;
+            notes[2] = root;     notes[3] = root + 1;
             break;
         }
 
@@ -568,9 +701,21 @@ public:
 
     static const char* voicingName(VoicingMode v)
     {
-        static const char* names[] = {"ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON"};
+        static const char* names[] = {
+            // Tertian (0-4)
+            "ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON",
+            // Quartal family (5-6)
+            "QUARTAL-3", "QUARTAL-4",
+            // Quintal family (7-8)
+            "QUINTAL-3", "QUINTAL-4",
+            // Modal-world family (9-13)
+            "HIJAZ", "BHAIRAVI", "YO", "IN", "PHRYG-DOM",
+            // Drone family (14-19)
+            "DRONE-P5", "DRONE-P4", "DRONE-M3", "DRONE-m3", "DRONE-M2", "DRONE-m2"
+        };
+        static constexpr int kCount = static_cast<int>(VoicingMode::NumModes);
         int i = static_cast<int>(v);
-        return (i >= 0 && i < 5) ? names[i] : "?";
+        return (i >= 0 && i < kCount) ? names[i] : "?";
     }
 
     static const char* patternName(RhythmPattern p)

--- a/Source/UI/Gallery/ChordMachinePanel.h
+++ b/Source/UI/Gallery/ChordMachinePanel.h
@@ -70,16 +70,30 @@ public:
             }
         };
 
-        // Voicing selector
+        // Voicing selector — items must match VoicingMode enum order exactly.
+        // NOTE: XOceanusProcessor.cpp cm_voicing StringArray must also be kept in sync.
         addAndMakeVisible(voicingBox);
-        voicingBox.addItemList({"ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON"}, 1);
+        voicingBox.addItemList({
+            // Tertian (0-4)
+            "ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON",
+            // Quartal family (5-6)
+            "QUARTAL-3", "QUARTAL-4",
+            // Quintal family (7-8)
+            "QUINTAL-3", "QUINTAL-4",
+            // Modal-world family (9-13)
+            "HIJAZ", "BHAIRAVI", "YO", "IN", "PHRYG-DOM",
+            // Drone family (14-19)
+            "DRONE-P5", "DRONE-P4", "DRONE-M3", "DRONE-m3", "DRONE-M2", "DRONE-m2"
+        }, 1);
         voicingBox.setSelectedId(1, juce::dontSendNotification);
         voicingBox.onChange = [this]
         {
             if (auto* p = processor.getAPVTS().getParameter("cm_voicing"))
             {
+                const int idx = voicingBox.getSelectedItemIndex();
+                const int numChoices = static_cast<int>(VoicingMode::NumModes);
                 p->beginChangeGesture();
-                p->setValueNotifyingHost(static_cast<float>(voicingBox.getSelectedItemIndex()) / 4.0f);
+                p->setValueNotifyingHost(numChoices > 1 ? static_cast<float>(idx) / static_cast<float>(numChoices - 1) : 0.0f);
                 p->endChangeGesture();
             }
         };

--- a/Source/UI/Ocean/ChordBarComponent.h
+++ b/Source/UI/Ocean/ChordBarComponent.h
@@ -51,7 +51,19 @@ public:
     // Label tables — static constexpr so they live in the header with no ODR issue.
     // Palette names (#1177): DARK→LUSH (minor 9 is jazz-lush), SWEET→BREEZY (major 9).
     static constexpr const char* kPaletteNames[]  = { "WARM","BRIGHT","TENSION","OPEN","LUSH","BREEZY","COMPLEX","RAW" };
-    static constexpr const char* kVoicingNames[]  = { "ROOT-SPREAD","DROP-2","QUARTAL","UPPER-STRUCT","UNISON" };
+    static constexpr const char* kVoicingNames[]  = {
+        // Tertian (0-4) — indices MUST remain fixed for preset backward compat
+        "ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER-STRUCT", "UNISON",
+        // Quartal family (5-6)
+        "QUARTAL-3", "QUARTAL-4",
+        // Quintal family (7-8)
+        "QUINTAL-3", "QUINTAL-4",
+        // Modal-world family (9-13)
+        "HIJAZ", "BHAIRAVI", "YO", "IN", "PHRYG-DOM",
+        // Drone family (14-19)
+        "DRONE-P5", "DRONE-P4", "DRONE-M3", "DRONE-m3", "DRONE-M2", "DRONE-m2"
+    };
+    static constexpr int kNumVoicings = static_cast<int>(VoicingMode::NumModes);
     static constexpr const char* kRhythmNames[]   = { "Four","Off","Synco","Stab","Gate","Pulse","Broken","Rest" };
     static constexpr const char* kVelCurveNames[] = { "Equal","RootHvy","TopBrt","V-Shape" };
 
@@ -743,7 +755,7 @@ private:
         }
         case RegionType::Voicing:
         {
-            currentVoicing_ = (currentVoicing_ + 1) % 5;
+            currentVoicing_ = (currentVoicing_ + 1) % kNumVoicings;
             if (auto* p = apvts_.getParameter("cm_voicing"))
             {
                 p->beginChangeGesture();
@@ -884,7 +896,7 @@ private:
         };
 
         currentPalette_ = juce::jlimit(0, 7, readInt("cm_palette"));
-        currentVoicing_ = juce::jlimit(0, 4, readInt("cm_voicing"));
+        currentVoicing_ = juce::jlimit(0, kNumVoicings - 1, readInt("cm_voicing"));
         currentRhythm_  = juce::jlimit(0, 7, readInt("cm_seq_pattern"));
         currentSwing_   = readFloat("cm_seq_swing");
         currentGate_    = readFloat("cm_seq_gate");

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -671,7 +671,18 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
         juce::StringArray{"WARM", "BRIGHT", "TENSION", "OPEN", "DARK", "SWEET", "COMPLEX", "RAW"}, 0));
     params.push_back(std::make_unique<juce::AudioParameterChoice>(
         juce::ParameterID("cm_voicing", 1), "CM Voicing",
-        juce::StringArray{"ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON"}, 0));
+        juce::StringArray{
+            // Tertian (0-4) — indices fixed for preset backward compat
+            "ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON",
+            // Quartal family (5-6)
+            "QUARTAL-3", "QUARTAL-4",
+            // Quintal family (7-8)
+            "QUINTAL-3", "QUINTAL-4",
+            // Modal-world family (9-13)
+            "HIJAZ", "BHAIRAVI", "YO", "IN", "PHRYG-DOM",
+            // Drone family (14-19)
+            "DRONE-P5", "DRONE-P4", "DRONE-M3", "DRONE-m3", "DRONE-M2", "DRONE-m2"
+        }, 0));
     params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("cm_spread", 1), "CM Spread",
                                                                  juce::NormalisableRange<float>(0.0f, 1.0f), 0.75f));
     params.push_back(


### PR DESCRIPTION
## Summary

Extends ChordMachine's `VoicingMode` enum from 5 → 20 entries to cover the locked D7 B3+ "World" voicing decision. 12-TET only.

**New voicing families:**
- **Quartal**: 3-note + 4-note stacks of perfect fourths
- **Quintal**: 3-note + 4-note stacks of perfect fifths
- **Modal-world**: Hijaz, Bhairavi, Yo (Japanese pentatonic), In (Japanese), Phrygian Dominant
- **Drone**: root + (P5/P4/M3/m3/M2/m2) with slots 0+2 = root, slots 1+3 = interval

**Backward compatibility:** Tertian voicings (Root-Spread / Drop-2 / Quartal-legacy / Upper-Struct / Unison) remain at indices 0–4 unchanged. Existing presets load identically.

**Files touched:**
- `Source/Core/ChordMachine.h` — enum + switch cases + voicingName table
- `Source/XOceanusProcessor.cpp` — `cm_voicing` AudioParameterChoice StringArray extended to 20 entries (without this, JUCE clamps new voicings to index 4)
- `Source/UI/Ocean/ChordBarComponent.h` — voicing pill cycle uses `kNumVoicings` instead of hardcoded 5
- `Source/UI/Gallery/ChordMachinePanel.h` — Gallery dropdown sync; normalization uses `NumModes - 1` denominator

**Recovery note:** The dispatching sub-agent stalled (watchdog timeout) after writing the diff but before committing. Diff was hand-verified against the locked D7 spec, the missing `XOceanusProcessor.cpp` StringArray was added, then committed and pushed by the orchestrator. All interval values audited against the D7 B1 task description.

## Test plan

- [ ] Load a stock preset → confirm Tertian voicing still selected and behaves identically (preset compat)
- [ ] Cycle voicing pill in ChordBar through all 20 entries → audibly distinct chord shapes
- [ ] Select each modal voicing (Hijaz, Bhairavi, Yo, In, PhryDom) → confirm interval set matches spec
- [ ] Drone voicings → confirm slots 0+2 = root, slots 1+3 = interval (use a 4-voice instrument to hear it)
- [ ] Save preset with new voicing (e.g. PHRYG-DOM, index 13) → reopen → voicing restored correctly
- [ ] DAW automation: write `cm_voicing` automation → playback hits correct index

## Sub-track context

Wave 5 Phase B1 of 14-PR plan. Sibling PRs:
- B2 (auto-harmonize / pad-per-chord / scale-degree input modes) — separate PR
- B3 (per-engine chord/seq routing toggle + chord slide-up breakout) — separate PR

Does NOT touch any file in PR #1251 (Wave 5 A1)'s scope; merge order is independent. The shared file `Source/XOceanusProcessor.cpp` is touched in different regions (A1 = serialization at line 2613+ and globals near line 230s; B1 = StringArray at line 672–688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)