### PR TITLE
fix(#1281): SeqUpstream — wire sequencer step value as chord-tone selector

### DIFF
--- a/Source/Core/ChordMachine.h
+++ b/Source/Core/ChordMachine.h
@@ -585,12 +585,15 @@ public:
         // into each outputMidi[slot], rewrite slots whose routing mode is not the
         // default (ChordUpstream):
         //
-        //   SeqUpstream  — replace chord-distributed output with raw inputMidi,
-        //                  so the engine's own step-seq / arpeggiator drives timing
-        //                  and pitch without chord expansion.  The engine treats
-        //                  incoming notes as its sequencer triggers (C1 integration
-        //                  point: when PerEnginePatternSequencer lands, it will read
-        //                  from this slot buffer).
+        //   SeqUpstream  — the sequencer drives timing; the chord palette/voicing
+        //                  still shapes the pitch the engine plays.  Each NoteOn in
+        //                  inputMidi is re-pitched to the chord tone assigned to this
+        //                  slot (currentAssignment.midiNotes[slot]).  NoteOff events
+        //                  are likewise re-pitched so the engine receives a matching
+        //                  note-off for the note it was told to play.  All other
+        //                  messages (CC, pitchbend, etc.) are forwarded unchanged.
+        //                  If no chord has been assigned yet (midiNotes[slot] == -1)
+        //                  the slot receives the raw note as a safe fallback.
         //
         //   Parallel     — merge raw inputMidi on top of the chord output so both
         //                  the chord-distributed notes AND the raw input reach the
@@ -606,9 +609,40 @@ public:
 
             if (mode == ChordSeqRoutingMode::SeqUpstream)
             {
-                // Replace chord output with raw input for this slot.
+                // Re-pitch NoteOn/NoteOff to the chord tone for this slot.
+                // All other message types pass through unchanged.
+                const int chordTone = currentAssignment.midiNotes[slot]; // -1 if no chord yet
+
                 outputMidi[slot].clear();
-                outputMidi[slot] = inputMidi;
+                for (const auto metadata : inputMidi)
+                {
+                    const auto msg = metadata.getMessage();
+                    const int samplePos = metadata.samplePosition;
+
+                    if (msg.isNoteOn())
+                    {
+                        // Use the slot's chord tone; fall back to the raw note if no
+                        // chord has been distributed yet (chordTone == -1).
+                        const int targetNote = (chordTone >= 0) ? chordTone : msg.getNoteNumber();
+                        outputMidi[slot].addEvent(
+                            juce::MidiMessage::noteOn(msg.getChannel(), targetNote, msg.getFloatVelocity()),
+                            samplePos);
+                    }
+                    else if (msg.isNoteOff())
+                    {
+                        // Mirror the re-pitch so the engine receives a NoteOff for
+                        // exactly the note it was told to play.
+                        const int targetNote = (chordTone >= 0) ? chordTone : msg.getNoteNumber();
+                        outputMidi[slot].addEvent(
+                            juce::MidiMessage::noteOff(msg.getChannel(), targetNote, msg.getFloatVelocity()),
+                            samplePos);
+                    }
+                    else
+                    {
+                        // CCs, pitchbend, aftertouch, etc. — forward verbatim.
+                        outputMidi[slot].addEvent(msg, samplePos);
+                    }
+                }
             }
             else if (mode == ChordSeqRoutingMode::Parallel)
             {


### PR DESCRIPTION
## Diagnosed root cause

PR #1276 (Wave 5 B3) added `ChordSeqRoutingMode`. The `SeqUpstream` branch in `processBlock()` (lines 607–612 pre-fix) did:

```cpp
outputMidi[slot].clear();
outputMidi[slot] = inputMidi;   // raw passthrough — wrong
```

This contradicts the header-doc spec (lines 131–139) which states:

> *"Implemented by injecting the chord-distributed note of ONLY the slot's own index (i.e. the per-slot chord tone) into the raw-MIDI stream — the engine sees a single note-on/off whose pitch is the chord tone for that slot at the trigger moment."*

Any slot set to `SeqUpstream` would receive unharmonized raw MIDI — the chord palette and voicing had no effect, making the mode identical to bypassing the chord machine entirely.

## Fix applied

`Source/Core/ChordMachine.h` — `processBlock()` SeqUpstream branch:

- Iterate `inputMidi` per slot instead of bulk-copying.
- **NoteOn**: substitute pitch with `currentAssignment.midiNotes[slot]` (the chord tone this slot was assigned). Falls back to the raw note if `midiNotes[slot] == -1` (no chord distributed yet — e.g. on the very first trigger before any NoteOn has been played through ChordMachine).
- **NoteOff**: re-pitch identically so the engine receives a matched note-off for the note it actually played (prevents stuck notes).
- **Everything else** (CC, pitchbend, aftertouch, sysex): forwarded verbatim.

`ChordUpstream` and `Parallel` branches are untouched.

## Verification

1. Load any preset on a 4-slot configuration. Set one slot to `SeqUpstream`, the others to `ChordUpstream`.
2. Play a root note (e.g. C3) to establish a chord (Warm palette = minor-7th → C3, Eb3, G3, Bb3).
3. While holding, trigger additional NoteOn events (e.g. from a MIDI keyboard or step sequencer).
4. **Expected (after fix)**: the `SeqUpstream` slot plays its palette chord-tone (e.g. slot 1 = Eb3) regardless of the incoming trigger pitch — the trigger drives timing, chord shapes pitch.
5. **Previous (broken) behavior**: the `SeqUpstream` slot would play the raw incoming pitch, ignoring the chord entirely.
6. Confirm NoteOff does not produce stuck notes by releasing each trigger cleanly.

Closes #1281