### PR TITLE
Wave 5 A2: Mod matrix curves + quantize + knob badge ring (D9 E3 + F4)

### DIFF
--- a/Source/DSP/ModMatrix.h
+++ b/Source/DSP/ModMatrix.h
@@ -5,6 +5,8 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <functional>
+#include <vector>
 
 namespace xoceanus
 {
@@ -55,6 +57,25 @@ namespace xoceanus
 //
 // All methods are RT-safe (no allocation, no blocking).
 //==============================================================================
+
+//==============================================================================
+// CurveShape — per-route transfer function applied before the amount multiply.
+// All curves operate on a bipolar input x ∈ [-1, +1] and preserve sign.
+//
+//   Linear: y = x                         (default, no curve)
+//   Exp:    y = sign(x) * x²              (concave-up, slow start → fast end)
+//   Log:    y = sign(x) * √|x|            (concave-down, fast start → slow end)
+//   S:      y = sign(x) * smoothstep(|x|) (S-curve, slow at both ends)
+//
+// APVTS parameter name pattern: {prefix}modSlot{N}Curve (AudioParameterChoice,
+// 4 entries matching this enum order).
+enum class CurveShape : int { Linear = 0, Exp, Log, S, Count };
+
+inline const juce::StringArray& curveShapeChoices()
+{
+    static const juce::StringArray kCurves {"Linear", "Exp", "Log", "S"};
+    return kCurves;
+}
 
 template <int N>
 struct ModMatrix
@@ -110,6 +131,19 @@ struct ModMatrix
                 slotLabel + " Amt",
                 juce::NormalisableRange<float> (-1.0f, 1.0f, 0.01f),
                 0.0f));
+
+            // D9 E3: per-route curve shape (Linear/Exp/Log/S)
+            params.push_back(std::make_unique<juce::AudioParameterChoice>(
+                juce::ParameterID {prefix + "modSlot" + idx + "Curve", 1},
+                slotLabel + " Curve",
+                curveShapeChoices(),
+                static_cast<int>(CurveShape::Linear)));
+
+            // D9 E3: per-route quantize-to-scale toggle
+            params.push_back(std::make_unique<juce::AudioParameterBool>(
+                juce::ParameterID {prefix + "modSlot" + idx + "Quant", 1},
+                slotLabel + " Quantize",
+                false));
         }
     }
 
