### PR TITLE
feat(Wave5-C5): expose sequencer step values as per-slot ModSources

### DIFF
--- a/Source/DSP/PerEnginePatternSequencer.h
+++ b/Source/DSP/PerEnginePatternSequencer.h
@@ -104,6 +104,8 @@ public:
                 {
                     noteOffCountdown_ = 0;
                     out.addEvent(juce::MidiMessage::noteOff(channel, rootNote), 0);
+                    // C5: gate closed
+                    liveGate_.store(0.0f, std::memory_order_relaxed);
                 }
             }
             return;
@@ -125,6 +127,10 @@ public:
         const int stepIdx = static_cast<int>(std::floor(ppqPosition * stepsPerQuarter))
                             % stepCount;
 
+        // C5: update step-phase every block (even on same step) so mod sources track position.
+        liveStepPhase_.store(static_cast<float>(stepIdx) / static_cast<float>(stepCount),
+                             std::memory_order_relaxed);
+
         // Edge detection: only act when the step index advances
         if (stepIdx == prevStepIdx_)
         {
@@ -136,6 +142,8 @@ public:
                 {
                     noteOffCountdown_ = 0;
                     out.addEvent(juce::MidiMessage::noteOff(channel, rootNote), 0);
+                    // C5: gate closed
+                    liveGate_.store(0.0f, std::memory_order_relaxed);
                 }
             }
             return;
@@ -174,6 +182,16 @@ public:
             noteOffCountdown_ = static_cast<int>(halfStepSecs * sampleRate_);
             // Clamp so noteOff always fires within a reasonable time
             noteOffCountdown_ = juce::jmax(1, noteOffCountdown_);
+
+            // C5: update live state for ModSource consumers
+            liveVelocity_.store(velocity, std::memory_order_relaxed);
+            liveGate_.store(1.0f, std::memory_order_relaxed);
+        }
+        else
+        {
+            // Silent step — gate stays closed, velocity resets to 0
+            liveVelocity_.store(0.0f, std::memory_order_relaxed);
+            liveGate_.store(0.0f, std::memory_order_relaxed);
         }
     }
 
@@ -187,6 +205,23 @@ public:
     void setEnabled(bool e)        { enabled_.store(e, std::memory_order_relaxed); }
     void setRootNote(int n)        { rootNote_.store(juce::jlimit(0, 127, n), std::memory_order_relaxed); }
     void setBaseVelocity(float v)  { baseVelocity_.store(juce::jlimit(0.0f, 1.0f, v), std::memory_order_relaxed); }
+
+    //==========================================================================
+    // Wave 5 C5: Live ModSource read-outs (safe to call from any thread).
+    //
+    // These atomics are written by the audio thread at each step boundary inside
+    // processBlock() and are read by the mod-source evaluation loop (also audio
+    // thread, same processBlock, after sequencer processBlock).  They may also
+    // be read from the message thread for UI meters — a one-block stale value is
+    // acceptable.
+    //
+    // liveVelocity:  current step velocity 0.0–1.0 (0 when gate is off/silent)
+    // liveGate:      1.0 while the gate countdown is active, 0.0 otherwise
+    // liveStepPhase: current step index as a 0.0–1.0 ramp (stepIdx / stepCount)
+
+    float getLiveVelocity()  const noexcept { return liveVelocity_.load(std::memory_order_relaxed); }
+    float getLiveGate()      const noexcept { return liveGate_.load(std::memory_order_relaxed); }
+    float getLiveStepPhase() const noexcept { return liveStepPhase_.load(std::memory_order_relaxed); }
 
     //==========================================================================
     // APVTS integration
@@ -333,6 +368,12 @@ private:
     std::atomic<float> humanization_{0.0f};
     std::atomic<float> baseVelocity_{0.75f};
     std::atomic<int>   rootNote_{60};     // middle C
