### PR TITLE
Wave 5 B2: Three chord input modes (AutoHarmonize / PadPerChord / ScaleDegree)

### DIFF
--- a/Source/Core/ChordMachine.h
+++ b/Source/Core/ChordMachine.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 XO_OX Designs
 #pragma once
 #include <juce_audio_processors/juce_audio_processors.h>
+#include "ScaleHelpers.h"
 #include <array>
 #include <algorithm>
 #include <atomic>
@@ -78,6 +79,33 @@ enum class VoicingMode : int
     DroneMin2, // root + m2   (0, 1)  — slots 0/2=root, slots 1/3=m2
 
     NumModes
+};
+
+// ── B2: Chord Input Mode ──────────────────────────────────────────────────────
+// Three ways a note arriving at ChordMachine can produce chord output:
+//   AutoHarmonize — incoming note is the chord root; uses current palette+voicing.
+//   PadPerChord   — incoming note number (mod 16) selects a stored pad slot with
+//                   its own root, voicing, and inversion.
+//   ScaleDegree   — incoming note maps to a scale degree; chord root = that degree's
+//                   note in the global key/scale.
+enum class ChordInputMode : int
+{
+    AutoHarmonize = 0, // default — preserves all existing behavior
+    PadPerChord,
+    ScaleDegree,
+    Count
+};
+
+// ── B2: Pad Chord Slot ────────────────────────────────────────────────────────
+// One entry in the 16-slot pad chord grid.  Read by the audio thread; written by
+// the message thread via setPadChord().  Fields are independent PODs: a torn read
+// produces at worst a brief inconsistency on a single pad trigger, which is inaudible.
+struct PadChordSlot
+{
+    int         rootNote  = 60;                  // MIDI note for this slot's chord root
+    VoicingMode voicing   = VoicingMode::RootSpread; // voicing override for this slot
+    int         inversion = 0;                   // 0=root pos, 1=1st inv, 2=2nd inv, 3=3rd inv
+    bool        active    = true;                // false = this pad slot is silent
 };
 
 enum class RhythmPattern : int
@@ -758,6 +786,65 @@ public:
     void setEnoMode(bool on) { enoMode.store(on, std::memory_order_relaxed); }
     bool isEnoMode() const { return enoMode.load(std::memory_order_relaxed); }
 
+    //-- B2: Input Mode (message thread → audio thread via atomic) ──────────────
+
+    void setInputMode(ChordInputMode m)
+    {
+        inputMode_.store(static_cast<int>(m), std::memory_order_relaxed);
+    }
+    ChordInputMode getInputMode() const
+    {
+        return static_cast<ChordInputMode>(inputMode_.load(std::memory_order_relaxed));
+    }
+
+    //-- B2: Pad chord slot setters (message thread) ────────────────────────────
+
+    static constexpr int kNumPadChords = 16;
+
+    void setPadChord(int padIndex, int rootNote, VoicingMode v, int inversion, bool active = true)
+    {
+        if (padIndex < 0 || padIndex >= kNumPadChords)
+            return;
+        padChords_[padIndex].rootNote  = juce::jlimit(0, 127, rootNote);
+        padChords_[padIndex].voicing   = v;
+        padChords_[padIndex].inversion = juce::jlimit(0, 3, inversion);
+        padChords_[padIndex].active    = active;
+    }
+
+    PadChordSlot getPadChord(int padIndex) const
+    {
+        if (padIndex < 0 || padIndex >= kNumPadChords)
+            return {};
+        return padChords_[padIndex];
+    }
+
+    //-- B2: Global key/scale for ScaleDegree mode (message thread) ─────────────
+    // Mirrors the values stored in APVTS params cm_global_root and cm_global_scale.
+    // Audio thread reads via atomics.
+
+    void setGlobalRootKey(int rootKey)
+    {
+        globalRootKey_.store(((rootKey % 12) + 12) % 12, std::memory_order_relaxed);
+    }
+    int getGlobalRootKey() const
+    {
+        return globalRootKey_.load(std::memory_order_relaxed);
+    }
+
+    void setGlobalScaleIndex(int scaleIdx)
+    {
+        globalScaleIdx_.store(
+            juce::jlimit(0, kNumScaleTypes - 1, scaleIdx),
+            std::memory_order_relaxed);
+    }
+    int getGlobalScaleIndex() const
+    {
+        return globalScaleIdx_.load(std::memory_order_relaxed);
+    }
+
+    // Read-only: last incoming degree (for UI feedback in ScaleDegree mode)
+    int getLastIncomingDegree() const { return lastIncomingDegree_.load(std::memory_order_relaxed); }
+
     //-- Serialization (message thread) ----------------------------------------
 
     // Serialize full Chord Machine state to a juce::var (for .xometa storage).
@@ -1076,7 +1163,67 @@ private:
         if (hasActiveChord)
             releaseCurrentChord(samplePos, outputMidi);
 
