### PR TITLE
fix(Origami): P36 trailing — per-voice noise seeding (#1254)

### DIFF
--- a/Source/Engines/Origami/OrigamiEngine.h
+++ b/Source/Engines/Origami/OrigamiEngine.h
@@ -447,12 +447,16 @@ public:
         // Build bit-reversal table and twiddle factors for the radix-2 FFT
         buildBitReversalTable();
 
-        // Initialize all voices to clean state
-        for (auto& voice : voices)
+        // Initialize all voices to clean state with per-voice noise seeds.
+        // P36 fix: without per-voice seeding, all 8 voices share the same
+        // noiseGeneratorState=12345u and produce identical noise oscillator
+        // output on simultaneous polyphony — chord noise content sounds mono.
+        for (int i = 0; i < kMaxVoices; ++i)
         {
-            voice.reset();
-            voice.postFilter.reset();
-            voice.postFilter.setMode(CytomicSVF::Mode::LowPass);
+            voices[i].reset();
+            voices[i].postFilter.reset();
+            voices[i].postFilter.setMode(CytomicSVF::Mode::LowPass);
+            voices[i].noiseGeneratorState = static_cast<uint32_t>(i * 31337u) ^ 0xDEAD1234u;
         }
     }
 


### PR DESCRIPTION
## Summary

Trailing P36 site deferred from #1278 because the in-flight Tier 2 PR (#1270) was touching the same file. Tier 2 merged; applying the deferred fix off main.

**The bug**: all 8 `OrigamiVoice` instances share `noiseGeneratorState = 12345u` from the struct default. The engine's `prepare()` calls `voice.reset()` but does not re-seed per voice index, so all voices enter rendering at the same LCG state. Simultaneous polyphony with the noise oscillator dominant produces identical noise across voices — stereo collapses to mono on chord-from-the-start.

**The fix**: per-voice seed in `prepare()` loop using the canonical pattern `(i * 31337u) ^ 0xDEAD1234u` — matching Oxidize from #1278 and Ollotron from prior work.

Mono retrigger paths (single voice without re-prepare) keep the existing `12345u` reset default — acceptable since P36 is specifically a polyphonic-collapse pattern.

## Test plan

- [ ] Build passes
- [ ] Load a pad preset with `origami_oscMix` near 1.0 (noise oscillator dominant)
- [ ] Hold a 3-note chord from the start, pan hard L/R
- [ ] Audible stereo width / scatter (was: stereo null / mono center)

## Refs

- `~/.claude/skills/fathom-workspace/iteration-2/sweep-p36-rng-seed-fleet.md` (Tier 1 Origami site)
- Follows #1278 (Oxidize P36 + sweep batch)
- Closes the FATHOM iteration-2 P36 fleet sweep