+
+    // Wave 5 C5: Live ModSource state — written by audio thread, read by mod evaluator.
+    // Atomics allow message-thread reads for UI meters (one-block stale is fine).
+    std::atomic<float> liveVelocity_{0.0f};   // 0.0–1.0; 0 when step is silent
+    std::atomic<float> liveGate_{0.0f};       // 1.0 while noteOffCountdown_ > 0
+    std::atomic<float> liveStepPhase_{0.0f};  // stepIdx / stepCount, 0.0–1.0
 
     //==========================================================================
     // Cached APVTS parameter pointers — resolved once on first syncFromApvts() call.

--- a/Source/Future/UI/ModRouting/DragDropModRouter.h
+++ b/Source/Future/UI/ModRouting/DragDropModRouter.h
@@ -36,6 +36,10 @@ struct ModRoute
     juce::String destParamId; // APVTS parameter ID of the destination
     float depth;              // -1.0 to +1.0
     bool bipolar;             // true = source range is ±1
+    // Wave 5 C5: per-route slot index for sequencer-scoped sources.
+    // -1 = not slot-scoped (all non-sequencer sources, backward-compat default).
+    // 0–3 = which slotSequencer to read from (SeqStepValue, BeatPhase, ChordToneIdx).
+    int slotIndex{-1};
 };
 
 //==============================================================================
@@ -88,7 +92,11 @@ public:
     // Add a route.  Returns the index of the new route, or -1 if the model is
     // full.  If a route from the same source to the same dest already exists,
     // the existing route's depth is updated and its index is returned.
-    int addRoute(int sourceId, const juce::String& destParamId, float depth, bool bipolar = false)
+    //
+    // slotIndex: -1 = not slot-scoped (default, backward-compat).
+    //            0–3 = which PerEnginePatternSequencer slot to read (C5: SeqStepValue etc.)
+    int addRoute(int sourceId, const juce::String& destParamId, float depth, bool bipolar = false,
+                 int slotIndex = -1)
     {
         // Update existing route with the same (source, dest) pair.
         for (int i = 0; i < static_cast<int>(routes.size()); ++i)
@@ -98,6 +106,7 @@ public:
             {
                 routes[static_cast<size_t>(i)].depth = juce::jlimit(-1.0f, 1.0f, depth);
                 routes[static_cast<size_t>(i)].bipolar = bipolar;
+                routes[static_cast<size_t>(i)].slotIndex = slotIndex;
                 notifyListeners();
                 return i;
             }
@@ -112,6 +121,7 @@ public:
         r.destParamId = destParamId;
         r.depth = juce::jlimit(-1.0f, 1.0f, depth);
         r.bipolar = bipolar;
+        r.slotIndex = slotIndex;
         routes.push_back(r);
 
         notifyListeners();
@@ -169,6 +179,8 @@ public:
             child.setProperty("destParamId", r.destParamId, nullptr);
             child.setProperty("depth", r.depth, nullptr);
             child.setProperty("bipolar", r.bipolar, nullptr);
+            // C5: persist slotIndex (-1 for non-slot-scoped routes).
+            child.setProperty("slotIndex", r.slotIndex, nullptr);
             vt.addChild(child, -1, nullptr);
         }
         return vt;
@@ -200,11 +212,18 @@ public:
 
             bool bipolar = static_cast<bool>(int(child.getProperty("bipolar", 0)));
 
+            // C5: restore slotIndex; default -1 for backward-compat with older presets.
+            int slotIdx = static_cast<int>(child.getProperty("slotIndex", -1));
+            // Validate: must be -1 (N/A) or 0–3.
+            if (slotIdx < -1 || slotIdx > 3)
+                slotIdx = -1;
+
             ModRoute r;
             r.sourceId = srcInt;
             r.destParamId = destId;
             r.depth = depth;
             r.bipolar = bipolar;
+            r.slotIndex = slotIdx;
             routes.push_back(r);
         }
         notifyListeners();