-        auto newAssignment = distributor.distribute(noteNumber, pal, voic, spr, velocity);
+        // ── B2: Input mode dispatch ──────────────────────────────────────────
+        // Snapshot input mode once (RT-safe: atomic load at block boundary)
+        const ChordInputMode mode = static_cast<ChordInputMode>(inputMode_.load(std::memory_order_relaxed));
+
+        int    chordRoot = noteNumber; // AutoHarmonize default
+        VoicingMode chordVoicing = voic;
+
+        if (mode == ChordInputMode::PadPerChord)
+        {
+            // Map incoming note → pad slot (mod 16), use that slot's root + voicing
+            const int padIdx = noteNumber % kNumPadChords;
+            const PadChordSlot& slot = padChords_[padIdx];
+            if (!slot.active)
+            {
+                // Silent slot — no chord
+                hasActiveChord = false;
+                activeInputNote = noteNumber;
+                return;
+            }
+            chordRoot    = juce::jlimit(0, 127, slot.rootNote);
+            chordVoicing = slot.voicing;
+            // Apply inversion: rotate notes up by inversion steps after distribute
+        }
+        else if (mode == ChordInputMode::ScaleDegree)
+        {
+            // Map incoming note → scale degree → chord root for that degree
+            const int rootKey  = globalRootKey_.load(std::memory_order_relaxed);
+            const int scaleIdx = globalScaleIdx_.load(std::memory_order_relaxed);
+            const int degree   = scaleDegreeFromNote(noteNumber, rootKey, scaleIdx);
+            lastIncomingDegree_.store(degree, std::memory_order_relaxed);
+            chordRoot = chordRootForDegree(degree, rootKey, scaleIdx, noteNumber);
+            // Voicing stays as the current global voicing (chordVoicing = voic)
+        }
+        // AutoHarmonize: chordRoot = noteNumber, chordVoicing = voic (already set)
+
+        auto newAssignment = distributor.distribute(chordRoot, pal, chordVoicing, spr, velocity);
+
+        // Apply inversion for PadPerChord mode (rotate notes up)
+        if (mode == ChordInputMode::PadPerChord)
+        {
+            const int padIdx = noteNumber % kNumPadChords;
+            const int inv = juce::jlimit(0, 3, padChords_[padIdx].inversion);
+            for (int k = 0; k < inv; ++k)
+            {
+                // Lowest note goes up an octave
+                int lowestIdx = 0;
+                for (int i = 1; i < 4; ++i)
+                    if (newAssignment.midiNotes[i] < newAssignment.midiNotes[lowestIdx])
+                        lowestIdx = i;
+                newAssignment.midiNotes[lowestIdx] += 12;
+                // Re-sort so slot ordering is consistent
+                // (simple bubble for 4 elements — no allocation)
+                for (int a = 0; a < 3; ++a)
+                    for (int b = a + 1; b < 4; ++b)
+                        if (newAssignment.midiNotes[a] > newAssignment.midiNotes[b])
+                        {
+                            std::swap(newAssignment.midiNotes[a], newAssignment.midiNotes[b]);
+                            std::swap(newAssignment.velocities[a], newAssignment.velocities[b]);
+                        }
+            }
+        }
 
         if (hadPreviousChord)
             newAssignment = distributor.voiceLead(previousAssignment, newAssignment);
@@ -1305,6 +1452,20 @@ private:
 
     // External MIDI clock state (#359) — audio thread only
     int externalClockPulseCount = 0; // 0–5; resets to 0 at each 16th-note boundary
+
+    // ── B2: Input mode state ───────────────────────────────────────────────────
+    // Written by message thread; read by audio thread — all atomic.
+
+    std::atomic<int> inputMode_    { 0 }; // ChordInputMode::AutoHarmonize
+    std::atomic<int> globalRootKey_{ 0 }; // C
+    std::atomic<int> globalScaleIdx_{ 1 }; // Major
+
+    // Pad chord slots: written by message thread, read by audio thread.
+    // Benign race per-slot (independent POD fields, no array-level lock needed).
+    std::array<PadChordSlot, kNumPadChords> padChords_;
+
+    // Last scale degree processed (ScaleDegree mode) — for UI readout.
+    std::atomic<int> lastIncomingDegree_{ 0 };
 };
 
 } // namespace xoceanus

