### PR TITLE
fix(#1237): wire MPE integration end-to-end (was dead)

### DIFF
--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1200,6 +1200,7 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
             eng->prepare(sampleRate, samplesPerBlock);
             eng->prepareSilenceGate(sampleRate, samplesPerBlock, silenceGateHoldMs(eng->getEngineId()));
             eng->setSharedTransport(&hostTransport);
+            eng->setMPEManager(&mpeManager); // issue #1237 — was never called; engines saw nullptr
         }
     }
 
@@ -1429,6 +1430,18 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
             static_cast<MPEManager::ExpressionTarget>(static_cast<int>(cachedParams.mpeSlideTarget->load())));
     }
 
+    // ── MPE expression extraction (#1237 — was dead; now wired) ──────────────
+    // Parse pitch-bend, channel-pressure, aftertouch, and CC74 from the raw
+    // MIDI stream into per-channel expression state so MPE-aware engines can
+    // call mpeManager->updateVoiceExpression() in their renderBlock().
+    // mpeMidiBuffer receives the expression-stripped MIDI (pitch wheel removed,
+    // note-on/off and all other messages pass through).
+    // Raw `midi` is still forwarded to ChordMachine below so the ~85 non-MPE-aware
+    // engines that parse pitch wheel directly from their MIDI stream continue to
+    // function — per-channel expression is available via mpeExpression for the
+    // engines that have been upgraded to use it (#1237).
+    mpeManager.processBlock(midi, mpeMidiBuffer); // issue #1237 — was never called
+
     // ── External MIDI Clock sync (#359) ──────────────────────────────────────
     // Scan incoming MIDI for system real-time messages (0xF8 Clock, 0xFA Start,
     // 0xFB Continue, 0xFC Stop).  These are single-byte messages that arrive
@@ -1520,6 +1533,12 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
     // Route MIDI through ChordMachine → 4 per-slot MidiBuffers.
     // When disabled, each slot gets a copy of the input MIDI (previous behavior).
     // When enabled, each slot gets its own chord-distributed note.
+    // NOTE (#1237): We pass raw `midi` (not mpeMidiBuffer) here so that the ~85
+    // non-MPE-aware engines that parse pitch-wheel from their MIDI stream continue
+    // to function correctly. MPE-aware engines (Opal, Oblong, Overbite, Orca,
+    // Octopus, Ouie) use mpeExpression.pitchBendSemitones populated above.
+    // Double-apply risk for MPE-aware engines in non-MPE mode (P29 / Bob) is a
+    // pre-existing issue flagged for separate fix — do not conflate with #1237.
     chordMachine.processBlock(midi, slotMidi, numSamples);
 
     // ── CC64 sustain pedal — fleet-wide pre-filter ────────────────────────────
@@ -2364,6 +2383,10 @@ void XOceanusProcessor::loadEngine(int slot, const std::string& engineId)
         // of whether prepare() has run yet — the engine caches the pointer and
         // reads from it in renderBlock(), which only runs after prepareToPlay().
         newEngine->setSharedTransport(&hostTransport);
+        // Give the new engine a pointer to MPEManager so per-note expression
+        // (pitch bend, pressure, slide) is live from the first rendered block.
+        // issue #1237 — was never called; engines loaded at runtime saw nullptr.
+        newEngine->setMPEManager(&mpeManager);
     }
 
     // Wake the silence gate so the new engine renders its first block immediately.


### PR DESCRIPTION
## Summary

Fixes #1237 (P0 ship-blocker). MPE integration was configured (`setMPEEnabled`, `setZoneLayout`, `setPitchBendRange`, `setPressureTarget`, `setSlideTarget`) but never actually run — `mpeManager.processBlock()` was never called, and engines never received the manager pointer. Per-note pitch/pressure/slide were therefore always 0.0f. `mpeMidiBuffer` was declared but never populated or used.

## Changes

- `XOceanusProcessor::prepareToPlay()`: `engine->setMPEManager(&mpeManager)` now called for each active engine slot alongside `setSharedTransport`. Engines loaded before `prepareToPlay` has run will have the pointer and can use it once audio starts.
- `XOceanusProcessor::loadEngine()`: `newEngine->setMPEManager(&mpeManager)` now called for engines loaded at runtime, mirroring the `setSharedTransport` pattern.
- `XOceanusProcessor::processBlock()`: `mpeManager.processBlock(midi, mpeMidiBuffer)` now called after MPE config sync and before MIDI clock scan / ChordMachine distribution. This populates `channelExpression[]` per-block so MPE-aware engines can call `updateVoiceExpression()` in their `renderBlock()`.

## Design decision: raw `midi` → ChordMachine (not expression-stripped `mpeMidiBuffer`)

Raw `midi` is still forwarded to ChordMachine (not `mpeMidiBuffer`). This is intentional: ~85 non-MPE-aware engines parse pitch wheel directly from their MIDI stream in `renderBlock()`. Routing `mpeMidiBuffer` (from which pitch wheel is stripped) would silently kill pitch bend fleet-wide for those engines. MPE-aware engines (Opal, Oblong, Overbite, Orca, Octopus, Ouie) read `mpeExpression.pitchBendSemitones` via `updateVoiceExpression()`.

## Behavior change

Previously dead: per-note pitch bend, channel pressure (aftertouch), slide (timbre/CC74). Now active for the 6 MPE-aware engines that check `mpeManager != nullptr`.

This is the fix — but it IS a behavior change for MPE-aware engines. Engines that read `mpeExpression.pitchBendSemitones` etc. will now get real values where they previously saw 0.0f.

## Suspect callers flagged (not fixed in this PR)

- **OblongEngine.h:1428 (P29 / Bob)** — adds BOTH `voice.mpeExpression.pitchBendSemitones` AND `pitchBendNorm * 2.0f` in the same `totalPitch` expression. In MPE mode, both paths now carry real values → **double-apply**. This is P29 (Bob 14b, "MPE pitch-bend double-application") requiring a separate targeted fix.
- **OperaEngine.h:848** — parses pitch wheel directly into own `pitchBendSemitones_` from MIDI; no `mpeExpression` used, no double-apply risk, but will not benefit from MPE per-note pitch until upgraded.
- **OceanDeepEngine.h:793** — same pattern as Opera, no double-apply risk.
- **mpeManager.prepare()** not yet called in `prepareToPlay()` — not a blocker (all-zeros at construction), but should be wired in follow-up.

## Test plan

- [ ] CI build passes
- [ ] Manual MPE controller test (Roli, LinnStrument, Sensel) on any MPE-aware engine (Opal, Orca, Octopus, Ouie, Overbite) — per-note pitch bend should audibly track individual fingers
- [ ] Channel pressure → assigned ExpressionTarget routes correctly
- [ ] Polyphonic test with non-MPE controller — confirm no regression for non-MPE workflows (pitch bend still works on non-MPE-aware engines)
- [ ] Re-test P29 candidates (OblongEngine / Bob) to confirm double-apply is now observable and can be isolated for fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)