@@ -395,8 +414,10 @@ public:
         g.setColour(srcColour);
         g.fillRect(0, 2, 3, height - 4);
 
-        // Source name
+        // Source name — append "S1"–"S4" suffix for slot-scoped sources (C5).
         auto srcName = modSourceName(static_cast<ModSourceId>(r.sourceId));
+        if (r.slotIndex >= 0 && r.slotIndex <= 3)
+            srcName += " S" + juce::String(r.slotIndex + 1);
         g.setFont(GalleryFonts::label(9.5f));
         g.setColour(juce::Colour(GalleryColors::t1()));
         g.drawText(srcName, 8, 0, 70, height, juce::Justification::centredLeft);
@@ -453,9 +474,12 @@ private:
             return;
 
         const auto& r = cachedRoutes[static_cast<size_t>(row)];
+        // C5: include slot suffix if this is a slot-scoped route.
+        juce::String srcLabel = modSourceName(static_cast<ModSourceId>(r.sourceId));
+        if (r.slotIndex >= 0 && r.slotIndex <= 3)
+            srcLabel += " (Slot " + juce::String(r.slotIndex + 1) + ")";
         auto* alert = new juce::AlertWindow("Set Modulation Depth",
-                                            "Enter depth for " + modSourceName(static_cast<ModSourceId>(r.sourceId)) +
-                                                " -> " + r.destParamId,
+                                            "Enter depth for " + srcLabel + " -> " + r.destParamId,
                                             juce::MessageBoxIconType::NoIcon);
         alert->addTextEditor("depth", juce::String(r.depth, 3), "Depth (-1.0 to +1.0):");
         alert->addButton("OK", 1, juce::KeyPress(juce::KeyPress::returnKey));
@@ -667,6 +691,15 @@ public:
             bool bipolar = (payload.sourceId == ModSourceId::LFO1 || payload.sourceId == ModSourceId::LFO2 ||
                             payload.sourceId == ModSourceId::Envelope);
 
+            // C5: slot-scoped sources require a slot picker before committing the route.
+            if (isSlotScopedSource(payload.sourceId))
+            {
+                showSlotPickerForDrop(payload.sourceId, targetParamId, bipolar);
+                // resetDragState is called inside showSlotPickerForDrop's async callback.
+                resetDragState();
+                return;
+            }
+
             model.addRoute(static_cast<int>(payload.sourceId), targetParamId,
                            /* depth = */ 0.5f, bipolar);
         }
@@ -780,7 +813,10 @@ public:
         for (int i = 0; i < static_cast<int>(routes.size()); ++i)
         {
             const auto& r = routes[static_cast<size_t>(i)];
+            // C5: append slot suffix for slot-scoped sources
             auto srcName = modSourceName(static_cast<ModSourceId>(r.sourceId));
+            if (r.slotIndex >= 0 && r.slotIndex <= 3)
+                srcName += " S" + juce::String(r.slotIndex + 1);
             juce::String label = srcName + "   depth: " + juce::String(r.depth, 2);
             menu.addItem(100 + i, label);
         }
@@ -928,8 +964,12 @@ private:
             return;
 
         const auto& r = routes[static_cast<size_t>(routeIndex)];
+        // C5: include slot suffix if this is a slot-scoped route.
+        juce::String srcLabel = modSourceName(static_cast<ModSourceId>(r.sourceId));
+        if (r.slotIndex >= 0 && r.slotIndex <= 3)
+            srcLabel += " (Slot " + juce::String(r.slotIndex + 1) + ")";
         auto* alert = new juce::AlertWindow(
-            "Set Modulation Depth", modSourceName(static_cast<ModSourceId>(r.sourceId)) + " -> " + r.destParamId,
+            "Set Modulation Depth", srcLabel + " -> " + r.destParamId,
             juce::MessageBoxIconType::NoIcon);
 
         alert->addTextEditor("depth", juce::String(r.depth, 3), "Depth (-1.0 to +1.0):");