--- a/Source/Core/ScaleHelpers.h
+++ b/Source/Core/ScaleHelpers.h
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+// ScaleHelpers.h — Scale interval tables + degree-to-note helpers for ChordMachine.
+//
+// Used by ChordMachine::ScaleDegree input mode to:
+//   1. Map an incoming MIDI note number to a scale degree (1-7 for heptatonic scales).
+//   2. Derive the chord root for that degree in the current global key.
+//
+// Scale indices match NoteInputZone::scales[] order so the same index can be stored
+// in a single APVTS param (cm_global_scale) and used by both the UI (PlaySurface) and
+// the audio engine (ChordMachine), without coupling those two classes.
+//
+// Scale index table (must stay stable — frozen once persisted):
+//   0  Chromatic      — all semitones (degree resolution: returns semitone class)
+//   1  Major          — Ionian:     0 2 4 5 7 9 11
+//   2  Minor          — Aeolian:    0 2 3 5 7 8 10
+//   3  Dorian         — Dorian:     0 2 3 5 7 9 10
+//   4  Mixolydian     — Mixolydian: 0 2 4 5 7 9 10
+//   5  Pent Minor     — 0 3 5 7 10
+//   6  Pent Major     — 0 2 4 7 9
+//   7  Blues          — 0 3 5 6 7 10
+//   8  Harm Minor     — 0 2 3 5 7 8 11
+//
+// Thread safety: all functions are pure (no side effects), safe on the audio thread.
+
+#include <array>
+#include <cstdint>
+#include <algorithm>
+
+namespace xoceanus
+{
+
+// Number of scale types (matches NoteInputZone::scales[] count)
+static constexpr int kNumScaleTypes = 9;
+
+// Maximum intervals in a single scale (chromatic has 12)
+static constexpr int kMaxScaleIntervals = 12;
+
+// Interval tables: semitone offsets from root, ascending, padded with -1.
+// Row 0 = Chromatic, Row 1 = Major, ... Row 8 = Harm Minor
+// Sizes: [0]=12, [1-4]=7, [5-6]=5, [7]=6, [8]=7
+static constexpr int kScaleIntervals[kNumScaleTypes][kMaxScaleIntervals] = {
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }, // 0 Chromatic
+    { 0, 2, 4, 5, 7, 9, 11,-1,-1,-1,-1,-1 },   // 1 Major
+    { 0, 2, 3, 5, 7, 8, 10,-1,-1,-1,-1,-1 },   // 2 Minor
+    { 0, 2, 3, 5, 7, 9, 10,-1,-1,-1,-1,-1 },   // 3 Dorian
+    { 0, 2, 4, 5, 7, 9, 10,-1,-1,-1,-1,-1 },   // 4 Mixolydian
+    { 0, 3, 5, 7, 10,-1,-1,-1,-1,-1,-1,-1 },   // 5 Pent Minor
+    { 0, 2, 4, 7,  9,-1,-1,-1,-1,-1,-1,-1 },   // 6 Pent Major
+    { 0, 3, 5, 6,  7, 10,-1,-1,-1,-1,-1,-1},   // 7 Blues
+    { 0, 2, 3, 5,  7,  8, 11,-1,-1,-1,-1,-1},  // 8 Harm Minor
+};
+
+// Number of intervals per scale (degrees / unique notes)
+static constexpr int kScaleIntervalCount[kNumScaleTypes] = {
+    12, // Chromatic
+     7, // Major
+     7, // Minor
+     7, // Dorian
+     7, // Mixolydian
+     5, // Pent Minor
+     5, // Pent Major
+     6, // Blues
+     7, // Harm Minor
+};
+
+//==============================================================================
+// scaleDegreeFromNote — returns the 0-based degree index into the scale's
+// interval array for the given MIDI note number, or -1 if not in scale.
+//
+// For Chromatic (scaleIdx==0), every semitone is degree (semitone class 0-11).
+//
+// Example: key=0 (C), scaleIdx=1 (Major), note=62 (D4) → D is at semitone 2,
+//   kScaleIntervals[1] = {0,2,4,5,7,9,11} → degree index 1 (ii).
+//
+// Audio-thread safe: pure, no allocation.
+inline int scaleDegreeFromNote(int noteNumber, int rootKey, int scaleIdx) noexcept
+{
+    if (scaleIdx < 0 || scaleIdx >= kNumScaleTypes)
+        scaleIdx = 0;
+    rootKey = ((rootKey % 12) + 12) % 12;
+
+    const int relSemi = ((noteNumber % 12) - rootKey + 12) % 12;
+    const int count = kScaleIntervalCount[scaleIdx];
+    for (int d = 0; d < count; ++d)
+    {
+        if (kScaleIntervals[scaleIdx][d] == relSemi)
+            return d;
+    }
+    // Not in scale — snap to nearest degree below
+    int best = 0;
+    int bestDist = 12;
+    for (int d = 0; d < count; ++d)
+    {
+        const int dist = (relSemi - kScaleIntervals[scaleIdx][d] + 12) % 12;
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = d;
+        }
+    }
+    return best;
+}
+
+//==============================================================================
+// chordRootForDegree — returns the MIDI note number (relative to the same
+// octave range as the incoming note) for the chord root at `degree` in the
+// given scale.
+//
+// Preserves octave: the returned note is in the same octave as `noteNumber`
+// (within ±6 semitones — nearest octave reachable).
+//
+// Audio-thread safe: pure, no allocation.
+inline int chordRootForDegree(int degree, int rootKey, int scaleIdx, int referenceNote) noexcept
+{
+    if (scaleIdx < 0 || scaleIdx >= kNumScaleTypes)
+        scaleIdx = 0;
+    rootKey = ((rootKey % 12) + 12) % 12;
+    degree = std::max(0, std::min(degree, kScaleIntervalCount[scaleIdx] - 1));
+
+    const int interval = kScaleIntervals[scaleIdx][degree];
+    // Compute the absolute root in the same octave block as referenceNote
+    const int octaveBase = (referenceNote / 12) * 12;
+    int candidate = octaveBase + rootKey + interval;
+    // Clamp to valid MIDI range
+    if (candidate > 127) candidate -= 12;
+    if (candidate < 0)   candidate += 12;
+    return candidate;
+}
+
+//==============================================================================
+// isNoteInScale — returns true if noteNumber is in the given scale/key.
+// Chromatic always returns true.
+inline bool isNoteInScale(int noteNumber, int rootKey, int scaleIdx) noexcept
+{
+    if (scaleIdx < 0 || scaleIdx >= kNumScaleTypes)
+        return true;
+    if (scaleIdx == 0)
+        return true; // Chromatic
+    rootKey = ((rootKey % 12) + 12) % 12;
+    const int relSemi = ((noteNumber % 12) - rootKey + 12) % 12;
+    const int count = kScaleIntervalCount[scaleIdx];
+    for (int d = 0; d < count; ++d)
+        if (kScaleIntervals[scaleIdx][d] == relSemi)
+            return true;
+    return false;
+}
+
+// Scale degree quality hint: is the degree a "major" or "minor" context?
+// Returns true if the degree is considered major-quality in the scale.
+// Used by ScaleDegree mode to pick chord voicings that match scale function.
+// Simplified: even-numbered intervals from root are typically major-quality.
+inline bool isDegreeMinorQuality(int degree, int scaleIdx) noexcept
+{
+    if (scaleIdx <= 0 || scaleIdx >= kNumScaleTypes) return false;
+    if (degree < 0 || degree >= kScaleIntervalCount[scaleIdx]) return false;
+    const int interval = kScaleIntervals[scaleIdx][degree];
+    // A minor third above the previous degree indicates minor quality chord.
+    // Check: is the interval between degree and degree+1 a minor 3rd (3 semitones)?
+    // Simpler heuristic: degrees with flat 3rd (interval mod 12 in {3,8,10}) are minor.
+    // Major chord degrees have pure major third = 4 semitones above.
+    // We detect this from the scale's step pattern.
+    if (degree + 1 < kScaleIntervalCount[scaleIdx])
+    {
+        const int nextInterval = kScaleIntervals[scaleIdx][degree + 1];
+        const int step = nextInterval - interval;
+        return (step == 1); // half-step = minor quality leading tone (rare heuristic)
+    }
+    // Fallback: use interval from root: 0 (I) and 4 (V) are major, 2 (iii) and 5 (vi) are minor
+    static constexpr bool kMajorMinorFallback[7] = { false, true, true, false, false, true, true };
+    if (degree < 7) return kMajorMinorFallback[degree];
+    return false;
+}
+
+// Scale name lookup (matches scale index order)
+inline const char* scaleName(int scaleIdx) noexcept
+{
+    static constexpr const char* kNames[kNumScaleTypes] = {
+        "Chromatic", "Major", "Minor", "Dorian", "Mixolydian",
+        "Pent Min", "Pent Maj", "Blues", "Harm Min"
+    };
+    if (scaleIdx >= 0 && scaleIdx < kNumScaleTypes)
+        return kNames[scaleIdx];
+    return "?";
+}
+
+// Roman numeral labels for scale degrees (7-degree max)
+inline const char* degreeRomanNumeral(int degree, int scaleIdx, bool minorQuality) noexcept
+{
+    static constexpr const char* kMajorRoman[7] = { "I","ii","iii","IV","V","vi","vii\xC2\xB0" };
+    static constexpr const char* kMinorRoman[7] = { "i","ii\xC2\xB0","III","iv","v","VI","VII" };
+    (void)scaleIdx;
+    if (degree < 0 || degree > 6) return "?";
+    return minorQuality ? kMinorRoman[degree] : kMajorRoman[degree];
+}
+
+} // namespace xoceanus

