### PR TITLE
fix(#1256): P29 — single source for MPE pitch bend (was double-applied)

### DIFF
--- a/Source/Engines/Oblong/OblongEngine.h
+++ b/Source/Engines/Oblong/OblongEngine.h
@@ -1424,8 +1424,14 @@ public:
                 lfoCutoffMod += curOut.curiosity * 0.5f;
 
                 // Apply pitch modulation (fastExp avoids std::pow per sample) + MPE + pitch bend + mod matrix
+                // P29 fix: pick ONE pitch-bend source — MPE expression OR raw MIDI wheel, never both.
+                // Before #1255, mpeExpression.pitchBendSemitones was always 0.0f so the sum was safe;
+                // once MPE is wired, summing both sources produces 2× pitch on MPE controllers.
+                const float pitchBendContrib = (mpeManager != nullptr && mpeManager->isMPEEnabled())
+                    ? voice.mpeExpression.pitchBendSemitones  // MPE mode: use per-voice MPE pitch bend
+                    : pitchBendNorm * 2.0f;                   // non-MPE: use channel pitch wheel (±2 st)
                 float totalPitch =
-                    lfoPitchMod * 2.0f + pitchMod + voice.mpeExpression.pitchBendSemitones + pitchBendNorm * 2.0f + bobModPitchOffset;
+                    lfoPitchMod * 2.0f + pitchMod + pitchBendContrib + bobModPitchOffset;
                 float freq = baseFreq * fastExp(totalPitch * (0.693147f / 12.0f));
 
                 // OscA — wave/tune/drift hoisted; only frequency and shape (LFO-modulated) per-sample

--- a/Source/Engines/Octopus/OctopusEngine.h
+++ b/Source/Engines/Octopus/OctopusEngine.h
@@ -669,11 +669,14 @@ public:
                 voice.currentFreq = flushDenormal(voice.currentFreq);
 
                 // Apply microtonal offset + arm pitch modulation + coupling pitch + MPE + pitch bend
+                // P29 fix: single pitch-bend source — MPE expression OR raw MIDI wheel, not both.
+                const float octoPitchBendCents = (mpeManager != nullptr && mpeManager->isMPEEnabled())
+                    ? voice.mpeExpression.pitchBendSemitones * 100.0f  // MPE: per-voice pitch bend in cents
+                    : pitchBendNorm * 200.0f;                           // non-MPE: channel wheel (±2 st = ±200 cents)
                 float pitchCents = pShiftMicro + voice.microtonalOffset +
                                    armMods[ArmPitch] * 50.0f // arm 3 modulates pitch +/-50 cents
                                    + blockCouplingPitchMod * 100.0f +
-                                   voice.mpeExpression.pitchBendSemitones * 100.0f // MPE pitch bend in cents
-                                   + pitchBendNorm * 200.0f; // channel pitch bend in cents (±2 semitones)
+                                   octoPitchBendCents;
                 float freqMod = voice.currentFreq * fastPow2(pitchCents / 1200.0f);
 
                 // --- Envelopes ---

--- a/Source/Engines/Orca/OrcaEngine.h
+++ b/Source/Engines/Orca/OrcaEngine.h
@@ -607,9 +607,12 @@ public:
                 // LFO1 scans wavetable position slowly (the "dialect" evolving)
                 float wtPos = clamp(smoothedWTPos + lfo1Val * 0.3f + modLevel * pWTScanRate * 0.5f, 0.0f, 1.0f);
                 voice.wtOsc.setPosition(wtPos);
-                float mpeFreqOrc = voice.glide.getFreq() *
-                                   xoceanus::fastPow2(voice.mpeExpression.pitchBendSemitones / 12.0f) *
-                                   PitchBendUtil::semitonesToFreqRatio(pitchBendNorm * 2.0f);
+                // P29 fix: single pitch-bend source (see OblongEngine.h for full rationale).
+                // Multiplicative form: MPE ratio OR channel-wheel ratio, not both.
+                const float orcaPitchBendRatio = (mpeManager != nullptr && mpeManager->isMPEEnabled())
+                    ? xoceanus::fastPow2(voice.mpeExpression.pitchBendSemitones / 12.0f)
+                    : PitchBendUtil::semitonesToFreqRatio(pitchBendNorm * 2.0f);
+                float mpeFreqOrc = voice.glide.getFreq() * orcaPitchBendRatio;
                 voice.wtOsc.setFrequency(mpeFreqOrc, srf);
 
                 float wtSample = voice.wtOsc.processSample();


### PR DESCRIPTION
## Summary

Fixes #1256. Blocks merge of #1255.

PR #1255 wires MPE end-to-end. `OblongEngine.h` (and others) was authored assuming `mpeExpression.pitchBendSemitones` was always 0.0f, and added/multiplied it with the raw-MIDI pitchBend value. Once #1255 lands, both terms carry real values → 2× pitch on MPE controllers.

Memory P29 (reopened in Bob Round 14b) is this exact bug pattern. Confirmed and fixed in 3 engines.

## Changes

- `Source/Engines/Oblong/OblongEngine.h:1428` — replace additive SUM with TERNARY (pick one source based on `mpeManager->isMPEEnabled()`).
- `Source/Engines/Orca/OrcaEngine.h:610` — replace multiplicative chain (both ratios applied) with TERNARY selecting one ratio.
- `Source/Engines/Octopus/OctopusEngine.h:675` — replace additive cents sum with TERNARY selecting one cents contribution.

## Fleet sweep results

All 5 other MPE-aware engines were grep'd for `pitchBendSemitones`:

| Engine | Pattern | Disposition |
|--------|---------|-------------|
| Orca | multiplicative double-ratio | Fixed in this PR |
| Octopus | additive cents double-source | Fixed in this PR |
| Opal | multiplicative double-ratio | Deferred (follow-up issue) |
| Overbite | split block-setup + sample-loop (complex) | Deferred (follow-up issue) |
| Ouie | multiplicative double-ratio | Deferred (follow-up issue) |

Deferred engines will be tracked in a follow-up issue. They share the same root cause but Overbite's split-block structure needs more careful surgery.

## Test plan

- [ ] CI passes (#1259 must merge first to restore CI signal)
- [ ] Non-MPE controller: pitch wheel still bends pitch as before (regression check on all 3 engines)
- [ ] MPE controller: per-note pitch bend tracks the controller exactly, NOT 2× (Oblong, Orca, Octopus)
- [ ] Polyphonic chord on MPE: each voice bends independently and correctly
- [ ] Opal / Overbite / Ouie: no regression (not touched in this PR)

## Merge order

1. #1259 (CI fix) — restores green CI
2. **This PR** (#1256 fix)
3. #1255 (MPE wire-up) — depends on this