### PR TITLE
fix: FATHOM Tier 1 CRITs — Ohm/Ottoni/Obiont/Offering

### DIFF
--- a/Source/Engines/Obiont/ObiontEngine.h
+++ b/Source/Engines/Obiont/ObiontEngine.h
@@ -1428,8 +1428,11 @@ public:
         const float ruleMorph = std::clamp(p_ruleMorph->load(), 0.f, 1.f);
         const float baseEvoRate = p_evolutionRate->load();
         const float macroEvo = p_macroEvolution ? p_macroEvolution->load() : 0.5f;
-        // EVOLUTION macro scales the evolution rate 0.1x..4x around the base
-        const float evoRate = baseEvoRate * (0.1f + macroEvo * 3.9f);
+        // EVOLUTION macro scales the evolution rate 0.1x..4x around the base.
+        // Hard cap at 50 Hz: above this CA evolution produces no audible timbral
+        // change but burns CPU proportionally. 50 Hz = one evolve() per 882 samples
+        // at 44100 Hz — generous headroom for the mod matrix EvolutionRate destination.
+        const float evoRate = std::min(baseEvoRate * (0.1f + macroEvo * 3.9f), 50.0f);
         // gridDensity is read directly by handleNoteOn() from p_gridDensity;
         // not needed in the render-loop ParamSnapshot.
         const float baseChaos = p_chaos->load();

--- a/Source/Engines/Offering/OfferingEngine.h
+++ b/Source/Engines/Offering/OfferingEngine.h
@@ -366,8 +366,8 @@ public:
 
         // Per-sample scratch buffers for this engine's render + FX chain.
         // 4096 samples handles 96kHz at large buffer sizes (~42ms); guarded by safeSamples.
-        // NOTE: OfferingCityProcessor::process() allocates a shadow[2048] for blend mode,
-        // so the effective city-blend limit is 2048 samples. safeSamples is capped there too.
+        // OfferingCityProcessor::process() allocates shadow[4096] — matches this buffer.
+        // Both are guarded by safeSamples = min(numSamples, 4096).
         float scrL[4096];
         float scrR[4096];
         // Per-sample mono mix buffer for city processing.

--- a/Source/Engines/Ohm/OhmEngine.h
+++ b/Source/Engines/Ohm/OhmEngine.h
@@ -665,8 +665,9 @@ public:
                 // Exponential release: coefficient gives -60 dB in 0.3 s at any sample rate.
                 // DSP FIX F12/F13: relCoeff now precomputed once per block (above).
                 if (v.releasing)
+                {
                     v.ampEnv *= relCoeff;
-                    v.ampEnv *= relCoeff; // hoisted — block-constant from sr
+                }
                 if (v.ampEnv < 0.0001f && v.releasing)
                 {
                     v.active = false;

--- a/Source/Engines/Ottoni/OttoniEngine.h
+++ b/Source/Engines/Ottoni/OttoniEngine.h
@@ -393,11 +393,7 @@ public:
 
                 // Exponential release — eliminates the "soft note releases fast"
                 // bug from linear subtraction on small ampEnv values.
-                // PERF-1/SOUND-4 fix: use cached releaseCoeff (computed once in prepare())
-                // instead of calling std::exp() per-sample, which was a hot-path overhead.
-                if (v.releasing)
-                    v.ampEnv *= v.releaseCoeff;
-                // releaseCoeff precomputed at block start (block-constant from sampleRate).
+                // Block-constant releaseCoeff precomputed at block start (line ~356).
                 if (v.releasing)
                     v.ampEnv *= releaseCoeff;
                 v.ampEnv = flushDenormal(v.ampEnv);


### PR DESCRIPTION
## Summary

Four CRIT-tier audio defects unblocking engine testing:

- **Ohm** (`OhmEngine.h:667`): missing brace + double `ampEnv` decay caused every active voice to apply `relCoeff` twice per sample regardless of release state — notes died in ~0.3s.
- **Ottoni** (`OttoniEngine.h:394`): cached per-voice `releaseCoeff` caused the block-constant coefficient to be applied twice, halving release time.
- **Obiont** (`ObiontEngine.h:1429`): cap `evoRate` at 50 Hz to prevent CPU bomb at max EVOLUTION macro (was potentially 200 Hz CA evolve calls). The `modEvoRateMul` clamp at line 1563 is already present; chain is now complete.
- **Offering** (`OfferingEngine.h:369`): align stale comment with already-landed `shadow[4096]` fix (functional change was upstream).

Refs: FATHOM iteration-2 audit, see workspace `crit-fix-patches.md` (Tier 1).

## Test plan

- [ ] Build passes (`auval` clean)
- [ ] Sustained note on Ohm — does not decay in ~0.3s
- [ ] Long release setting on Ottoni — duration matches param value
- [ ] Drive Obiont EVOLUTION macro to max — CPU stays bounded
- [ ] Offering still renders at 96kHz without OOB on `shadow` buffer