--- a/Source/UI/Ocean/ChordBarComponent.h
+++ b/Source/UI/Ocean/ChordBarComponent.h
@@ -22,7 +22,9 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "../../Core/ChordMachine.h"
+#include "../../Core/ScaleHelpers.h"
 #include "../GalleryColors.h"
+#include "../AccentColors.h"
 #include <functional>
 #include <cmath>
 #include <array>
@@ -94,6 +96,9 @@ public:
     // Mode enum for LIVE / SEQ / ENO
     enum class ChordMode { Live = 0, Seq, Eno, NumModes };
 
+    // B2: Input mode (AUTO / PAD / DEG) — maps to ChordInputMode enum
+    enum class InputMode { Auto = 0, Pad, Deg, NumModes };
+
     // Height constant — the bar is always 28 px when visible.
     static constexpr int kBarHeight = 28;
 
@@ -131,6 +136,10 @@ public:
     /// Callback fired whenever setVisible() changes the visibility state.
     std::function<void()> onVisibilityChanged;
 
+    /// B2: Callback fired when input mode pill changes (AUTO/PAD/DEG).
+    /// Optional — used for testability and parent-component notification.
+    std::function<void(InputMode)> onInputModeChanged;
+
 private:
     //==========================================================================
     // Sub-component geometry (computed in layoutControls(), used in paint/mouse).
@@ -152,7 +161,11 @@ private:
         Duck        = 10,
         ModeLive    = 11,
         ModeSeq     = 12,
-        ModeEno     = 13
+        ModeEno     = 13,
+        // B2: Input mode pills
+        InputAuto   = 14,
+        InputPad    = 15,
+        InputDeg    = 16,
     };
 
     struct PillRegion
@@ -232,6 +245,14 @@ private:
         paintLabeledSlider(g, labelFont, midY, swingLabelBounds_, swingSlider_,  "SWING");
         paintLabeledSlider(g, labelFont, midY, gateLabelBounds_,  gateSlider_,   "GATE");
         paintLabeledSlider(g, labelFont, midY, humanLabelBounds_, humanSlider_,  "HUMAN");
+
+        // ── B2: Pad grid overlay (PadPerChord mode) ──
+        if (currentInputMode_ == InputMode::Pad && !padGridBounds_.isEmpty())
+            paintPadGrid(g, pillFont);
+
+        // ── B2: Degree readout (ScaleDegree mode) ──
+        if (currentInputMode_ == InputMode::Deg && !degreeReadoutBounds_.isEmpty())
+            paintDegreeReadout(g, pillFont);
     }
 
     //--------------------------------------------------------------------------
@@ -447,6 +468,96 @@ private:
         g.drawRect(pb, 1.0f);
     }
 
