### PR TITLE
ci(release): fix YAML ScannerError causing chronic failure on every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -664,25 +664,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Write release notes to a temp file.
+          # A heredoc embedded directly in a `run:` block confuses the GitHub
+          # Actions YAML parser when the heredoc body contains lines that start
+          # with '#' characters (e.g. markdown headers '##' / '###').  The YAML
+          # scanner sees them as mapping-key candidates and raises a
+          # "could not find expected ':'" ScannerError, which causes every push
+          # — including non-tag pushes — to report "This run likely failed
+          # because of a workflow file issue".  Writing via printf sidesteps
+          # the parser entirely.
+          NOTES_FILE="$RUNNER_TEMP/release_notes.md"
+          printf "## XOceanus %s\n\nSigned, notarized, and ready to install on macOS 12 Monterey and later.\n\n### Installation\n\n**AU Plugin (Logic Pro, GarageBand, Ableton Live, Bitwig, etc.)**\n1. Open the DMG and copy \`XOceanus.component\` to \`~/Library/Audio/Plug-Ins/Components/\`\n2. Restart your DAW and scan for new plugins.\n\n**Standalone App**\n1. Open the DMG and drag \`XOceanus.app\` to your \`/Applications/\` folder.\n\n---\n" \
+            "$VERSION" > "$NOTES_FILE"
+
           gh release create "$TAG" \
             --title "XOceanus $TAG" \
-            --notes "$(cat <<'NOTES'
-## XOceanus ${VERSION}
-
-Signed, notarized, and ready to install on macOS 12 Monterey and later.
-
-### Installation
-
-**AU Plugin (Logic Pro, GarageBand, Ableton Live, Bitwig, etc.)**
-1. Open the DMG and copy `XOceanus.component` to `~/Library/Audio/Plug-Ins/Components/`
-2. Restart your DAW and scan for new plugins.
-
-**Standalone App**
-1. Open the DMG and drag `XOceanus.app` to your `/Applications/` folder.
-
----
-NOTES
-)" \
+            --notes-file "$NOTES_FILE" \
             --generate-notes \
             "${DMG_PATH}#XOceanus-${TAG}.dmg (macOS, signed + notarized)"
 


### PR DESCRIPTION
## Root cause

The `release` job's final step embedded a bash heredoc directly inside a YAML `run:` block:

```yaml
run: |
  gh release create "$TAG" \
    --notes "$(cat <<'NOTES'
## XOceanus ${VERSION}
### Installation
...
NOTES
)"
```

The heredoc body contained markdown headers (`##`, `###`). The GitHub Actions YAML parser — which parses the entire workflow file including the content of `run:` blocks — misread those `#`-prefixed lines as YAML mapping-key candidates, raising:

> `yaml.scanner.ScannerError: while scanning a simple key … could not find expected ':'`

GitHub surfaces this as **"This run likely failed because of a workflow file issue"** and triggers the workflow on **every push** (not just tag pushes), causing 6+ days of chronic red noise on main that masked real CI failures.

## Fix

Replace the inline heredoc with a `printf` call that writes the release notes to `$RUNNER_TEMP/release_notes.md`, then pass it via `--notes-file`:

```yaml
run: |
  NOTES_FILE="$RUNNER_TEMP/release_notes.md"
  printf "## XOceanus %s\n\n..." "$VERSION" > "$NOTES_FILE"

  gh release create "$TAG" \
    --notes-file "$NOTES_FILE" \
    --generate-notes \
    ...
```

This avoids the heredoc-inside-YAML issue entirely. The trigger (`on: push: tags: ['v*']`) is unchanged and correct — the workflow will only fire on semantic version tags going forward.

## Verification

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml').read()); print('YAML OK')"` passes cleanly on the fixed file.

---

_From autonomous issue cleanup orchestration._