@@ -948,6 +988,40 @@ private:
                                        delete alert;
                                    }),
                                false);
+    }
+
+    //==========================================================================
+    // C5: Returns true for the three slot-scoped ModSourceIds.
+    static bool isSlotScopedSource(ModSourceId id) noexcept
+    {
+        return id == ModSourceId::SeqStepValue ||
+               id == ModSourceId::BeatPhase    ||
+               id == ModSourceId::ChordToneIdx;
+    }
+
+    // C5: Show a popup menu to choose which sequencer slot (1–4) this route reads from.
+    // On selection, adds the route with the chosen slotIndex.
+    // Called from itemDropped when the dragged source is slot-scoped.
+    void showSlotPickerForDrop(ModSourceId sourceId, const juce::String& destParamId, bool bipolar)
+    {
+        juce::PopupMenu menu;
+        menu.addSectionHeader("Which sequencer slot?");
+        menu.addItem(1, "Slot 1");
+        menu.addItem(2, "Slot 2");
+        menu.addItem(3, "Slot 3");
+        menu.addItem(4, "Slot 4");
+
+        menu.showMenuAsync(juce::PopupMenu::Options{},
+                           [this, sourceId, destParamId, bipolar](int result)
+                           {
+                               if (result >= 1 && result <= 4)
+                               {
+                                   const int slotIndex = result - 1; // 0-based
+                                   model.addRoute(static_cast<int>(sourceId), destParamId,
+                                                  /* depth = */ 0.5f, bipolar, slotIndex);
+                               }
+                               // result == 0 means cancelled — no route added.
+                           });
     }
 
     //==========================================================================

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -2062,9 +2062,38 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     continue;
 
                 // Source value — only LFO1 (id=0) wired in A1.
+                // C5: SeqStepValue / BeatPhase / ChordToneIdx read from slotSequencers_.
                 float srcVal = 0.0f;
                 if (snap.sourceId == static_cast<int>(ModSourceId::LFO1))
+                {
                     srcVal = lfo1Val;
+                }
+                else if (snap.sourceId == static_cast<int>(ModSourceId::SeqStepValue) ||
+                         snap.sourceId == static_cast<int>(ModSourceId::BeatPhase)    ||
+                         snap.sourceId == static_cast<int>(ModSourceId::ChordToneIdx))
+                {
+                    // Validate slot index — guard against stale or bad snapshots.
+                    const int slot = snap.slotIndex;
+                    if (slot < 0 || slot >= kNumPrimarySlots)
+                        continue; // no slot assigned — skip route
+
+                    if (snap.sourceId == static_cast<int>(ModSourceId::SeqStepValue))
+                    {
+                        // Velocity 0.0–1.0 (unipolar from the sequencer's gate).
+                        // Already 0 when the step is silent, so bipolar flag maps to ±.
+                        srcVal = slotSequencers_[static_cast<size_t>(slot)].getLiveVelocity();
+                    }
+                    else if (snap.sourceId == static_cast<int>(ModSourceId::BeatPhase))
+                    {
+                        // Step phase 0.0–1.0 — expose as bipolar -1..+1 by mapping 0..1 → -1..+1.
+                        const float phase = slotSequencers_[static_cast<size_t>(slot)].getLiveStepPhase();
+                        srcVal = phase * 2.0f - 1.0f; // bipolar ramp
+                    }
+                    else // ChordToneIdx — repurposed here as gate state (0 or 1, unipolar)
+                    {
+                        srcVal = slotSequencers_[static_cast<size_t>(slot)].getLiveGate();
+                    }
+                }
                 else
                     continue; // A2 will add remaining sources
 
@@ -2767,10 +2796,11 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
         if (count >= kMaxGlobalRoutes)
             break;
         auto& snap = routesSnapshot_[static_cast<size_t>(count)];