+    //--------------------------------------------------------------------------
+    /// B2: Paint the 16-pad chord grid (PadPerChord mode).
+    /// Renders in a compact row — 16 pads × (padCellW × h).
+    /// Cached gradient: none needed (solid fill per pad).
+    void paintPadGrid(juce::Graphics& g, const juce::Font& font) const
+    {
+        const auto& r    = padGridBounds_;
+        const float cellW = r.getWidth() / 16.0f;
+        const float cellH = r.getHeight();
+
+        // Teal chain color from AccentColors (AAA contrast on dark bg)
+        const juce::Colour activeCol  = XOceanus::AccentColors::chainBright;   // #90F2FA AAA
+        const juce::Colour inactiveCol = juce::Colour(200, 204, 216).withAlpha(0.18f);
+        const juce::Colour selectedCol = XOceanus::AccentColors::chainAccent;  // #6CEBF4 AAA
+
+        for (int i = 0; i < 16; ++i)
+        {
+            const float cx = r.getX() + static_cast<float>(i) * cellW;
+            const juce::Rectangle<float> cell(cx + 1.0f, r.getY() + 1.0f, cellW - 2.0f, cellH - 2.0f);
+
+            const PadChordSlot slot = cm_.getPadChord(i);
+            const bool isSelected = (i == selectedPadIndex_);
+
+            // Background tint
+            if (slot.active)
+            {
+                g.setColour((isSelected ? selectedCol : activeCol).withAlpha(0.10f));
+                g.fillRoundedRectangle(cell, 2.0f);
+            }
+
+            // Border
+            const juce::Colour borderCol = isSelected
+                ? selectedCol.withAlpha(0.60f)
+                : (slot.active ? activeCol.withAlpha(0.28f) : inactiveCol);
+            g.setColour(borderCol);
+            g.drawRoundedRectangle(cell, 2.0f, 1.0f);
+
+            // Root letter label (WCAG AAA: chainBright on dark bg = 13.5:1)
+            if (slot.active)
+            {
+                const juce::String rootLetter = ChordMachine::midiNoteToName(slot.rootNote);
+                g.setFont(font);
+                g.setColour(isSelected ? selectedCol : activeCol.withAlpha(0.85f));
+                g.drawText(rootLetter, cell.toNearestInt(), juce::Justification::centred, false);
+            }
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    /// B2: Paint the scale-degree readout (ScaleDegree mode).
+    /// Shows Roman numerals for all scale degrees; highlights the last-triggered degree.
+    void paintDegreeReadout(juce::Graphics& g, const juce::Font& font) const
+    {
+        const auto& r = degreeReadoutBounds_;
+        const int scaleIdx = cm_.getGlobalScaleIndex();
+        const int degreeCount = kScaleIntervalCount[std::max(0, std::min(scaleIdx, kNumScaleTypes - 1))];
+        if (degreeCount <= 0) return;
+
+        const float cellW = r.getWidth() / static_cast<float>(degreeCount);
+        const float cellH = r.getHeight();
+        const int lastDegree = cm_.getLastIncomingDegree();
+
+        // AAA color for active degree: chainBright (#90F2FA, 13.5:1)
+        const juce::Colour activeCol   = XOceanus::AccentColors::chainBright;
+        const juce::Colour inactiveCol = juce::Colour(200, 204, 216).withAlpha(0.35f);
+
+        for (int d = 0; d < degreeCount; ++d)
+        {
+            const float cx = r.getX() + static_cast<float>(d) * cellW;
+            const juce::Rectangle<float> cell(cx + 1.0f, r.getY() + 1.0f, cellW - 2.0f, cellH - 2.0f);
+            const bool isActive = (d == lastDegree);
+
+            if (isActive)
+            {
+                g.setColour(activeCol.withAlpha(0.12f));
+                g.fillRoundedRectangle(cell, 2.0f);
+                g.setColour(activeCol.withAlpha(0.45f));
+                g.drawRoundedRectangle(cell, 2.0f, 1.0f);
+            }
+
+            // Compute Roman numeral for this degree
+            const bool minorQ = isDegreeMinorQuality(d, scaleIdx);
+            const char* roman = degreeRomanNumeral(d, scaleIdx, minorQ);
+
+            g.setFont(font);
+            g.setColour(isActive ? activeCol : inactiveCol);
+            g.drawText(juce::String(roman), cell.toNearestInt(), juce::Justification::centred, false);
+        }
+    }
+
     //==========================================================================
     void resized() override
     {
@@ -552,6 +663,27 @@ private:
         addPill(RegionType::ModeLive, 30.0f);
         addPill(RegionType::ModeSeq,  28.0f);
         addPill(RegionType::ModeEno,  28.0f);
+        addSep();
+
+        // ── B2: Input mode pills: AUTO / PAD / DEG ──
+        addPill(RegionType::InputAuto, 32.0f);
+        addPill(RegionType::InputPad,  28.0f);
+        addPill(RegionType::InputDeg,  28.0f);
+
+        // ── B2: Pad grid / degree readout — use remaining width to right of pills ──
+        // Only occupies space when the respective mode is active.
+        addSep();
+        const float remainW = static_cast<float>(getWidth() > 0 ? getWidth() : 800) - curX - padX;
+        padGridBounds_      = juce::Rectangle<float>{};
+        degreeReadoutBounds_ = juce::Rectangle<float>{};
+        if (currentInputMode_ == InputMode::Pad && remainW > 80.0f)
+        {
+            padGridBounds_ = juce::Rectangle<float>(curX, midY - 8.0f, remainW, 16.0f);
+        }
+        else if (currentInputMode_ == InputMode::Deg && remainW > 40.0f)
+        {
+            degreeReadoutBounds_ = juce::Rectangle<float>(curX, midY - 8.0f, remainW, 16.0f);
+        }
     }
 
     //==========================================================================
@@ -580,6 +712,22 @@ private:
         if (miniPianoBounds_.expanded(4.0f).contains(mx, my))
         {
             handleRootCycle(+1);
+            return;
+        }
+
+        // ── B2: Pad grid click ──
+        if (currentInputMode_ == InputMode::Pad && !padGridBounds_.isEmpty()
+            && padGridBounds_.expanded(4.0f).contains(mx, my))
+        {
+            const float cellW = padGridBounds_.getWidth() / 16.0f;
+            const int padIdx  = juce::jlimit(0, 15,
+                static_cast<int>((mx - padGridBounds_.getX()) / cellW));
+
+            if (e.mods.isRightButtonDown())
+                showPadEditMenu(padIdx);
+            else
+                selectedPadIndex_ = padIdx;
+            repaint();
             return;
         }
     }
@@ -802,11 +950,118 @@ private:
             syncModeToApvts();
             break;
 
+        // ── B2: Input mode pills ──
+        case RegionType::InputAuto:
+            currentInputMode_ = InputMode::Auto;
+            syncInputModeToApvts();
+            break;
+
+        case RegionType::InputPad:
+            currentInputMode_ = InputMode::Pad;
+            syncInputModeToApvts();
+            break;
+
+        case RegionType::InputDeg:
+            currentInputMode_ = InputMode::Deg;
+            syncInputModeToApvts();
+            break;
+
         default:
             break;
         }
 
         repaint();
