### PR TITLE
fix(fleet): P34/P36/P37 sweeps — 96kHz buffers + RNG seeds + invSR guards

### DIFF
--- a/Source/Engines/Oblong/OblongEngine.h
+++ b/Source/Engines/Oblong/OblongEngine.h
@@ -474,6 +474,10 @@ public:
 
     void processSample(float level, float& outL, float& outR) noexcept
     {
+        // P37 guard: invSR=0 before prepare() — return silence rather than using
+        // an uninitialised filter coefficient (wrong-SR at 96kHz, not a crash but
+        // semantically wrong for the brief pre-prepare window).
+        if (invSR <= 0.0f) { outL = outR = 0.0f; return; }
         if (level < 0.001f)
         {
             outL = outR = 0.0f;
@@ -549,7 +553,7 @@ public:
 
 private:
     double sr = 0.0;   // Sentinel: must be set by prepare() before use
-    float invSR = 1.0f / 44100.0f;  // overwritten by prepare() — avoids per-sample division
+    float invSR = 0.0f; // Sentinel: set by prepare(). Do NOT init from literal SR (wrong at 96kHz). P37 fix.
     float breathHPCoeff = 0.001f;   // overwritten by prepare() — SR-correct DC-block coefficient
     int mode = 1;
     float tone = 0.5f;
@@ -1035,6 +1039,9 @@ public:
 
     float process(float input, float amount) noexcept
     {
+        // P37 guard: invSR=0 before prepare() — return dry input rather than using
+        // an uninitialised filter coefficient (wrong-SR at 96kHz, no crash but wrong).
+        if (invSR <= 0.0f) return input;
         if (amount < 0.001f)
             return input;
 
@@ -1051,7 +1058,7 @@ public:
 
 private:
     double sr = 0.0;   // Sentinel: must be set by prepare() before use
-    float invSR = 1.0f / 44100.0f;  // overwritten by prepare()
+    float invSR = 0.0f; // Sentinel: set by prepare(). Do NOT init from literal SR (wrong at 96kHz). P37 fix.
     float lpState = 0.0f;
     float lastTone = -1.0f;
     float cachedCoeff = 0.5f;

--- a/Source/Engines/Ostinato/OstinatoEngine.h
+++ b/Source/Engines/Ostinato/OstinatoEngine.h
@@ -663,8 +663,14 @@ private:
 class OstiWaveguideBody
 {
 public:
-    // 4096 samples: supports body delay up to ~93ms at 44.1kHz
-    static constexpr int kMaxDelay = 4096;
+    // 9216 samples: supports body delay up to ~96ms at 96kHz (max instrument = 96ms at that SR).
+    // Instrument table max is 350ms; at 96kHz 350ms needs 33600 samples.
+    // Use 9216 (96000 * 0.096) to cover 96ms while staying within memory budget.
+    // Instruments with bodyDelayMs > 96ms are intentionally clamped — the body resonance
+    // becomes a reverberation at those long delays and the clamp is musically acceptable.
+    // At 44.1kHz, 9216 samples = ~209ms, covering all instrument values.
+    // P34 fix: was 4096 (42.7ms at 96kHz), now 9216 — correct body resonance at 96kHz.
+    static constexpr int kMaxDelay = 9216;
 
     void prepare(double sampleRate) noexcept
     {
@@ -751,7 +757,8 @@ public:
         // back into the delay creates a secondary feedback loop that can cause
         // instability at high reflection settings on the Box body type.
         delayBuffer[writePos] = input + reflected * feedbackGain;
-        writePos = (writePos + 1) & (kMaxDelay - 1);
+        // P34 fix: kMaxDelay=9216 is NOT a power of 2; modulo replaces the bitmask.
+        writePos = (writePos + 1 >= kMaxDelay) ? 0 : writePos + 1;
 
         // Blend dry input with body resonance
         return input * (1.0f - currentBodyAmount) + (delayed + multiTap) * currentBodyAmount;

--- a/Source/Engines/Overgrow/OvergrowEngine.h
+++ b/Source/Engines/Overgrow/OvergrowEngine.h
@@ -377,6 +377,10 @@ public:
     void renderBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi, int numSamples) override
     {
         juce::ScopedNoDenormals noDenormals;
+        // P37 guard: srf=0.0 before prepare() → blockSec=+Inf → engineSilenceTimer=+Inf
+        // which permanently silences the engine even after prepare() fires. Return clear
+        // buffer until prepare() sets srf correctly.
+        if (srf <= 0.0f) { buffer.clear(); return; }
         int noteOnCount = 0;
 
         for (const auto metadata : midi)

--- a/Source/Engines/Overworld/OverworldEngine.h
+++ b/Source/Engines/Overworld/OverworldEngine.h
@@ -296,6 +296,9 @@ public:
         juce::ScopedNoDenormals noDenormals;
         if (numSamples <= 0)
             return;
+        // P37 guard: sr=0.0 before prepare() → eraPhase = +Inf at line 489.
+        // Return silence until prepare() sets sr correctly.
+        if (sr <= 0.0f) { buffer.clear(); return; }
 
         // Build ParamSnapshot from cached atomics
         auto snap = buildSnapshot();

--- a/Source/Engines/Owlfish/ArmorBuffer.h
+++ b/Source/Engines/Owlfish/ArmorBuffer.h
@@ -189,7 +189,12 @@ public:
     bool isActive() const { return armed; }
 
 private:
-    static constexpr int kHistorySize = 2048;
+    // 4096 samples: covers ~42.7ms at 96kHz (was 2048 → 21ms at 96kHz, halving
+    // the effective capture window at higher sample rates). At 44.1kHz, 4096
+    // samples = ~92.9ms of capture history. Using power-of-2 keeps bitmask
+    // arithmetic at lines 83, 98-99, 142-143, 150-151 intact (4096-1=0xFFF valid).
+    // P34 fix: was 2048, doubled to 4096 for correct 96kHz granulator coverage.
+    static constexpr int kHistorySize = 4096;
     static constexpr int kMaxDelay = 22050;
     static constexpr int kNumGrains = 8;
 

--- a/Source/Engines/Oxidize/OxidizeEngine.h
+++ b/Source/Engines/Oxidize/OxidizeEngine.h
@@ -62,8 +62,14 @@ public:
         luts_.initialize();
 
         // Initialise all voices
-        for (auto& v : voices_)
-            v.prepare(sampleRate, maxBlockSize);
+        for (int i = 0; i < static_cast<int>(voices_.size()); ++i)
+        {
+            voices_[i].prepare(sampleRate, maxBlockSize);
+            // P36 fix: differentiate per-voice noise seeds so polyphonic crackle
+            // is independent rather than correlated. Uncorrelated voices produce a
+            // natural "each string ages differently" character.
+            voices_[i].noiseState = static_cast<uint32_t>(i * 31337u) ^ 0xDEAD1234u;
+        }
 
         // Initialise shared sediment reverb
         sediment_.prepare(sampleRate, maxBlockSize);


### PR DESCRIPTION
## Summary

Three orthogonal FATHOM pattern sweeps applied across 6 engines.

**P34 — 96kHz buffer sizing (2 engines):**
- **Ostinato** `kMaxDelay` 4096 → 9216 to preserve ~93ms body-resonance intent at 96kHz. Bitmask `& (kMaxDelay-1)` replaced with conditional wrap (9216 is not power-of-2). Fixes CONGA/BONGOS body delay being clamped to 42.7ms at 96kHz (instrument sounded wrong on supported sample rates).
- **Owlfish** `kHistorySize` 2048 → 4096 (still power-of-2, bitmask preserved).

**P36 — RNG seed mixing (1 engine, 1 deferred):**
- **Oxidize** per-voice `noiseState` seeded from voice index instead of all voices sharing `seed=1`.
- **Origami** noise generator deferred — in-flight PR #1270 already touches that file.

**P37 — invSR NaN race (3 engines, 5 sites):**
- **Overgrow** `renderBlock()` `srf <= 0` guard prevents `engineSilenceTimer = +Inf` permanent silence lock (engine dead until DAW reload).
- **Overworld** `renderBlock()` same guard prevents `eraPhase = +Inf`.
- **Oblong** `BobTextureOsc` + `BobDustTape`: member init `1/44100` → `0` sentinel + per-method guard. Adapted to actual method signatures (`processSample` void vs `process` float).
- Oxytocin sites covered separately in `fathom/oxytocin-l2-and-p37`.

## Test plan

- [ ] Build passes
- [ ] Ostinato CONGA / BONGOS at 96kHz — body delay matches 44.1 kHz character (no instrument identity drift)
- [ ] Owlfish at 96kHz — no buffer-bounds issues
- [ ] Two simultaneous voices on Oxidize — distinct noise character (no shared-seed collapse)
- [ ] Probe `prepare(0, sr)` on Overgrow / Overworld / Oblong — does not lock or NaN

## Followup
- After PR #1270 (Tier 2) merges, apply Origami P36 in a separate small PR.