-        snap.sourceId = r.sourceId;
-        snap.depth    = r.depth;
-        snap.bipolar  = r.bipolar;
-        snap.valid    = true;
+        snap.sourceId  = r.sourceId;
+        snap.depth     = r.depth;
+        snap.bipolar   = r.bipolar;
+        snap.valid     = true;
+        snap.slotIndex = r.slotIndex; // C5: per-route slot index (-1 = N/A)
         // Copy dest param ID into fixed-length char array — no std::string on audio thread.
         // juce::String::copyToUTF8 writes at most maxBytes chars (inc. null terminator).
         r.destParamId.copyToUTF8(snap.destParamId, sizeof(snap.destParamId));

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -141,6 +141,14 @@ public:
     // Max routes: ModRoutingModel::MaxRoutes (32).
     void flushModRoutesSnapshot() noexcept;
 
+    // Wave 5 C5: Read-only access to per-slot sequencer live state.
+    // Used by UI components to display live step values; audio thread uses the
+    // atomics directly via slotSequencers_ (private, same translation unit).
+    const XOceanus::PerEnginePatternSequencer& getSlotSequencer(int slot) const noexcept
+    {
+        return slotSequencers_[static_cast<size_t>(juce::jlimit(0, kNumPrimarySlots - 1, slot))];
+    }
+
     // Wave 5 A1: Write the current LFO1 output so the global router can use it
     // as a mod source.  Called from OrreryEngine::renderBlock (audio thread).
     // Use relaxed ordering — a single-sample jitter is acceptable for mod routing.
@@ -780,6 +788,9 @@ private:
         bool    bipolar{false};
         bool    valid{false};
         char    destParamId[64]{};  // fixed-length to avoid std::string on audio thread
+        // Wave 5 C5: per-route slot index for sequencer-scoped sources.
+        // -1 = not slot-scoped (backward-compat default).  0–3 = slot to query.
+        int     slotIndex{-1};
     };
     static constexpr int kMaxGlobalRoutes = ModRoutingModel::MaxRoutes;
     std::array<GlobalModRouteSnapshot, kMaxGlobalRoutes> routesSnapshot_{};


### PR DESCRIPTION
## Summary

- Adds `slotIndex` field to `ModRoute` (default -1, backward-compat). Routes with slot-scoped sources (SeqStepValue / BeatPhase / ChordToneIdx) carry a 0–3 slot index that the audio-thread evaluator uses to query `PerEnginePatternSequencer`.
- `PerEnginePatternSequencer` now writes `liveVelocity_`, `liveGate_`, `liveStepPhase_` atomics each block; exposed via `getLiveVelocity/Gate/StepPhase()`.
- Audio-thread mod evaluator in `processBlock` handles the three new source IDs by reading from `slotSequencers_[slotIndex]`.
- `DragDropModRouter`: dropping a slot-scoped source shows a "Slot 1/2/3/4" popup picker before committing the route. Route list panel and right-click menus show "S1–S4" slot suffix.
- `GlobalModRouteSnapshot` carries `slotIndex` through the lock-free flush path.
- Follow-up issue #1289 filed: step pitch offset sub-dimension blocked on C3.

## Source mapping
| ModSourceId | Live reading |
|---|---|
| SeqStepValue | step velocity 0.0–1.0 |
| BeatPhase | step-phase ramp −1..+1 (0/N → N/N) |
| ChordToneIdx | gate state 0 or 1 |

## Backward-compat
Existing routes have `slotIndex = -1` (or load as -1 from older presets). The new branch in the evaluator does `continue` on `slot < 0`, leaving those routes producing `srcVal = 0.0f` (same as the prior `else continue` path for unrecognized source IDs).

## Test plan
- [ ] Create a route with SeqStepValue and verify slot picker appears on drop
- [ ] Verify Slot 1 label appears in route list panel
- [ ] Load an old preset — confirm no regression (no slot-scoped routes, slotIndex = -1, cutoff mod still works)
- [ ] Enable slot sequencer on slot 0, verify liveVelocity_ / liveGate_ animate in debugger during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)