+    }
+
+    //--------------------------------------------------------------------------
+    /// B2: Show right-click popup menu to edit a pad chord slot.
+    /// Popup is message-thread only — no audio-thread access.
+    void showPadEditMenu(int padIdx)
+    {
+        const PadChordSlot current = cm_.getPadChord(padIdx);
+
+        juce::PopupMenu menu;
+        menu.addSectionHeader("Pad " + juce::String(padIdx + 1) + " — Edit Chord");
+
+        // Root note submenu (C0–B5 range, chromatic)
+        juce::PopupMenu rootMenu;
+        static constexpr const char* kNoteNames[12] = {
+            "C","C#","D","D#","E","F","F#","G","G#","A","A#","B"
+        };
+        // Show 3 octaves: 48-83 (C3-B5) as a reasonable playable range
+        for (int oct = 3; oct <= 5; ++oct)
+        {
+            for (int semi = 0; semi < 12; ++semi)
+            {
+                const int midiNote = oct * 12 + semi;
+                const juce::String name = juce::String(kNoteNames[semi]) + juce::String(oct);
+                const bool isCurrent    = (midiNote == current.rootNote);
+                rootMenu.addItem(1000 + midiNote, name, true, isCurrent);
+            }
+        }
+        menu.addSubMenu("Root Note", rootMenu);
+
+        // Voicing submenu
+        juce::PopupMenu voicingMenu;
+        for (int v = 0; v < kNumVoicings; ++v)
+        {
+            const bool isCurrent = (static_cast<int>(current.voicing) == v);
+            voicingMenu.addItem(2000 + v, juce::String(kVoicingNames[v]), true, isCurrent);
+        }
+        menu.addSubMenu("Voicing", voicingMenu);
+
+        // Inversion
+        juce::PopupMenu invMenu;
+        static constexpr const char* kInvNames[] = { "Root Position", "1st Inversion", "2nd Inversion", "3rd Inversion" };
+        for (int i = 0; i < 4; ++i)
+            invMenu.addItem(3000 + i, kInvNames[i], true, (current.inversion == i));
+        menu.addSubMenu("Inversion", invMenu);
+
+        // Active toggle
+        menu.addSeparator();
+        menu.addItem(4000, current.active ? "Silence this pad" : "Activate this pad");
+
+        // Sync callback: writes APVTS params for the selected pad slot.
+        // We copy padIdx into a lambda — menu runs async on message thread.
+        const int capturedPadIdx = padIdx;
+        menu.showMenuAsync(juce::PopupMenu::Options{}.withTargetComponent(this),
+            [this, capturedPadIdx, current](int result)
+            {
+                if (result <= 0) return; // dismissed
+
+                PadChordSlot updated = current;
+
+                if (result >= 1000 && result < 2000)
+                    updated.rootNote = result - 1000;
+                else if (result >= 2000 && result < 3000)
+                    updated.voicing = static_cast<VoicingMode>(result - 2000);
+                else if (result >= 3000 && result < 4000)
+                    updated.inversion = result - 3000;
+                else if (result == 4000)
+                    updated.active = !current.active;
+
+                // Write through APVTS (3 params per slot: root, voicing, inv)
+                const juce::String prefix = "chord_pad_" + juce::String(capturedPadIdx) + "_";
+                if (auto* p = apvts_.getParameter(prefix + "root"))
+                {
+                    p->beginChangeGesture();
+                    p->setValueNotifyingHost(p->convertTo0to1(static_cast<float>(updated.rootNote)));
+                    p->endChangeGesture();
+                }
+                if (auto* p = apvts_.getParameter(prefix + "voicing"))
+                {
+                    p->beginChangeGesture();
+                    p->setValueNotifyingHost(p->convertTo0to1(static_cast<float>(updated.voicing)));
+                    p->endChangeGesture();
+                }
+                if (auto* p = apvts_.getParameter(prefix + "inv"))
+                {
+                    p->beginChangeGesture();
+                    p->setValueNotifyingHost(p->convertTo0to1(static_cast<float>(updated.inversion)));
+                    p->endChangeGesture();
+                }
+                repaint();
+            });
     }
 
     //--------------------------------------------------------------------------
@@ -833,6 +1088,22 @@ private:
         // ENO mode doesn't have a dedicated param — track locally.
     }
 
+    //--------------------------------------------------------------------------
+    /// B2: Push input mode selection to APVTS.
+    void syncInputModeToApvts()
+    {
+        if (auto* p = apvts_.getParameter("chord_input_mode"))
+        {
+            p->beginChangeGesture();
+            p->setValueNotifyingHost(p->convertTo0to1(static_cast<float>(currentInputMode_)));
+            p->endChangeGesture();
+        }
+
+        if (onInputModeChanged)
+            onInputModeChanged(currentInputMode_);
+    }
+
+
     //==========================================================================
     // ── Pill active state & labels ──
 
@@ -849,6 +1120,10 @@ private:
         case RegionType::ModeLive:  return (currentMode_ == ChordMode::Live);
         case RegionType::ModeSeq:   return (currentMode_ == ChordMode::Seq);
         case RegionType::ModeEno:   return (currentMode_ == ChordMode::Eno);
+        // B2: input mode pills
+        case RegionType::InputAuto: return (currentInputMode_ == InputMode::Auto);
+        case RegionType::InputPad:  return (currentInputMode_ == InputMode::Pad);
+        case RegionType::InputDeg:  return (currentInputMode_ == InputMode::Deg);
         default:                    return false;
         }
     }
@@ -863,10 +1138,14 @@ private:
         case RegionType::Rhythm:   return juce::String(kRhythmNames[currentRhythm_]).toUpperCase();
         case RegionType::VelCurve: return juce::String(kVelCurveNames[currentVelCurve_]).toUpperCase();
         case RegionType::Duck:     return "DUCK";
-        case RegionType::ModeLive: return "LIVE";
-        case RegionType::ModeSeq:  return "SEQ";
-        case RegionType::ModeEno:  return "ENO";
-        default:                   return {};
+        case RegionType::ModeLive:  return "LIVE";
+        case RegionType::ModeSeq:   return "SEQ";
+        case RegionType::ModeEno:   return "ENO";
+        // B2: input mode pills
+        case RegionType::InputAuto: return "AUTO";
+        case RegionType::InputPad:  return "PAD";
+        case RegionType::InputDeg:  return "DEG";
+        default:                    return {};
         }
     }
 
