### PR TITLE
fix(Oxytocin): L2 audit CRITs (wobble 129x, passion lock) + P37 SR guards

### DIFF
--- a/Source/Engines/Oxytocin/OxytocinEngine.h
+++ b/Source/Engines/Oxytocin/OxytocinEngine.h
@@ -185,6 +185,12 @@ public:
     {
         juce::ScopedNoDenormals noDenormals;
         const int numSamples = buffer.getNumSamples();
+        // P37 guard: sr = 0.0 before prepare() is called (sentinel default at line 368).
+        // If a DAW sends a probe block before prepareToPlay(), blockTime = numSamples / 0.0 = +Inf.
+        // OxytocinMemory::update() receives +Inf as blockTime, computing learnRate = +Inf and
+        // corrupting the persistent memory state (memI/memP/memC all become +Inf → NaN).
+        // Return clear silence; the jassert below still catches un-prepared usage in Debug builds.
+        if (sr <= 0.0) { buffer.clear(); return; }
         jassert(numSamples <= allocatedBlockSize); // P0-1: guard
         // ADDITIVE: render into scratch, then add to output buffer at end
         juce::FloatVectorOperations::clear(scratchL.getData(), numSamples);
@@ -208,9 +214,17 @@ public:
                 aftertouch(msg.getAfterTouchValue());
         }
 
-        // D006: apply mod wheel and aftertouch to this block's snap
-        snap.entanglement = std::clamp(snap.entanglement + modWheelValue * 0.5f, 0.0f, 1.0f);
-        snap.passion = std::clamp(snap.passion + aftertouchValue * 0.3f, 0.0f, 1.0f);
+        // D006: apply mod wheel and aftertouch — compute effective values LOCALLY.
+        // CF-1 fix: snap is a ParamSnapshot that represents the knob/host position for
+        // this block.  If we overwrite snap.passion/entanglement in-place the mutation
+        // accumulates each block (sticky mod wheel → passion climbs to max and stays
+        // there, making the knob feel stuck).  The mutated snap also feeds applyBoost()
+        // through the voice loop, causing memory to record inflated values which then
+        // re-inflate future blocks — a slow-onset compound effect that emerges after
+        // ~30 s of play.  Fix: compute one-shot local scalars; thread them into voiceSnap
+        // after the copy so snap itself is never modified.
+        const float effectiveEntanglement = std::clamp(snap.entanglement + modWheelValue * 0.5f, 0.0f, 1.0f);
+        const float effectivePassion      = std::clamp(snap.passion      + aftertouchValue * 0.3f, 0.0f, 1.0f);
 
         // Honour voice count from param
         int maxV = std::clamp(snap.voices, 1, MaxVoices);
@@ -258,11 +272,20 @@ public:
             // F05/F06: fastPow2 pre-computed above; * (1.0f/12.0f) avoids per-call division
             voiceSnap.cutoff *= lfo1CutoffMult;
 
+            // CF-1 fix: thread effective (mod-wheel/aftertouch boosted) values into voiceSnap
+            // rather than reading snap.passion/entanglement which are now left unmutated.
+            voiceSnap.entanglement = effectiveEntanglement;
+            voiceSnap.passion      = effectivePassion;
+
             // LFO2 → triangle position modulates I/P/C balance
-            // Blend snap params toward triangle coords by lfo2 depth
+            // Blend snap params toward triangle coords by lfo2 depth.
+            // Note: voiceSnap.passion is already set to effectivePassion above; the LFO2
+            // blend below replaces it with the triangle-interpolated value (which is the
+            // correct behaviour — LFO2 triangle modulation takes precedence over the raw
+            // effective passion when lfo2Depth > 0).
             float blend = snap.lfo2Depth;
             voiceSnap.intimacy = snap.intimacy * (1.0f - blend) + triangleCoords.I * blend;
-            voiceSnap.passion = snap.passion * (1.0f - blend) + triangleCoords.P * blend;
+            voiceSnap.passion = effectivePassion * (1.0f - blend) + triangleCoords.P * blend;
             voiceSnap.commitment = snap.commitment * (1.0f - blend) + triangleCoords.C * blend;
 
             // D004: pass voice index so detune can spread voices

