### PR TITLE
ci: pre-push build hook + auto-update PRs on main advance

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Pre-push hook: incremental build sanity check.
+# Bypass once with `git push --no-verify` if you absolutely must.
+#
+# Why this exists: PRs opened without a clean local build accumulate
+# trunk-breaking compile errors that block CI for everyone. Catching
+# them here before push is faster than catching in CI 8 minutes later.
+
+set -e
+
+if [ ! -d build ]; then
+  echo "[pre-push] No build/ directory found."
+  echo "[pre-push] Run 'cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug' first to enable hook checks."
+  echo "[pre-push] Skipping check (initial setup); push will proceed."
+  exit 0
+fi
+
+echo "[pre-push] Running incremental build (Ninja)..."
+START=$(date +%s)
+if cmake --build build 2>&1 | tail -50; then
+  ELAPSED=$(($(date +%s) - START))
+  echo "[pre-push] ✓ Build clean (${ELAPSED}s). Proceeding with push."
+  exit 0
+else
+  ELAPSED=$(($(date +%s) - START))
+  echo ""
+  echo "[pre-push] ✗ Build FAILED in ${ELAPSED}s — push refused."
+  echo "[pre-push] Fix the errors above before pushing."
+  echo "[pre-push] Bypass once with: git push --no-verify"
+  exit 1
+fi

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,0 +1,48 @@
+name: Auto-update PRs on main push
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  update-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Update open PR branches
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main',
+              per_page: 100,
+            });
+            console.log(`Found ${prs.length} open PRs targeting main`);
+            let updated = 0, skipped = 0, failed = 0;
+            for (const pr of prs) {
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                console.log(`✓ Updated PR #${pr.number}: ${pr.title}`);
+                updated++;
+              } catch (e) {
+                if (e.status === 422) {
+                  // 422 = already up to date OR conflicts — both are fine to skip
+                  console.log(`- Skipped PR #${pr.number}: ${e.message}`);
+                  skipped++;
+                } else {
+                  console.log(`× Failed PR #${pr.number}: ${e.message}`);
+                  failed++;
+                }
+              }
+            }
+            console.log(`Summary: ${updated} updated, ${skipped} skipped, ${failed} failed`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,8 @@ See `Docs/specs/xoceanus_name_migration_reference.md` for the full mapping and g
 
 ## Build
 
+> **First-time setup:** run `./Tools/enable-git-hooks.sh` once to enable the pre-push build sanity check.
+
 ```bash
 # macOS (Release)
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release

--- a/Tools/enable-git-hooks.sh
+++ b/Tools/enable-git-hooks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wires .githooks/ as the hooks directory for this repo.
+# Run once after clone: ./Tools/enable-git-hooks.sh
+git config core.hooksPath .githooks
+echo "✓ Git hooks enabled (.githooks/)"
+echo "  Pre-commit: compile check, dead-param guard, audio thread lint, clang-format"
+echo "  Pre-push: incremental build sanity check"
+echo "  Bypass once: git push --no-verify"


### PR DESCRIPTION
## Summary

Two preventive measures targeting the recurring 'PRs always have red CI' pattern:

**A) Pre-push git hook** (`.githooks/pre-push`) — runs incremental Ninja build on every push, refuses push on compile errors. Catches the AboutModal/TooltipWindow-class bugs at push time instead of 8 min later in CI.

**B) Auto-update PRs workflow** (`.github/workflows/auto-update-prs.yml`) — when main advances, walks open PRs and merges main into each one, triggering fresh CI. Eliminates the stale-CI-on-rebased-main problem we hit today on PRs #1252/#1255/#1260.

## Setup

After this PR merges:
- One-time per clone: `./Tools/enable-git-hooks.sh` to wire the hook
- Bypass when needed: `git push --no-verify`
- Workflow B activates automatically; no setup needed

## Why both, not just one

- (A) prevents NEW compile errors from reaching CI at all → trunk stays clean
- (B) ensures fixes that DO land in main propagate to other open PRs without manual intervention
- Without (A), you keep landing trunk breakage; without (B), every fix needs N manual rebases

## Risks

- (A) adds ~10-30 sec to each push when build/ exists. Skips entirely on first push (no build/ dir). Bypass flag exists.
- (B) the GITHUB_TOKEN needs `pull-requests: write` (declared inline). On conflicts, just skips the PR with a log line — PR author still handles.

## Test plan

- [ ] Manual: clone fresh, run setup script, attempt a push with deliberate compile error → confirm rejection
- [ ] Auto: after merge, the next main-advancing merge should trigger a workflow run that updates any open PRs
- [ ] Watch `gh run list --workflow=auto-update-prs.yml` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)