@@ -922,6 +1201,11 @@ private:
         // Root: derive from cm_.getLiveRoot() semitone class.
         const int liveRoot  = cm_.getLiveRoot();
         currentRoot_ = ((liveRoot % 12) + 12) % 12;
+
+        // B2: input mode
+        const int modeInt = readInt("chord_input_mode");
+        if (modeInt >= 0 && modeInt < static_cast<int>(InputMode::NumModes))
+            currentInputMode_ = static_cast<InputMode>(modeInt);
     }
 
     //==========================================================================
@@ -967,6 +1251,10 @@ private:
     // Timer state
     bool lastSeqRunning_ = false;
 
+    // B2: Input mode state
+    InputMode  currentInputMode_ = InputMode::Auto;
+    int        selectedPadIndex_ = 0;  // selected pad in PadPerChord mode
+
     // Drag state
     RegionType activeSliderType_ = RegionType::None;
     RegionType hoveredRegion_    = RegionType::None;
@@ -987,6 +1275,10 @@ private:
     SliderRegion               swingSlider_   {};
     SliderRegion               gateSlider_    {};
     SliderRegion               humanSlider_   {};
+
+    // B2: pad grid and degree readout bounds (computed in layoutControls)
+    juce::Rectangle<float>     padGridBounds_        {};
+    juce::Rectangle<float>     degreeReadoutBounds_  {};
 
     //==========================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ChordBarComponent)

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -446,6 +446,22 @@ void XOceanusProcessor::cacheParameterPointers()
     cachedParams.cmHumanize = apvts.getRawParameterValue("cm_humanize");
     cachedParams.cmSidechainDuck = apvts.getRawParameterValue("cm_sidechain_duck");
     cachedParams.cmEnoMode = apvts.getRawParameterValue("cm_eno_mode");
+
+    // B2: input mode + global key/scale + 48 pad chord params
+    cachedParams.cmInputMode   = apvts.getRawParameterValue("chord_input_mode");
+    cachedParams.cmGlobalRoot  = apvts.getRawParameterValue("cm_global_root");
+    cachedParams.cmGlobalScale = apvts.getRawParameterValue("cm_global_scale");
+    for (int i = 0; i < 16; ++i)
+    {
+        const juce::String prefix = "chord_pad_" + juce::String(i) + "_";
+        cachedParams.padChords[i].root    = apvts.getRawParameterValue(prefix + "root");
+        cachedParams.padChords[i].voicing = apvts.getRawParameterValue(prefix + "voicing");
+        cachedParams.padChords[i].inv     = apvts.getRawParameterValue(prefix + "inv");
+        jassert(cachedParams.padChords[i].root    != nullptr);
+        jassert(cachedParams.padChords[i].voicing != nullptr);
+        jassert(cachedParams.padChords[i].inv     != nullptr);
+    }
+
     cachedParams.ohmCommune = apvts.getRawParameterValue("ohm_macroCommune");
     cachedParams.obblBond = apvts.getRawParameterValue("obbl_macroBond");
     cachedParams.oleDrama = apvts.getRawParameterValue("ole_macroDrama");
@@ -707,6 +723,58 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
                                                                  juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
     params.push_back(
         std::make_unique<juce::AudioParameterBool>(juce::ParameterID("cm_eno_mode", 1), "CM Eno Mode", false));
+
+    // ── B2: Chord input mode + global key/scale ───────────────────────────────
+    params.push_back(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("chord_input_mode", 1), "Chord Input Mode",
+        juce::StringArray{"AUTO", "PAD", "DEG"}, 0)); // default = AutoHarmonize
+
+    params.push_back(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("cm_global_root", 1), "CM Global Root",
+        juce::StringArray{"C","C#","D","D#","E","F","F#","G","G#","A","A#","B"}, 0)); // C
+
+    params.push_back(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID("cm_global_scale", 1), "CM Global Scale",
+        juce::StringArray{"Chromatic","Major","Minor","Dorian","Mixolydian",
+                          "Pent Min","Pent Maj","Blues","Harm Min"}, 1)); // Major
+
+    // ── B2: Pad chord slots — 16 pads × 3 params = 48 params ─────────────────
+    // Build the voicing string array once (reused for all 16 pads)
+    {
+        juce::StringArray voicingChoices{
+            "ROOT-SPREAD","DROP-2","QUARTAL","UPPER-STRUCT","UNISON",
+            "QUARTAL-3","QUARTAL-4","QUINTAL-3","QUINTAL-4",
+            "HIJAZ","BHAIRAVI","YO","IN","PHRYG-DOM",
+            "DRONE-P5","DRONE-P4","DRONE-M3","DRONE-m3","DRONE-M2","DRONE-m2"
+        };
+
+        // Default roots follow the C major scale degrees for pads 0-7:
+        // C D E F G A B C (pads 0-7), then repeat for pads 8-15
+        static constexpr int kDefaultRoots[16] = {
+            60, 62, 64, 65, 67, 69, 71, 72,  // C4 D4 E4 F4 G4 A4 B4 C5
+            60, 62, 64, 65, 67, 69, 71, 72   // repeat (pads 8-15)
+        };
+
+        for (int i = 0; i < 16; ++i)
+        {
+            const juce::String prefix = "chord_pad_" + juce::String(i) + "_";
+
+            params.push_back(std::make_unique<juce::AudioParameterInt>(
+                juce::ParameterID(prefix + "root", 1),
+                "Chord Pad " + juce::String(i + 1) + " Root",
+                0, 127, kDefaultRoots[i]));
+
+            params.push_back(std::make_unique<juce::AudioParameterChoice>(
+                juce::ParameterID(prefix + "voicing", 1),
+                "Chord Pad " + juce::String(i + 1) + " Voicing",
+                voicingChoices, 0)); // default = RootSpread
+
+            params.push_back(std::make_unique<juce::AudioParameterInt>(
+                juce::ParameterID(prefix + "inv", 1),
+                "Chord Pad " + juce::String(i + 1) + " Inversion",
+                0, 3, 0)); // default = root position
+        }
+    }
 
     // Master FX parameters
     // Stage 1: Saturation