--- a/Source/Engines/Oxytocin/OxytocinThermal.h
+++ b/Source/Engines/Oxytocin/OxytocinThermal.h
@@ -169,10 +169,13 @@ public:
         {
             // AM approximation of motor flutter (delay-line-free; see updateWarmth()).
             // F13: uses block-rate cached cachedWobbleSin to avoid per-sample sin().
+            // CF-2 fix: the per-sample wobblePhase advance that was here (wobblePhase +=
+            // twoPi * 0.3 / sr) was a half-completed refactor left over after F13 moved
+            // phase advancement to updateWarmth().  Having BOTH advances caused the wobble
+            // oscillator to run ~129x too fast (39 Hz instead of 0.3 Hz), producing an
+            // audible AM distortion artifact rather than capstan flutter on all circuit-aged
+            // patches.  Removed: updateWarmth() is the sole phase owner.
             float wobble = 1.0f + circuitAge * 0.0017f * cachedWobbleSin;
-            wobblePhase += static_cast<float>(juce::MathConstants<double>::twoPi * 0.3 / sr);
-            if (wobblePhase > juce::MathConstants<float>::twoPi)
-                wobblePhase -= juce::MathConstants<float>::twoPi;
             output *= wobble;
         }
 

--- a/Source/Engines/Oxytocin/OxytocinVoice.h
+++ b/Source/Engines/Oxytocin/OxytocinVoice.h
@@ -256,6 +256,13 @@ public:
         if (!isActive())
             return;
 
+        // P37 guard: sr = 0.0 before prepare() (sentinel at line 524).
+        // If the engine receives a probe block before prepareToPlay() sets sr, the
+        // division blockTimeSec = numSamples / sr = +Inf at line 282 propagates into
+        // thermal.updateWarmth(), corrupting the NTC stage state with NaN values.
+        // Canonical guard from OxytocinDrive.h line 53.
+        if (sr <= 0.0) return;
+
         // --- Base frequency ---
         // F03 fix: use fastPow2 (available via FastMath.h, included in OxytocinDrive.h
         // which is included by this file) instead of std::pow — called per active voice


### PR DESCRIPTION
## Summary

Outcome of FATHOM Level 2 deep audit on the Oxytocin engine — fleet leader, score 9.5 — plus consolidation of the P37 invSR NaN-race sweep sites that landed in this engine.

**CRITs (2/2 applied):**

- **CF-2 wobble double-advance** (`OxytocinThermal.h`): capstan `wobblePhase` was advancing both per-block in `updateWarmth()` AND per-sample in `processSample()` — running ~129× too fast as a 39 Hz AM distortion on patches with `circuitAge > 0`. Removed the per-sample advance; `updateWarmth()` is now sole phase owner. Wobble runs at intended 0.3 Hz flutter rate.
- **CF-1 snap mutation + memory compounding** (`OxytocinEngine.h`): in-place writes to `snap.entanglement` / `snap.passion` (lines 212-213) compounded with `OxytocinMemory`'s per-block boost, locking `passion` at the 0.85 cap after ~30-60s of play with sticky mod wheel. Replaced in-place mutation with local `const effectiveX` values threaded into `voiceSnap` (incl. LFO2 blend path). Host knob values now survive blocks.

**P37 SR guards (consolidated):**
- `Engine.h::processBlock()` early return on `sr <= 0` — prevents `blockTime = numSamples / 0 = +Inf` from corrupting `Memory` on pre-prepare probe blocks.
- `Voice.h::processBlock()` same guard — prevents NTC thermal state corruption.
- Pattern matches canonical `OxytocinDrive.h:53` guard.

**Deferred for follow-up:**
- `Reactive.h` `std::tan` per-sample (~352K calls/sec) — needs `fastTan` in `Source/DSP/FastMath.h` first.
- `Engine.h` hard-clip placement (lines 311-315) — audit gave two alternatives; needs decision (remove vs. move post-mix).
- CF-4 `getLastOutput()` mis-scale — needs correct formula definition.

## Test plan

- [ ] Build passes (auval clean)
- [ ] Aged-circuit patch (circuitAge > 0) — wobble audibly slower (0.3 Hz flutter), no AM distortion
- [ ] Sustained play with mod wheel up — passion knob position is respected, doesn't pin to 0.85
- [ ] Probe `prepare(0, sr)` does not corrupt Memory or Thermal state