@@ -122,9 +156,11 @@ struct ModMatrix
         for (int i = 0; i < N; ++i)
         {
             const juce::String idx (i + 1);
-            pSrc[i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Src");
-            pDst[i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Dst");
-            pAmt[i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Amt");
+            pSrc  [i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Src");
+            pDst  [i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Dst");
+            pAmt  [i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Amt");
+            pCurve[i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Curve");
+            pQuant[i] = apvts.getRawParameterValue (prefix + "modSlot" + idx + "Quant");
         }
     }
 
@@ -168,6 +204,17 @@ struct ModMatrix
                 default: break;
             }
 
+            // D9 E3: apply per-route curve shape BEFORE amount multiply
+            const auto curve = (pCurve[i] != nullptr)
+                                    ? static_cast<CurveShape>(static_cast<int>(pCurve[i]->load()))
+                                    : CurveShape::Linear;
+            srcVal = applyCurve(srcVal, curve);
+
+            // D9 E3: apply quantize-to-scale if toggled + quantizer_ is wired
+            const bool quantOn = (pQuant[i] != nullptr) && (pQuant[i]->load() >= 0.5f);
+            if (quantOn && quantizer_)
+                srcVal = quantizer_(srcVal);
+
             if (outputs[dst] != nullptr)
                 *outputs[dst] += srcVal * amt;
         }
@@ -188,10 +235,111 @@ struct ModMatrix
         apply(sources, ptrs, D);
     }
 
+    //--------------------------------------------------------------------------
+    // D9 E3: applyCurve — bipolar transfer function, sign-preserving.
+    //
+    //   x is bipolar [-1, +1].  All curves preserve sign so that a negative
+    //   modulation amount can sweep downward (see CLAUDE.md "Bipolar modulation").
+    //
+    //   CurveShape::Exp  source=0.5  → output = sign(0.5) * 0.5² = 0.25
+    //                                  i.e. route(Exp, amt=0.5, src=0.5) → 0.125
+    //   CurveShape::Log  source=0.5  → output = sign(0.5) * √0.5   ≈ 0.707
+    //   CurveShape::S    source=0.5  → output = sign(0.5) * smoothstep(0.5) = 0.5
+    //--------------------------------------------------------------------------
+    static float applyCurve(float x, CurveShape c) noexcept
+    {
+        const float sign = (x < 0.0f) ? -1.0f : 1.0f;
+        const float absX = std::abs(x);
+        switch (c)
+        {
+            case CurveShape::Linear:
+                return x;
+            case CurveShape::Exp:
+                return sign * absX * absX;                                         // x²
+            case CurveShape::Log:
+                return sign * std::sqrt(absX);                                     // √|x|
+            case CurveShape::S:
+                return sign * (3.0f * absX * absX - 2.0f * absX * absX * absX);   // smoothstep
+            default:
+                return x;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // D9 E3: setScaleQuantizer — inject a scale-quantization function.
+    //
+    // The quantizer maps a normalised pitch offset (0..1 ≈ 0..127 MIDI notes)
+    // to the nearest scale degree.  It does NOT need to know about global key/
+    // scale: the processor wires that in via a lambda.  Provide a no-op (or
+    // leave unset) to disable quantization across all routes.
+    //
+    //   void MyProcessor::prepareToPlay(...) {
+    //       auto& scale = globalScaleModule.getCurrentScale();
+    //       modMatrix.setScaleQuantizer([&scale](float x) {
+    //           return scale.quantise(x);
+    //       });
+    //   }
+    //
+    // Called on the message thread before audio is running — not RT-safe
+    // itself, but the stored function is only read on the audio thread after
+    // assignment is complete.
+    //--------------------------------------------------------------------------
+    void setScaleQuantizer(std::function<float(float)> q)
+    {
+        quantizer_ = std::move(q);
+    }
+
+    //--------------------------------------------------------------------------
+    // D9 F4: getRoutesTargeting — return info for all active routes whose
+    // destination index matches destIdx.  Used by knob paint code to collect
+    // the per-route amount values for the badge ring overlay.
+    //
+    //   destIdx — the destination index as read from pDst (integer choice index).
+    //   Returns a vector of {amount, curveShape} pairs for each active route.
+    //
+    // O(N) over slots — N ≤ 16 so this is negligible.  Call from paint()
+    // (message thread) only — does NOT lock.
+    //--------------------------------------------------------------------------
+    struct RouteInfo { float amount; CurveShape curve; };
+
+    std::vector<RouteInfo> getRoutesTargeting(int destIdx) const
+    {
+        std::vector<RouteInfo> result;
+        if (destIdx <= 0)
+            return result;
+        result.reserve(N);
+
+        for (int i = 0; i < N; ++i)
+        {
+            if (pSrc[i] == nullptr || pDst[i] == nullptr || pAmt[i] == nullptr)
+                continue;
+
+            const int src = static_cast<int>(pSrc[i]->load());
+            const int dst = static_cast<int>(pDst[i]->load());
+            const float amt = pAmt[i]->load();
+
+            if (src == 0 || dst != destIdx || std::fabs(amt) < 1e-5f)
+                continue;
+
+            const auto curve = (pCurve[i] != nullptr)
+                                    ? static_cast<CurveShape>(static_cast<int>(pCurve[i]->load()))
+                                    : CurveShape::Linear;
+            result.push_back({amt, curve});
+        }
+        return result;
+    }
+
 private:
-    std::atomic<float>* pSrc[N] = {};
-    std::atomic<float>* pDst[N] = {};
-    std::atomic<float>* pAmt[N] = {};
+    std::atomic<float>* pSrc  [N] = {};
+    std::atomic<float>* pDst  [N] = {};
+    std::atomic<float>* pAmt  [N] = {};
+    std::atomic<float>* pCurve[N] = {};
+    std::atomic<float>* pQuant[N] = {};
+
+    // Scale quantizer function — injected by the processor, null by default.
+    // Applied after curve transform, before amount multiply, only when the
+    // per-route Quantize toggle is on.
+    std::function<float(float)> quantizer_;
 };
 
 } // namespace xoceanus

--- a/Source/UI/Gallery/GalleryKnob.h
+++ b/Source/UI/Gallery/GalleryKnob.h
@@ -4,6 +4,7 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include "../GalleryColors.h"
 #include "MidiLearnMouseListener.h"
+#include <vector>
 
 namespace xoceanus
 {
@@ -56,6 +57,38 @@ public:
 
     // Convenience overload — clear any active modulation arc.
     void clearModulation() { setModulation(0.0f); }
+
+    // D9 F4: Badge ring — per-route amounts for the segmented arc overlay.
+    //
+    // Call from any timer or update path that knows the current mod matrix state
+    // for this knob's parameter.  Pass an empty vector to clear.
+    //
+    // Data is packed into "badgeRouteAmounts" as a juce::Array<juce::var> so it
+    // survives the NamedValueSet round-trip without heap allocation in paint().
+    // The badge ring is only drawn when at least one route is active (amount ≠ 0).
+    //
+    // Colour is fixed to XOceanus::AccentColors::chainAccent (chain cool teal),
+    // per the D9/D10 design contract: routing layer = chain palette.
+    void setBadgeRoutes(const std::vector<float>& routeAmounts)
+    {
+        auto& props = getProperties();
+        juce::Array<juce::var> arr;
+        for (float a : routeAmounts)
+            arr.add(juce::jlimit(-1.0f, 1.0f, a));
+
+        const juce::var newVal (arr);
+        if (props["badgeRouteAmounts"].toString() != newVal.toString())
+        {
+            props.set("badgeRouteAmounts", newVal);
+            repaint();
+        }
+    }
+
+    // Convenience: clear the badge ring.
+    void clearBadgeRoutes()
+    {
+        setBadgeRoutes({});
+    }
 
     // Wire up MIDI Learn for this knob.  Call after SliderAttachment is created.
     // The caller must store the returned listener pointer in a unique_ptr vector.

--- a/Source/UI/Gallery/GalleryLookAndFeel.h
+++ b/Source/UI/Gallery/GalleryLookAndFeel.h
@@ -3,7 +3,9 @@
 #pragma once
 #include <juce_audio_processors/juce_audio_processors.h>
 #include "../GalleryColors.h"
+#include "../AccentColors.h"
 #include <map>
+#include <vector>
 
 namespace xoceanus
 {
@@ -78,6 +80,104 @@ public:
             constexpr float dotR = 1.8f;
             g.setColour (arcCol.withAlpha (0.9f));
             g.fillEllipse (dotX - dotR, dotY - dotR, dotR * 2.0f, dotR * 2.0f);
+        }
+    }
+
+    //==========================================================================
+    // paintModulationBadgeRing — D9 F4 knob discoverability overlay.
+    //
+    // Renders a thin (1.5px) segmented arc just outside the knob body, one
+    // segment per active modulation route targeting this knob.  Each segment
+    // arc length is proportional to abs(amount).  Positive amounts use the
+    // supplied color at full alpha; negative amounts use 60% alpha (inversion
+    // cue).  The ring starts at 12 o'clock and sweeps clockwise.
+    //
+    // knobBounds — the rectangle that encloses the knob (same as Slider bounds).
+    // color       — chain-cool accent color (XOceanus::AccentColors::chainAccent).
+    // routeAmounts — bipolar amounts [-1..+1], one per active route.  Empty →
+    //               no-op.  Called from the knob paint site (message thread only).
+    //
+    // Lucy's gate: no gradient allocation here. Pure path/stroke only.
+    // Constraint: segments smaller than 2° are skipped to avoid hair-thin arcs.
+    //
+    // Usage (from knob paint call-site):
+    //   auto routes = modMatrix.getRoutesTargeting(destIdx);
+    //   if (!routes.empty()) {
+    //       std::vector<float> amounts;
+    //       for (auto& r : routes) amounts.push_back(r.amount);
+    //       GalleryLookAndFeel::paintModulationBadgeRing(g, knobBounds,
+    //           XOceanus::AccentColors::chainAccent, amounts);
+    //   }
+    //==========================================================================
+    static void paintModulationBadgeRing(juce::Graphics& g,
+                                          juce::Rectangle<float> knobBounds,
+                                          juce::Colour color,
+                                          const std::vector<float>& routeAmounts)
+    {
+        if (routeAmounts.empty())
+            return;
+
+        using juce::MathConstants;
+        using juce::Path;
+        using juce::PathStrokeType;
+
+        // Ring radius: just outside the knob body (knob body fills diameter,
+        // subtract 1.5px for the stroke half-width).
+        const float diameter = juce::jmin(knobBounds.getWidth(), knobBounds.getHeight());
+        const float ringR    = diameter * 0.5f - 1.5f;
+        if (ringR <= 1.0f)
+            return; // knob too small to show ring
+
+        const float cx = knobBounds.getCentreX();
+        const float cy = knobBounds.getCentreY();
+
+        // Distribute the full 2π circle proportionally among routes, weighted
+        // by abs(amount).  Routes with amount=0 are filtered by getRoutesTargeting
+        // before this function is called, but clamp anyway.
+        float totalWeight = 0.0f;
+        for (float a : routeAmounts)
+            totalWeight += std::abs(a);
+
+        if (totalWeight < 1e-5f)
+            return;
+
+        constexpr float kMinSegmentRad = 2.0f * juce::MathConstants<float>::pi / 180.0f; // 2°
+        const float kFullSweep = juce::MathConstants<float>::twoPi;
+
+        // Start at 12 o'clock (−π/2), sweep clockwise.
+        float angleStart = -MathConstants<float>::halfPi;
+
+        for (float amt : routeAmounts)
+        {
+            const float weight   = std::abs(amt);
+            const float segSweep = (weight / totalWeight) * kFullSweep;
+
+            if (segSweep < kMinSegmentRad)
+            {
+                angleStart += segSweep;
+                continue;
+            }
+
+            const float angleEnd = angleStart + segSweep;
+
+            // Positive amounts → full alpha; negative → 60% (inversion cue).
+            const float alpha = (amt >= 0.0f) ? 1.0f : 0.60f;
+            g.setColour(color.withAlpha(alpha));
+
+            // JUCE addCentredArc uses its own angle convention:
+            //   0 = 12 o'clock, clockwise positive (same as our convention here).
+            // We built our angles in standard math (counter-clockwise from 3 o'clock),
+            // so convert: juceAngle = ourAngle + π/2.
+            Path seg;
+            seg.addCentredArc(cx, cy, ringR, ringR, 0.0f,
+                               angleStart + MathConstants<float>::halfPi,
+                               angleEnd   + MathConstants<float>::halfPi,
+                               true);
+            g.strokePath(seg, PathStrokeType(1.5f,
+                                              PathStrokeType::curved,
+                                              PathStrokeType::rounded));
+
+            angleStart = angleEnd;
         }
     }
 
@@ -279,7 +379,36 @@ public:
             }
         }
 
-        // ── 6c. Passive hover ring — 1px translucent ring, only when hovering ─
+        // ── 6c. Badge ring (D9 F4) — per-route segmented arc, chain-cool teal ─
+        // The knob stores route amounts in a juce::Array<juce::var> property
+        // "badgeRouteAmounts" via GalleryKnob::setBadgeRoutes().  An empty array
+        // (or missing property) is a no-op.  Lucy's gate: no gradient; pure path.
+        if (diameter >= 28.0f)
+        {
+            if (const auto* v = slider.getProperties().getVarPointer("badgeRouteAmounts"))
+            {
+                if (const auto* arr = v->getArray())
+                {
+                    if (arr->size() > 0)
+                    {
+                        std::vector<float> amounts;
+                        amounts.reserve(static_cast<size_t>(arr->size()));
+                        for (int ri = 0; ri < arr->size(); ++ri)
+                            amounts.push_back(static_cast<float>((*arr)[ri]));
+
+                        // Badge ring sits just outside the normal arc at radius+2px.
+                        const auto knobBounds = juce::Rectangle<float>(
+                            cx - radius - 2.0f, cy - radius - 2.0f,
+                            (radius + 2.0f) * 2.0f, (radius + 2.0f) * 2.0f);
+                        paintModulationBadgeRing(g, knobBounds,
+                                                  XOceanus::AccentColors::chainAccent,
+                                                  amounts);
+                    }
+                }
+            }
+        }
+
+        // ── 6d. Passive hover ring — 1px translucent ring, only when hovering ─
         // Shown at all slider positions (including zero) so the user always gets
         // visual confirmation that the knob is interactive when they hover over it.
         if (isPassiveHover)

--- a/Source/UI/Gallery/ModMatrixDrawer.h
+++ b/Source/UI/Gallery/ModMatrixDrawer.h
@@ -251,7 +251,7 @@ public:
                     const int curveVal = juce::roundToInt(curveParam->getValue()
                                             * (float)(curveParam->getNumSteps() - 1));
                     slots_[i].curvePicker->setSelectedIndex(curveVal, /*notify=*/false);
-                    slots_[i].curvePicker->onCurveSelected = [this, i, curveId](int idx) {
+                    slots_[i].curvePicker->onCurveSelected = [this, curveId](int idx) {
                         if (auto* p = apvts_.getParameter(curveId))
                             p->setValueNotifyingHost(p->convertTo0to1((float)idx));
                     };
@@ -267,7 +267,7 @@ public:
                 if (quantParam)
                 {
                     slots_[i].quantToggle->setQuantized(quantParam->getValue() >= 0.5f, /*notify=*/false);
-                    slots_[i].quantToggle->onToggled = [this, i, quantId](bool on) {
+                    slots_[i].quantToggle->onToggled = [this, quantId](bool on) {
                         if (auto* p = apvts_.getParameter(quantId))
                             p->setValueNotifyingHost(on ? 1.0f : 0.0f);
                     };

--- a/Source/UI/Gallery/ModMatrixDrawer.h
+++ b/Source/UI/Gallery/ModMatrixDrawer.h
@@ -4,18 +4,22 @@
 // ModMatrixDrawer.h — Collapsible mod matrix panel for EngineDetailPanel.
 //
 // Displays up to 8 routing slots, each with:
-//   Source ComboBox → Destination ComboBox → Depth Slider → Enable Toggle
+//   Source ComboBox → Destination ComboBox → Depth Slider → Curve Picker → Q Toggle → Enable Toggle
 //
 // APVTS parameter discovery pattern:
-//   {prefix}modSlot{i}Src  — Choice parameter (source)
-//   {prefix}modSlot{i}Dst  — Choice parameter (destination)
-//   {prefix}modSlot{i}Amt  — Float parameter, bipolar -1 to +1
+//   {prefix}modSlot{i}Src   — Choice parameter (source)
+//   {prefix}modSlot{i}Dst   — Choice parameter (destination)
+//   {prefix}modSlot{i}Amt   — Float parameter, bipolar -1 to +1
+//   {prefix}modSlot{i}Curve — Choice parameter (CurveShape: Linear/Exp/Log/S)
+//   {prefix}modSlot{i}Quant — Bool parameter (quantize-to-scale)
 //
-// Expanded width: 220px. Collapsed: 0px (only MOD tab in parent is visible).
+// Expanded width: 260px (increased from 220px to accommodate curve+Q controls).
+// Collapsed: 0px (only MOD tab in parent is visible).
 // Call loadEngine(prefix) after engine changes; clear() before loading new engine.
 
 #include <juce_audio_processors/juce_audio_processors.h>
 #include "../GalleryColors.h"
+#include "../AccentColors.h"
 
 namespace xoceanus
 {
@@ -142,7 +146,7 @@ public:
 class ModMatrixDrawer : public juce::Component
 {
 public:
-    static constexpr int kExpandedWidth = 220;
+    static constexpr int kExpandedWidth = 260; // expanded from 220px to fit curve picker + Q toggle
     static constexpr int kHeaderHeight  = 26;
     static constexpr int kSlotHeight    = 26;
     static constexpr int kMaxSlots      = 8;
@@ -183,13 +187,17 @@ public:
         for (int i = 0; i < kMaxSlots; ++i)
         {
             const int slotNum = i + 1; // 1-indexed
-            const juce::String srcId = pfx + "modSlot" + juce::String(slotNum) + "Src";
-            const juce::String dstId = pfx + "modSlot" + juce::String(slotNum) + "Dst";
-            const juce::String amtId = pfx + "modSlot" + juce::String(slotNum) + "Amt";
+            const juce::String srcId   = pfx + "modSlot" + juce::String(slotNum) + "Src";
+            const juce::String dstId   = pfx + "modSlot" + juce::String(slotNum) + "Dst";
+            const juce::String amtId   = pfx + "modSlot" + juce::String(slotNum) + "Amt";
+            const juce::String curveId = pfx + "modSlot" + juce::String(slotNum) + "Curve";
+            const juce::String quantId = pfx + "modSlot" + juce::String(slotNum) + "Quant";
 
-            auto* srcParam = apvts_.getParameter(srcId);
-            auto* dstParam = apvts_.getParameter(dstId);
-            auto* amtParam = apvts_.getParameter(amtId);
+            auto* srcParam   = apvts_.getParameter(srcId);
+            auto* dstParam   = apvts_.getParameter(dstId);
+            auto* amtParam   = apvts_.getParameter(amtId);
+            auto* curveParam = apvts_.getParameter(curveId);
+            auto* quantParam = apvts_.getParameter(quantId);
 
             const bool slotExists = (srcParam != nullptr);
 
@@ -237,6 +245,40 @@ public:
                     amtAttachments_[i] = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
                         apvts_, amtId, *slots_[i].depthSlider);
 
+                // D9 E3: wire curve picker → APVTS (read initial value; updates via callback)
+                if (curveParam)
+                {
+                    const int curveVal = juce::roundToInt(curveParam->getValue()
+                                            * (float)(curveParam->getNumSteps() - 1));
+                    slots_[i].curvePicker->setSelectedIndex(curveVal, /*notify=*/false);
+                    slots_[i].curvePicker->onCurveSelected = [this, i, curveId](int idx) {
+                        if (auto* p = apvts_.getParameter(curveId))
+                            p->setValueNotifyingHost(p->convertTo0to1((float)idx));
+                    };
+                    slots_[i].curvePicker->setEnabled(true);
+                }
+                else
+                {
+                    slots_[i].curvePicker->setSelectedIndex(0, false);
+                    slots_[i].curvePicker->setEnabled(false);
+                }
+
+                // D9 E3: wire quantize toggle → APVTS (read initial value; updates via callback)
+                if (quantParam)
+                {
+                    slots_[i].quantToggle->setQuantized(quantParam->getValue() >= 0.5f, /*notify=*/false);
+                    slots_[i].quantToggle->onToggled = [this, i, quantId](bool on) {
+                        if (auto* p = apvts_.getParameter(quantId))
+                            p->setValueNotifyingHost(on ? 1.0f : 0.0f);
+                    };
+                    slots_[i].quantToggle->setEnabled(true);
+                }
+                else
+                {
+                    slots_[i].quantToggle->setQuantized(false, false);
+                    slots_[i].quantToggle->setEnabled(false);
+                }
+
                 slots_[i].enableToggle->setActive(true);
                 slots_[i].enableToggle->setEnabled(true);
                 slots_[i].slotLabel->setAlpha(1.0f);
@@ -250,6 +292,10 @@ public:
                 slots_[i].dstCombo->clear(juce::dontSendNotification);
                 slots_[i].dstCombo->addItem("—", 1);
                 slots_[i].dstCombo->setEnabled(false);
+                slots_[i].curvePicker->setSelectedIndex(0, false);
+                slots_[i].curvePicker->setEnabled(false);
+                slots_[i].quantToggle->setQuantized(false, false);
+                slots_[i].quantToggle->setEnabled(false);
                 slots_[i].enableToggle->setActive(false);
                 slots_[i].enableToggle->setEnabled(false);
                 slots_[i].slotLabel->setAlpha(0.3f);
@@ -273,6 +319,10 @@ public:
             slots_[i].dstCombo->clear(juce::dontSendNotification);
             slots_[i].srcCombo->setEnabled(false);
             slots_[i].dstCombo->setEnabled(false);
+            slots_[i].curvePicker->setSelectedIndex(0, false);
+            slots_[i].curvePicker->setEnabled(false);
+            slots_[i].quantToggle->setQuantized(false, false);
+            slots_[i].quantToggle->setEnabled(false);
             slots_[i].enableToggle->setActive(false);
             slots_[i].enableToggle->setEnabled(false);
         }
@@ -438,6 +488,223 @@ private:
     };
 
     //==========================================================================
+    // CurvePicker — 4-button segmented control for CurveShape selection.
+    // Renders tiny glyph thumbnails (16×12 px each) for Linear/Exp/Log/S.
+    // WCAG AAA: active segment uses chainAccent (≥7:1 against dark bg).
+    class CurvePicker : public juce::Component
+    {
+    public:
+        static constexpr int kNumShapes = 4; // Linear, Exp, Log, S
+        static constexpr int kSegW      = 16;
+        static constexpr int kSegH      = 12;
+
+        std::function<void(int)> onCurveSelected; // callback with shape index 0–3
+
+        CurvePicker()
+        {
+            setWantsKeyboardFocus(true);
+            setTitle("Curve shape");
+            setDescription("Select modulation curve shape: Linear, Exponential, Logarithmic, or S-curve.");
+        }
+
+        int getSelectedIndex() const noexcept { return selectedIdx_; }
+
+        void setSelectedIndex(int idx, bool notify = true)
+        {
+            idx = juce::jlimit(0, kNumShapes - 1, idx);
+            if (selectedIdx_ == idx)
+                return;
+            selectedIdx_ = idx;
+            repaint();
+            if (notify && onCurveSelected)
+                onCurveSelected(selectedIdx_);
+        }
+
+        void paint(juce::Graphics& g) override
+        {
+            const int w = kSegW;
+            const int h = kSegH;
+
+            for (int i = 0; i < kNumShapes; ++i)
+            {
+                const int x = i * w;
+                const bool active = (i == selectedIdx_);
+
+                // Background: dim when inactive, chain-cool tint when active
+                if (active)
+                    g.setColour(XOceanus::AccentColors::chainAccent.withAlpha(0.18f));
+                else
+                    g.setColour(juce::Colour(200, 204, 216).withAlpha(0.05f));
+                g.fillRect(x, 0, w, h);
+
+                // Border
+                g.setColour(active ? XOceanus::AccentColors::chainAccent.withAlpha(0.5f)
+                                   : juce::Colour(200, 204, 216).withAlpha(0.10f));
+                g.drawRect(x, 0, w, h, 1);
+
+                // Glyph — tiny waveform thumbnail
+                paintCurveGlyph(g, i, x, 0, w, h, active);
+            }
+
+            // Keyboard focus ring
+            if (hasKeyboardFocus(false))
+                A11y::drawFocusRing(g, getLocalBounds().toFloat(), 3.0f);
+        }
+
+        void mouseDown(const juce::MouseEvent& e) override
+        {
+            const int idx = e.x / kSegW;
+            if (idx >= 0 && idx < kNumShapes)
+                setSelectedIndex(idx, true);
+        }
+
+        bool keyPressed(const juce::KeyPress& key) override
+        {
+            if (key == juce::KeyPress::leftKey)  { setSelectedIndex(selectedIdx_ - 1, true); return true; }
+            if (key == juce::KeyPress::rightKey) { setSelectedIndex(selectedIdx_ + 1, true); return true; }
+            return false;
+        }
+
+    private:
+        // Paint a tiny glyph representing the curve shape.
+        // Each glyph is a 3-point polyline drawn in the centre 12×8 px of the segment.
+        static void paintCurveGlyph(juce::Graphics& g, int shape,
+                                    int bx, int by, int bw, int bh,
+                                    bool active)
+        {
+            const juce::Colour col = active ? XOceanus::AccentColors::chainAccent
+                                            : juce::Colour(200, 204, 216).withAlpha(0.40f);
+            g.setColour(col);
+
+            // Glyph area — leave 2px border each side
+            const float gx = (float)bx + 2.0f;
+            const float gy = (float)by + 2.0f;
+            const float gw = (float)bw - 4.0f;
+            const float gh = (float)bh - 4.0f;
+
+            juce::Path p;
+            // Each curve is described as points in normalised [0,1]×[0,1] space
+            // (x=phase, y=output, y=0 at bottom, y=1 at top)
+            switch (shape)
+            {
+                case 0: // Linear: diagonal from bottom-left to top-right
+                {
+                    p.startNewSubPath(gx, gy + gh);
+                    p.lineTo(gx + gw, gy);
+                    break;
+                }
+                case 1: // Exp: concave-up (starts slow, ends fast)
+                {
+                    p.startNewSubPath(gx, gy + gh);
+                    p.quadraticTo(gx + gw * 0.8f, gy + gh, gx + gw, gy);
+                    break;
+                }
+                case 2: // Log: concave-down (starts fast, ends slow)
+                {
+                    p.startNewSubPath(gx, gy + gh);
+                    p.quadraticTo(gx, gy, gx + gw, gy);
+                    break;
+                }
+                case 3: // S-curve: smoothstep
+                {
+                    p.startNewSubPath(gx, gy + gh);
+                    p.cubicTo(gx + gw * 0.2f, gy + gh,
+                              gx + gw * 0.8f, gy,
+                              gx + gw, gy);
+                    break;
+                }
+                default:
+                    p.startNewSubPath(gx, gy + gh);
+                    p.lineTo(gx + gw, gy);
+                    break;
+            }
+
+            g.strokePath(p, juce::PathStrokeType(1.2f, juce::PathStrokeType::curved,
+                                                  juce::PathStrokeType::rounded));
+        }
+
+        int selectedIdx_ = 0; // 0 = Linear (default)
+    };
+
+    //==========================================================================
+    // QuantizeToggle — small "Q" pill button.
+    // Lit state uses chainAccent (chain cool palette, WCAG AAA).
+    // Unlit is dimmed.
+    class QuantizeToggle : public juce::Component
+    {
+    public:
+        std::function<void(bool)> onToggled;
+
+        QuantizeToggle()
+        {
+            setWantsKeyboardFocus(true);
+            setTitle("Quantize to scale");
+            setDescription("Toggle quantize-to-scale: routes pitch modulation to the nearest scale degree.");
+        }
+
+        bool isQuantized() const noexcept { return quantized_; }
+
+        void setQuantized(bool q, bool notify = true)
+        {
+            if (quantized_ == q)
+                return;
+            quantized_ = q;
+            repaint();
+            if (notify && onToggled)
+                onToggled(quantized_);
+        }
+
+        void paint(juce::Graphics& g) override
+        {
+            auto b = getLocalBounds().toFloat();
+
+            // Background
+            if (quantized_ && isEnabled())
+                g.setColour(XOceanus::AccentColors::chainAccent.withAlpha(0.20f));
+            else
+                g.setColour(juce::Colour(200, 204, 216).withAlpha(0.05f));
+            g.fillRoundedRectangle(b, 3.0f);
+
+            // Border
+            if (quantized_ && isEnabled())
+                g.setColour(XOceanus::AccentColors::chainAccent.withAlpha(0.60f));
+            else
+                g.setColour(juce::Colour(200, 204, 216).withAlpha(0.12f));
+            g.drawRoundedRectangle(b.reduced(0.5f), 3.0f, 1.0f);
+
+            // "Q" label — chainAccent when lit, dimmed when off
+            g.setFont(GalleryFonts::value(7.0f));
+            if (quantized_ && isEnabled())
+                g.setColour(XOceanus::AccentColors::chainAccent); // AAA contrast
+            else
+                g.setColour(juce::Colour(200, 204, 216).withAlpha(isEnabled() ? 0.30f : 0.12f));
+            g.drawText("Q", b.toNearestInt(), juce::Justification::centred, false);
+
+            if (hasKeyboardFocus(false))
+                A11y::drawFocusRing(g, b, 3.0f);
+        }
+
+        void mouseDown(const juce::MouseEvent&) override
+        {
+            if (isEnabled())
+                setQuantized(!quantized_, true);
+        }
+
+        bool keyPressed(const juce::KeyPress& key) override
+        {
+            if (key == juce::KeyPress::spaceKey || key == juce::KeyPress::returnKey)
+            {
+                if (isEnabled()) setQuantized(!quantized_, true);
+                return true;
+            }
+            return false;
+        }
+
+    private:
+        bool quantized_ = false;
+    };
+
+    //==========================================================================
     struct SlotRow
     {
         std::unique_ptr<juce::Label>        slotLabel;     // "1"–"8"
@@ -445,6 +712,8 @@ private:
         std::unique_ptr<juce::Label>        arrowLabel;    // "→"
         std::unique_ptr<juce::ComboBox>     dstCombo;
         std::unique_ptr<juce::Slider>       depthSlider;
+        std::unique_ptr<CurvePicker>        curvePicker;   // D9 E3: Linear/Exp/Log/S
+        std::unique_ptr<QuantizeToggle>     quantToggle;   // D9 E3: quantize-to-scale
         std::unique_ptr<EnableToggle>       enableToggle;
 
         // LookAndFeel instances owned per-slot to avoid cross-contamination
@@ -494,6 +763,14 @@ private:
         row.depthSlider->setValue(0.0, juce::dontSendNotification);
         addAndMakeVisible(*row.depthSlider);
 
+        // D9 E3: Curve picker — 4-segment Linear/Exp/Log/S
+        row.curvePicker = std::make_unique<CurvePicker>();
+        addAndMakeVisible(*row.curvePicker);
+
+        // D9 E3: Quantize toggle — "Q" pill, chain-cool accent
+        row.quantToggle = std::make_unique<QuantizeToggle>();
+        addAndMakeVisible(*row.quantToggle);
+
         // Enable toggle
         row.enableToggle = std::make_unique<EnableToggle>();
         addAndMakeVisible(*row.enableToggle);
@@ -501,32 +778,36 @@ private:
 
     // Layout a single slot row within its bounding rect.
     // Layout (left→right, 4px padding top+bottom):
-    //   [4px gap] [slotLabel 10px] [2px] [srcCombo ~54px] [arrowLabel 10px]
-    //   [dstCombo ~54px] [2px] [depthSlider 40px] [2px] [toggle 12px] [4px]
+    //   [4px gap] [slotLabel 10px] [2px] [srcCombo ~40px] [arrowLabel 10px]
+    //   [dstCombo ~40px] [2px] [depthSlider 32px] [2px] [curvePicker 64px] [2px] [Q 14px] [2px] [toggle 12px] [4px]
     void layoutSlotRow(int i, int rx, int ry, int rw, int rh)
     {
-        const int padV  = 4;
-        const int padH  = 4;
-        const int inner = rh - padV * 2;
-        int x           = rx + padH;
+        const int padV    = 4;
+        const int padH    = 4;
+        const int inner   = rh - padV * 2;
+        int x             = rx + padH;
 
-        // Slot number label — narrow column
-        const int labelW = 10;
+        // Fixed-width columns
+        const int labelW  = 10;
+        const int arrowW  = 10;
+        const int depthW  = 32;
+        const int curveW  = CurvePicker::kSegW * CurvePicker::kNumShapes; // 4 × 16 = 64px
+        const int quantW  = 14;
+        const int toggleW = 12;
+
+        // Budget: rw - padH*2 - labelW - arrowW - depthW - curveW - quantW - toggleW - gaps
+        // gaps: 2 (after label) + 0 (before arrow, arrow follows srcCombo) + 2 (after dst) + 2 (after depth) + 2 (after curve) + 2 (after quant) + 4 (right pad)
+        const int fixedUsed = padH + labelW + 2 + arrowW + depthW + curveW + quantW + toggleW + (2 + 2 + 2 + 2 + padH);
+        const int comboTotal = rw - fixedUsed;
+        const int comboW     = juce::jmax(24, comboTotal / 2);
+
+        // Slot number label
         slots_[i].slotLabel->setBounds(x, ry + padV, labelW, inner);
         x += labelW + 2;
 
-        // Remaining width budget: rw - padH*2 - labelW - 2 - 10 (arrow) - 40 (depth) - 12 (toggle) - 2 - 2 - 2
-        // Two combo boxes share the remaining space equally
-        const int arrowW  = 10;
-        const int depthW  = 40;
-        const int toggleW = 12;
-        const int gaps    = 2 + 2 + 2 + 2 + padH; // arrow gaps + depth gap + toggle gap + right pad
-        const int comboTotal = rw - padH - labelW - 2 - arrowW - depthW - toggleW - gaps;
-        const int comboW     = juce::jmax(30, comboTotal / 2);
-
         // Source ComboBox
         slots_[i].srcCombo->setBounds(x, ry + padV, comboW, inner);
-        x += comboW + 2;
+        x += comboW;
 
         // Arrow
         slots_[i].arrowLabel->setBounds(x, ry + padV, arrowW, inner);
@@ -540,7 +821,18 @@ private:
         slots_[i].depthSlider->setBounds(x, ry + padV, depthW, inner);
         x += depthW + 2;
 
-        // Enable toggle — centered vertically, 12x12
+        // Curve picker — 4 × 16px = 64px wide, full inner height
+        const int curveY = ry + (rh - CurvePicker::kSegH) / 2;
+        slots_[i].curvePicker->setBounds(x, curveY, curveW, CurvePicker::kSegH);
+        x += curveW + 2;
+
+        // Quantize toggle — "Q" pill, 14×12px centred vertically
+        const int quantH = 12;
+        const int quantY = ry + (rh - quantH) / 2;
+        slots_[i].quantToggle->setBounds(x, quantY, quantW, quantH);
+        x += quantW + 2;
+
+        // Enable toggle — 12×12px centred vertically
         const int toggleY = ry + (rh - toggleW) / 2;
         slots_[i].enableToggle->setBounds(x, toggleY, toggleW, toggleW);
     }
@@ -552,6 +844,10 @@ private:
             srcAttachments_[i].reset();
             dstAttachments_[i].reset();
             amtAttachments_[i].reset();
+            // Curve and quant are wired via callbacks — clear them to prevent
+            // dangling captures to old APVTS parameter IDs after engine change.
+            slots_[i].curvePicker->onCurveSelected = nullptr;
+            slots_[i].quantToggle->onToggled = nullptr;
         }
     }
 


### PR DESCRIPTION
## Summary

- **DSP (ModMatrix.h):** Added `CurveShape` enum (Linear/Exp/Log/S) and per-route `quantize-to-scale` bool to `ModMatrix<N>`. Each route now applies `applyCurve()` (bipolar, sign-preserving) before the amount multiply. `setScaleQuantizer()` accepts a `std::function<float(float)>` injected by the processor; no-op until wired. Two new APVTS parameters per slot: `{prefix}modSlot{N}Curve` (choice, 4 entries) and `{prefix}modSlot{N}Quant` (bool). `getRoutesTargeting(destIdx)` returns `{amount, curve}` pairs for badge ring callers.

- **UI row (ModMatrixDrawer.h):** Each route row gets a `CurvePicker` (4×16px segmented control with glyph thumbnails for Linear/Exp/Log/S) and a `QuantizeToggle` ("Q" pill). Both use `XOceanus::AccentColors::chainAccent` (cool teal, WCAG AAA ≥7:1) for lit state — chain palette per D10, not the warm coupling palette. Panel width expanded to 260px. Callbacks wire directly to APVTS via `param->setValueNotifyingHost()`.

- **Badge ring (GalleryLookAndFeel.h + GalleryKnob.h):** `paintModulationBadgeRing()` static draws a 1.5px segmented arc at knob outer edge, proportional arc per route amount. Positive = full alpha, negative = 60% (inversion cue). `GalleryKnob::setBadgeRoutes()` stores amounts in `NamedValueSet["badgeRouteAmounts"]` — same LookAndFeel-property pattern as existing `modAmount`/`modColour`. No gradient allocations (Lucy's gate compliance).

## Test plan

- [ ] CI build passes (header-only, no xcodeproj in worktree)
- [ ] Visual: curve picker glyphs render correctly for all 4 shapes (diagonal / concave-up / concave-down / S)
- [ ] Visual: Q toggle lights with chain-cool teal (#6CEBF4), NOT amber coupling color
- [ ] Visual: badge ring shows segmented arc when `setBadgeRoutes({0.7f, -0.3f})` called — second segment visibly dimmer (60% alpha)
- [ ] DSP trace: Exp curve, source=0.5, amt=0.5 → output=0.125 (`0.5² × 0.5`)
- [ ] No per-frame gradient allocation introduced (paint uses Path only)
- [ ] `kExpandedWidth` change (220→260) flows through `EngineDetailPanel` without hardcoded numbers
- [ ] Engines using `ModMatrix<N>` with existing presets: new `Curve`/`Quant` params default to `Linear`/`false` — no sound change on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)