@@ -1434,6 +1502,27 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         const auto newPat = static_cast<RhythmPattern>(static_cast<int>(cachedParams.cmSeqPattern->load()));
         if (newPat != chordMachine.getPattern())
             chordMachine.applyPattern(newPat);
+    }
+
+    // ── B2: Sync chord input mode + global key/scale + pad chord slots ─────────
+    if (cachedParams.cmInputMode)
+        chordMachine.setInputMode(static_cast<ChordInputMode>(
+            static_cast<int>(cachedParams.cmInputMode->load())));
+    if (cachedParams.cmGlobalRoot)
+        chordMachine.setGlobalRootKey(static_cast<int>(cachedParams.cmGlobalRoot->load()));
+    if (cachedParams.cmGlobalScale)
+        chordMachine.setGlobalScaleIndex(static_cast<int>(cachedParams.cmGlobalScale->load()));
+    // Sync 16 pad chord slots from APVTS (block-constant snapshot, no allocation)
+    for (int i = 0; i < 16; ++i)
+    {
+        if (cachedParams.padChords[i].root != nullptr)
+        {
+            chordMachine.setPadChord(
+                i,
+                static_cast<int>(cachedParams.padChords[i].root->load()),
+                static_cast<VoicingMode>(static_cast<int>(cachedParams.padChords[i].voicing->load())),
+                static_cast<int>(cachedParams.padChords[i].inv->load()));
+        }
     }
 
     // Sync MPE manager from cached APVTS parameters (no hash lookups)

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -502,6 +502,21 @@ private:
         std::atomic<float>* cmHumanize = nullptr;
         std::atomic<float>* cmSidechainDuck = nullptr;
         std::atomic<float>* cmEnoMode = nullptr;
+
+        // B2: input mode + global key/scale
+        std::atomic<float>* cmInputMode   = nullptr; // chord_input_mode (0=AUTO, 1=PAD, 2=DEG)
+        std::atomic<float>* cmGlobalRoot  = nullptr; // cm_global_root (0-11)
+        std::atomic<float>* cmGlobalScale = nullptr; // cm_global_scale (0-8)
+
+        // B2: pad chord slots (16 × 3 params)
+        struct PadChordParams
+        {
+            std::atomic<float>* root    = nullptr; // chord_pad_N_root   [0,127]
+            std::atomic<float>* voicing = nullptr; // chord_pad_N_voicing [0,NumModes-1]
+            std::atomic<float>* inv     = nullptr; // chord_pad_N_inv    [0,3]
+        };
+        std::array<PadChordParams, 16> padChords;
+
         // Family bleed params — cached to avoid string lookups on audio thread
         std::atomic<float>* ohmCommune = nullptr;
         std::atomic<float>* obblBond = nullptr;


### PR DESCRIPTION
## Summary

- **AutoHarmonize** (default): existing behavior preserved — incoming note is chord root, uses current palette + voicing. Zero regression risk.
- **PadPerChord**: 16-slot pad grid; each slot stores (rootNote, voicingMode, inversion). Pad index = `noteNumber % 16`. Silent pads skip chord output. Right-click popup editor per pad (root in C3-B5 range, voicing dropdown, inversion 0-3).
- **ScaleDegree**: incoming note maps to scale degree via `scaleDegreeFromNote()` → chord root = that degree's note in the global key/scale via `chordRootForDegree()`. Uses 9 scale types matching PlaySurface NoteInputZone order (frozen index contract).

## New files

- `Source/Core/ScaleHelpers.h` — pure interval tables + helpers: `scaleDegreeFromNote()`, `chordRootForDegree()`, `isNoteInScale()`, `isDegreeMinorQuality()`, `degreeRomanNumeral()`. All RT-safe, no allocation, no JUCE dependency.

## APVTS changes

- `chord_input_mode` — choice (AUTO/PAD/DEG), default 0 (AUTO)
- `cm_global_root` — choice 0-11 (C–B), default C
- `cm_global_scale` — choice 0-8, default Major
- 48 pad chord params: `chord_pad_N_root` (int 0-127), `chord_pad_N_voicing` (choice), `chord_pad_N_inv` (int 0-3) for N=0..15
- Total: 51 new APVTS params. Registered via loop in `createParameterLayout()`. No ID collision with existing `cm_` group.

## UI

- 3-pill segmented control (AUTO/PAD/DEG) in ChordBarComponent header, right of ENO pill
- Active pill: `AccentColors::chainBright` (#90F2FA, 13.5:1 WCAG AAA against dark bg)
- PadPerChord: 16-pad chord grid in remaining header width; root letter per pad; right-click popup editor
- ScaleDegree: Roman-numeral degree readout (I ii iii IV V vi vii°); live-degree highlighted from `cm_.getLastIncomingDegree()`
- `onInputModeChanged` callback for testability

## Test plan

- [ ] CI build passes (no xcodeproj in worktree; CI builds from CMake)
- [ ] AutoHarmonize: incoming C4 (note 60), key C major → `distribute(60, pal, voic, spr, vel)` identical to pre-B2 behavior
- [ ] PadPerChord: note 60 → pad 12 (60%16=12), if padChords_[12].rootNote=67 → `distribute(67, ...)` called
- [ ] ScaleDegree: note 62 (D4), key C major → degree=1 → root=62 (D) → `distribute(62, ...)` with current voicing
- [ ] 48 pad-chord APVTS params resolve (jassert guards in cacheParameterPointers)
- [ ] Pad right-click editor writes APVTS params, repaint triggered
- [ ] Degree readout highlights correct degree on note trigger
- [ ] No crash when input mode changes during playback (atomic sync per-block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)