### PR TITLE
feat(Wave5-C3): per-step gate + pitch offset (Maschine-style drag editing)

### DIFF
--- a/Source/DSP/PerEnginePatternSequencer.h
+++ b/Source/DSP/PerEnginePatternSequencer.h
@@ -96,14 +96,15 @@ public:
 
         if (!enabled || !isPlaying || bpm <= 0.0)
         {
-            // Ensure any pending noteOff still fires even when disabled mid-phrase
+            // Ensure any pending noteOff still fires even when disabled mid-phrase.
+            // C3: use lastSoundingNote_ so pitch-offset notes are released correctly.
             if (noteOffCountdown_ > 0)
             {
                 noteOffCountdown_ -= numSamples;
                 if (noteOffCountdown_ <= 0)
                 {
                     noteOffCountdown_ = 0;
-                    out.addEvent(juce::MidiMessage::noteOff(channel, rootNote), 0);
+                    out.addEvent(juce::MidiMessage::noteOff(channel, lastSoundingNote_), 0);
                 }
             }
             return;
@@ -129,13 +130,14 @@ public:
         if (stepIdx == prevStepIdx_)
         {
             // Same step — count down pending noteOff
+            // C3: use lastSoundingNote_ for correct pitch-offset release
             if (noteOffCountdown_ > 0)
             {
                 noteOffCountdown_ -= numSamples;
                 if (noteOffCountdown_ <= 0)
                 {
                     noteOffCountdown_ = 0;
-                    out.addEvent(juce::MidiMessage::noteOff(channel, rootNote), 0);
+                    out.addEvent(juce::MidiMessage::noteOff(channel, lastSoundingNote_), 0);
                 }
             }
             return;
@@ -143,10 +145,11 @@ public:
 
         // New step has arrived
         // First, flush any pending noteOff from the previous step
+        // C3: use lastSoundingNote_ so pitch-offset notes are released correctly
         if (noteOffCountdown_ > 0)
         {
             noteOffCountdown_ = 0;
-            out.addEvent(juce::MidiMessage::noteOff(channel, rootNote), 0);
+            out.addEvent(juce::MidiMessage::noteOff(channel, lastSoundingNote_), 0);
         }
 
         prevStepIdx_ = stepIdx;
@@ -154,6 +157,36 @@ public:
         // Evaluate whether this step gates (fires a note)
         const Pattern pat = static_cast<Pattern>(juce::jlimit(0, static_cast<int>(Pattern::Count) - 1, patternInt));
         float velocity = computeVelocity(pat, stepIdx, stepCount, baseVel);
+
+        // C3: per-step gate override — if the gate bitmap has ANY bit set, treat it as an
+        // explicit on/off mask for this step (overrides the algorithmic velocity).
+        // Rationale: bitmap==0 means "no overrides active" (default C1/C2 behaviour preserved).
+        // When any override exists, bit i==1 means "force gate on" (keep algorithmic velocity
+        // if > 0, else use baseVel), bit i==0 means "force gate off" (mute this step).
+        {
+            const uint32_t bitmap = stepGateBitmap_.load(std::memory_order_relaxed);
+            if (bitmap != 0u)
+            {
+                const bool gateOverrideOn = (bitmap & (1u << static_cast<unsigned>(stepIdx))) != 0u;
+                if (gateOverrideOn)
+                {
+                    // Step is explicitly forced ON — if algorithmic velocity was zero, use baseVel.
+                    if (velocity <= 0.0f)
+                        velocity = baseVel;
+                }
+                else
+                {
+                    // Step is explicitly forced OFF (muted).
+                    velocity = 0.0f;
+                }
+            }
+        }
+
+        // C3: per-step pitch offset — read the stored semitone delta (±12).
+        // Applied only when the step gates, so we compute the sounding note here.
+        const int pitchOffset = static_cast<int>(stepPitch_[static_cast<size_t>(stepIdx)]
+                                                    .load(std::memory_order_relaxed));
+        const int soundingNote = juce::jlimit(0, 127, rootNote + pitchOffset);
 
         if (velocity > 0.0f)
         {
@@ -165,8 +198,11 @@ public:
                 velocity = juce::jlimit(0.01f, 1.0f, velocity + velocity * jitter);
             }
 
-            // Fire noteOn at sample position 0 (block-aligned, v1 simplification)
-            out.addEvent(juce::MidiMessage::noteOn(channel, rootNote, velocity), 0);
+            // Fire noteOn at sample position 0 (block-aligned, v1 simplification).
+            // Use soundingNote (rootNote + pitchOffset) so pitch edits are reflected.
+            out.addEvent(juce::MidiMessage::noteOn(channel, soundingNote, velocity), 0);
+            // Track the sounding note so the correct noteOff fires even if rootNote changes mid-step.
+            lastSoundingNote_ = soundingNote;
 
             // Schedule noteOff at half a step duration (~gate 50%)
             // halfStepSamples = (60 / bpm) * (1 / stepsPerQuarter) * 0.5 * sampleRate
@@ -187,6 +223,63 @@ public:
     void setEnabled(bool e)        { enabled_.store(e, std::memory_order_relaxed); }
     void setRootNote(int n)        { rootNote_.store(juce::jlimit(0, 127, n), std::memory_order_relaxed); }
     void setBaseVelocity(float v)  { baseVelocity_.store(juce::jlimit(0.0f, 1.0f, v), std::memory_order_relaxed); }
+
+    //==========================================================================
+    // C3: Per-step overrides — gate and pitch offset
+    // RT-safe: packed into atomic ints (16-bit gate bitmap + 8 int8 pitch values per 64-bit word).
+    // UI thread writes via setStepGate / setStepPitch; audio thread reads in processBlock.
+
+    /** Toggle gate override for step `i` (0-based). `value` true = step fires, false = muted.
+        Has no effect when i >= 16. */
+    void setStepGate(int i, bool value) noexcept
+    {
+        if (i < 0 || i >= 16) return;
+        uint32_t mask = 1u << static_cast<unsigned>(i);
+        // CAS loop — gate bitmap is a 32-bit atomic where bit i = 1 means gate-override-on.
+        uint32_t prev = stepGateBitmap_.load(std::memory_order_relaxed);
+        uint32_t next;
+        do {
+            next = value ? (prev | mask) : (prev & ~mask);
+        } while (!stepGateBitmap_.compare_exchange_weak(prev, next,
+                                                         std::memory_order_relaxed,
+                                                         std::memory_order_relaxed));
+    }
+
+    /** Set pitch offset (semitones) for step `i`. Clamped to ±12 semitones.
+        Has no effect when i >= 16. */
+    void setStepPitch(int i, int semitones) noexcept
+    {
+        if (i < 0 || i >= 16) return;
+        stepPitch_[static_cast<size_t>(i)].store(
+            static_cast<int8_t>(juce::jlimit(-12, 12, semitones)),
+            std::memory_order_relaxed);
+    }
+
+    /** Read back gate override state for UI refresh. */
+    bool getStepGate(int i) const noexcept
+    {
+        if (i < 0 || i >= 16) return false;
+        uint32_t bitmap = stepGateBitmap_.load(std::memory_order_relaxed);
+        return (bitmap & (1u << static_cast<unsigned>(i))) != 0u;
+    }
+
+    /** Read back pitch offset for UI refresh. */
+    int getStepPitch(int i) const noexcept
+    {
+        if (i < 0 || i >= 16) return 0;
+        return static_cast<int>(stepPitch_[static_cast<size_t>(i)].load(std::memory_order_relaxed));
+    }
+
+    /** True if any step has a non-zero gate override or pitch offset (for dirty-state display). */
+    bool hasAnyStepOverride() const noexcept
+    {
+        if (stepGateBitmap_.load(std::memory_order_relaxed) != 0u)
+            return true;
+        for (int i = 0; i < 16; ++i)
+            if (stepPitch_[static_cast<size_t>(i)].load(std::memory_order_relaxed) != 0)
+                return true;
+        return false;
+    }
 
     //==========================================================================
     // APVTS integration
@@ -247,6 +340,19 @@ public:
         layout.add(std::make_unique<juce::AudioParameterInt>(
             juce::ParameterID(prefix + "rootNote", 1),
             displayPrefix + "Root Note", 0, 127, 60)); // default = middle C
+
+        // C3: per-step gate overrides (16 bool params) + pitch offsets (16 int params, ±12 st)
+        // Naming: slot[N]_seq_gate_<step> and slot[N]_seq_pitch_<step>  (step = 0..15)
+        for (int i = 0; i < 16; ++i)
+        {
+            layout.add(std::make_unique<juce::AudioParameterBool>(
+                juce::ParameterID(prefix + "gate_" + juce::String(i), 1),
+                displayPrefix + "Gate " + juce::String(i + 1), false));
+
+            layout.add(std::make_unique<juce::AudioParameterInt>(
+                juce::ParameterID(prefix + "pitch_" + juce::String(i), 1),
+                displayPrefix + "Pitch " + juce::String(i + 1), -12, 12, 0));
+        }
     }
 
     // Sync atomic state from APVTS. Safe to call from the audio thread.
@@ -304,12 +410,51 @@ public:
                             std::memory_order_relaxed);
     }
 
+    // C3: Sync per-step overrides from APVTS. Called from the 15 Hz UI timer or
+    // processBlock param-sync path. Safe on the message thread (reads APVTS directly).
+    // `prefix` must match the one used in addParameters().
+    void syncStepOverridesFromApvts(juce::AudioProcessorValueTreeState& apvts,
+                                    const juce::String& prefix)
+    {
+        // Cache parameter pointers on first call per slot.
+        if (cachedStepGateParams_[0] == nullptr)
+        {
+            for (int i = 0; i < 16; ++i)
+            {
+                cachedStepGateParams_[i]  = apvts.getRawParameterValue(prefix + "gate_"  + juce::String(i));
+                cachedStepPitchParams_[i] = apvts.getRawParameterValue(prefix + "pitch_" + juce::String(i));
+            }
+        }
+
+        uint32_t bitmap = 0u;
+        for (int i = 0; i < 16; ++i)
+        {
+            if (cachedStepGateParams_[i] != nullptr)
+            {
+                const bool gateOn = cachedStepGateParams_[i]->load(std::memory_order_relaxed) > 0.5f;
+                if (gateOn)
+                    bitmap |= (1u << static_cast<unsigned>(i));
+            }
+
+            if (cachedStepPitchParams_[i] != nullptr)
+            {
+                const int semitones = juce::jlimit(-12, 12,
+                    static_cast<int>(cachedStepPitchParams_[i]->load(std::memory_order_relaxed) + 0.5f));
+                stepPitch_[static_cast<size_t>(i)].store(
+                    static_cast<int8_t>(semitones), std::memory_order_relaxed);
+            }
+        }
+        stepGateBitmap_.store(bitmap, std::memory_order_relaxed);
+    }
+
     // Reset internal sequencer state (NOT parameter values).
     // Resets RNG to fixed seed for DRIFTS determinism; resets CA state for Eddy.
+    // C3: does NOT reset step gate/pitch overrides — those are parameter state.
     void reset()
     {
         prevStepIdx_      = -1;
         noteOffCountdown_ = 0;
+        lastSoundingNote_ = 60; // C3: reset to middle C (matches rootNote default)
         cachedStepCount_  = -1;
         cachedPatternInt_ = -1;
         riptideCycleCount_ = 0;
@@ -345,12 +490,30 @@ private:
     std::atomic<float>* cachedPBaseVel_   = nullptr;
     std::atomic<float>* cachedPRootNote_  = nullptr;
 
+    // C3: Cached APVTS pointers for per-step gate overrides and pitch offsets.
+    // Resolved once on first syncStepOverridesFromApvts() call.
+    std::array<std::atomic<float>*, 16> cachedStepGateParams_  {};  // default-inits all to nullptr
+    std::array<std::atomic<float>*, 16> cachedStepPitchParams_ {};
+
+    //==========================================================================
+    // C3: Per-step gate + pitch override state (written from UI thread, read from audio thread).
+    //
+    // Gate bitmap: bit i == 1 means step i is explicitly forced ON; bit i == 0 means OFF.
+    // Bitmap == 0 (all bits clear) is the default "no overrides" state (C1/C2 behaviour).
+    // When any bit is set, ALL 16 steps are interpreted via the bitmap (explicit mask mode).
+    //
+    // Pitch offsets: one int8 per step, ±12 semitones relative to rootNote_.
+    // Default 0 = no pitch shift (C1/C2 behaviour preserved).
+    std::atomic<uint32_t>                   stepGateBitmap_{0};
+    std::array<std::atomic<int8_t>, 16>     stepPitch_ {};  // zero-initialised
+
     //==========================================================================
     // Audio-thread-only state (no atomics needed — never touched from UI thread)
 
     double sampleRate_{44100.0};
     int    prevStepIdx_{-1};
     int    noteOffCountdown_{0};
+    int    lastSoundingNote_{60};  // C3: tracks the most recent noteOn pitch for correct noteOff
 
     // Pattern cache invalidation keys
     int cachedStepCount_{-1};

--- a/Source/UI/Ocean/SeqBreakoutComponent.h
+++ b/Source/UI/Ocean/SeqBreakoutComponent.h
@@ -29,18 +29,16 @@
 //   _baseVel    float 0..1
 //   _rootNote   int 0..127
 //
-// NOTE — Step on/off for C2:
-//   PerEnginePatternSequencer does not expose individual per-step on/off
-//   as separate APVTS parameters in C1 — gates are computed algorithmically
-//   per pattern.  In C2 we display the algorithmically-derived step state
-//   (read from a mirror array updated by the 15 Hz timer) as read-only LEDs.
-//   Clicking a pattern pill changes the whole pattern (the primary interaction).
-//   Individual step overrides (C3) require new APVTS bool array params that
-//   will be added in the C3 PR.
+// NOTE — Step interaction (C3):
+//   Tap a step LED to toggle its gate override (on/off).  When any gate override
+//   exists the bitmap is non-zero; the DSP engine respects the full bitmap mask.
+//   Vertical drag on a step LED adjusts its pitch offset in ±12 semitone range
+//   (Maschine-style): drag up = raise, drag down = lower.  First ~5px of drag
+//   determines direction lock (horizontal = gate toggle intent, vertical = pitch).
+//   A small arrow glyph is painted on any step whose pitch offset != 0.
 //
-// Deferred to C3:
-//   - Vertical-drag pitch editing per step (Maschine-style)
-//   - Per-step on/off toggle override parameters
+// Deferred to follow-up issue (long-press detail panel):
+//   - Long-press per-step detail panel (velocity, note length, slide)
 //   - Scroll-wheel velocity nudge
 //
 // TODO Wave5-C2 mount (in OceanView.h / resized):
@@ -215,16 +213,29 @@ public:
             return;
         }
 
-        // ── Step toggle hit test ──
-        // C2 shows read-only step LEDs derived from the algorithm.
-        // Clicking a step pill selects the closest pattern that accentuates it
-        // (deferred full override to C3 — for C2 just repaint).
-        if (stepRowBounds_.contains(pos))
+        // ── Step LED gate toggle (C3) ──
+        // If the mouseDown was on a step LED and drag did not resolve as a pitch edit,
+        // interpret the mouseUp as a gate toggle.
+        if (dragStepIdx_ >= 0)
         {
-            // No-op for C2 (step on/off overrides are a C3 feature).
-            // C3 TODO: set per-step bool parameter slot0_seq_stepOverride_i.
+            if (!stepDragConsumed_ && stepDragMode_ != StepDragMode::Pitch)
+            {
+                // Tap: toggle gate override for this step.
+                const bool newGate = !stepGateOverrides_[static_cast<size_t>(dragStepIdx_)];
+                stepGateOverrides_[static_cast<size_t>(dragStepIdx_)] = newGate;
+                setApvtsBool("gate_" + juce::String(dragStepIdx_), newGate);
+                repaint();
+            }
+            // Reset drag state
+            dragStepIdx_      = -1;
+            stepDragMode_     = StepDragMode::Pending;
+            stepDragConsumed_ = false;
             return;
         }
+
+        // ── Step row area fallthrough guard ──
+        if (stepRowBounds_.contains(pos))
+            return;
 
         // ── Controls row hit test ──
         handleControlsClick(pos, w, h);
@@ -232,6 +243,44 @@ public:
 
     void mouseDrag(const juce::MouseEvent& e) override
     {
+        // C3: handle step LED pitch drag (Maschine-style vertical edit)
+        if (dragStepIdx_ >= 0)
+        {
+            const float dy = e.position.y - dragStepStartY_;
+            const float dx = e.position.x - dragStartX_;
+
+            // Direction lock: first ~5px movement resolves the mode
+            if (stepDragMode_ == StepDragMode::Pending)
+            {
+                const float dist = std::sqrt(dx * dx + dy * dy);
+                if (dist > 5.0f)
+                {
+                    if (std::abs(dy) >= std::abs(dx))
+                        stepDragMode_ = StepDragMode::Pitch;
+                    else
+                        stepDragMode_ = StepDragMode::GateToggle;
+                }
+            }
+
+            if (stepDragMode_ == StepDragMode::Pitch)
+            {
+                // Vertical drag: each ~8px = 1 semitone. Drag up = positive offset.
+                // Using negative dy because screen Y increases downward.
+                const float kPxPerSemitone = 8.0f;
+                const int delta = static_cast<int>(std::round(-dy / kPxPerSemitone));
+                const int newPitch = juce::jlimit(-12, 12, dragStepStartPitch_ + delta);
+
+                if (newPitch != static_cast<int>(stepPitchOffsets_[static_cast<size_t>(dragStepIdx_)]))
+                {
+                    stepPitchOffsets_[static_cast<size_t>(dragStepIdx_)] = static_cast<int8_t>(newPitch);
+                    setApvtsParamValue("pitch_" + juce::String(dragStepIdx_), static_cast<float>(newPitch));
+                    stepDragConsumed_ = true;
+                    repaint();
+                }
+            }
+            return;
+        }
+
         // Drag on slider controls (horizontal)
         const juce::Point<float> pos = e.position;
         if (activeSlider_ != SliderTarget::None)
@@ -243,8 +292,21 @@ public:
 
     void mouseDown(const juce::MouseEvent& e) override
     {
-        activeSlider_ = SliderTarget::None;
-        dragStartX_   = e.position.x;
+        activeSlider_     = SliderTarget::None;
+        dragStartX_       = e.position.x;
+        dragStepIdx_      = -1;
+        stepDragMode_     = StepDragMode::Pending;
+        stepDragConsumed_ = false;
+
+        // C3: check if we hit a step LED first
+        const int stepHit = hitTestStepRow(e.position);
+        if (stepHit >= 0)
+        {
+            dragStepIdx_       = stepHit;
+            dragStepStartY_    = e.position.y;
+            dragStepStartPitch_ = static_cast<int>(stepPitchOffsets_[static_cast<size_t>(stepHit)]);
+            return; // control tracks handled only if step not hit
+        }
 
         // Identify which control track was pressed
         if (swingTrack_.contains(e.position))
@@ -272,13 +334,16 @@ public:
     void mouseExit(const juce::MouseEvent& /*e*/) override
     {
         hoveredPattern_ = -1;
+        hoveredStep_    = -1;
         repaint();
     }
 
     void mouseMove(const juce::MouseEvent& e) override
     {
-        const int prev = hoveredPattern_;
+        const int prevPat  = hoveredPattern_;
+        const int prevStep = hoveredStep_;
         hoveredPattern_ = -1;
+        hoveredStep_    = -1;
 
         if (patternGridBounds_.contains(e.position))
         {
@@ -287,7 +352,11 @@ public:
                 hoveredPattern_ = hit;
         }
 
-        if (hoveredPattern_ != prev)
+        // C3: step LED hover
+        if (stepRowBounds_.contains(e.position))
+            hoveredStep_ = hitTestStepRow(e.position);
+
+        if (hoveredPattern_ != prevPat || hoveredStep_ != prevStep)
             repaint();
     }
 
@@ -295,6 +364,9 @@ private:
     //==========================================================================
     // Slider targets
     enum class SliderTarget { None, Swing, Gate, Humanize, Velocity };
+
+    // C3: direction lock for step LED drag (resolved after first ~5px movement)
+    enum class StepDragMode { Pending, Pitch, GateToggle };
 
     //==========================================================================
     // ── Layout constants ──
@@ -427,15 +499,20 @@ private:
     }
 
     //--------------------------------------------------------------------------
-    /** Paint the 16-step LED row.  Returns height consumed. */
+    /** Paint the 16-step LED row with C3 gate overrides, pitch arrows, and hover.
+        Returns height consumed. */
     float paintStepRow(juce::Graphics& g, float x, float y, float areaW)
     {
         static const juce::Font labelFont(juce::FontOptions{}
             .withName(juce::Font::getDefaultSansSerifFontName())
             .withStyle("Bold")
             .withHeight(8.0f));
+        static const juce::Font arrowFont(juce::FontOptions{}
+            .withName(juce::Font::getDefaultSansSerifFontName())
+            .withStyle("Bold")
+            .withHeight(8.5f));
 
-        const float ledH      = 28.0f;
+        const float ledH      = 36.0f;  // C3: taller to accommodate pitch arrow glyph
         const float gap       = 3.0f;
         const float ledW      = (areaW - 15.0f * gap) / 16.0f;
         const int   stepCount = currentStepCount_;
@@ -446,18 +523,39 @@ private:
         const int   famIdx    = juce::jlimit(0, kNumFamilies - 1, patIdx / kPatternsPerFamily);
         const juce::Colour famCol = juce::Colour(kFamilyColors[famIdx]);
 
+        // Determine whether any gate override is active (any bit set in the override array).
+        // If so, the overrides act as an explicit mask for all steps.
+        bool anyGateOverride = false;
+        for (int i = 0; i < 16; ++i)
+            if (stepGateOverrides_[i]) { anyGateOverride = true; break; }
+
         // Row header
         g.setFont(labelFont);
         g.setColour(juce::Colour(0xFF9E9B97).withAlpha(0.40f));
         g.drawText("STEPS", juce::Rectangle<float>(x, y - 14.0f, 40.0f, 12.0f).toNearestInt(),
                    juce::Justification::centredLeft, false);
 
+        // C3: hint label (right-aligned) — replaces old "pitch edit in C3" deferred note
+        g.setColour(juce::Colour(0xFF5E6878));
+        g.drawText("drag = pitch  tap = gate", juce::Rectangle<float>(x, y - 14.0f, areaW, 12.0f).toNearestInt(),
+                   juce::Justification::centredRight, false);
+
         for (int i = 0; i < 16; ++i)
         {
             const float lx       = x + static_cast<float>(i) * (ledW + gap);
             const bool  inRange  = (i < stepCount);
             const bool  isCursor = (playing && enabled && i == curStep && inRange);
-            const bool  hasGate  = inRange && (stepGates_[static_cast<size_t>(i)] > 0.0f);
+            const bool  isHovered = (i == hoveredStep_ && inRange);
+
+            // C3: gate state resolves as follows:
+            //   - If any gate override active: use stepGateOverrides_[i] as the gate state.
+            //   - Otherwise: use the algorithmic stepGates_ mirror (C1/C2 behaviour).
+            const bool hasGate = inRange && (
+                anyGateOverride ? stepGateOverrides_[i]
+                                : (stepGates_[static_cast<size_t>(i)] > 0.0f));
+
+            // C3: pitch offset for this step
+            const int pitchOffset = static_cast<int>(stepPitchOffsets_[static_cast<size_t>(i)]);
 
             // LED rectangle
             juce::Rectangle<float> ledRect(lx, y, ledW, ledH);
@@ -469,18 +567,32 @@ private:
                 ledBg     = famCol.withAlpha(0.90f);
                 ledBorder = famCol;
             }
+            else if (isHovered)
+            {
+                // Hover: slightly brightened version of gate state
+                ledBg     = hasGate ? famCol.withAlpha(0.35f)
+                                    : juce::Colour(0xFF252A3A);
+                ledBorder = famCol.withAlpha(0.55f);
+            }
             else if (hasGate && inRange)
             {
-                // Active step with gate: coloured
-                const float gateFactor = juce::jlimit(0.2f, 1.0f, stepGates_[static_cast<size_t>(i)]);
+                // Active step with gate: coloured.
+                // C3: if step has a gate override, use a slightly different alpha to
+                // distinguish override-on from algorithmic-on (slightly brighter border).
+                const float gateFactor = anyGateOverride ? 1.0f
+                    : juce::jlimit(0.2f, 1.0f, stepGates_[static_cast<size_t>(i)]);
                 ledBg     = famCol.withAlpha(0.20f + gateFactor * 0.25f);
-                ledBorder = famCol.withAlpha(0.35f + gateFactor * 0.30f);
+                ledBorder = anyGateOverride ? famCol.withAlpha(0.75f)
+                                            : famCol.withAlpha(0.35f + gateFactor * 0.30f);
             }
             else if (inRange)
             {
-                // In range but rest (gate == 0)
-                ledBg     = juce::Colour(0xFF1A1F2E);
-                ledBorder = juce::Colour(0xFF9E9B97).withAlpha(0.12f);
+                // In range but rest (gate == 0).
+                // C3: if this step is explicitly muted via override, use a darker background.
+                ledBg     = anyGateOverride ? juce::Colour(0xFF0D1018)
+                                           : juce::Colour(0xFF1A1F2E);
+                ledBorder = anyGateOverride ? juce::Colour(0xFF9E9B97).withAlpha(0.06f)
+                                           : juce::Colour(0xFF9E9B97).withAlpha(0.12f);
             }
             else
             {
@@ -494,6 +606,36 @@ private:
             g.setColour(ledBorder);
             g.drawRoundedRectangle(ledRect, 3.0f, 1.0f);
 
+            // C3: pitch arrow glyph — drawn at centre-top of the LED when pitch != 0.
+            // Arrow points up for positive offset, down for negative.
+            // Intensity scales with |offset| / 12.
+            if (inRange && pitchOffset != 0)
+            {
+                const float arrowAlpha = 0.45f + 0.55f * (std::abs(pitchOffset) / 12.0f);
+                const juce::Colour arrowCol = isCursor
+                    ? juce::Colour(0xFF0E111A)
+                    : famCol.withAlpha(arrowAlpha);
+                g.setFont(arrowFont);
+                g.setColour(arrowCol);
+                // Unicode arrows: up = 0x25B2 (▲), down = 0x25BC (▼)
+                const juce::String arrow = (pitchOffset > 0) ? juce::String::charToString(0x25B2)
+                                                              : juce::String::charToString(0x25BC);
+                g.drawText(arrow,
+                           juce::Rectangle<float>(lx, y + 3.0f, ledW, 10.0f).toNearestInt(),
+                           juce::Justification::centred, false);
+
+                // Small semitone number below the arrow (only if |offset| > 0)
+                static const juce::Font pitchNumFont(juce::FontOptions{}
+                    .withName(juce::Font::getDefaultSansSerifFontName())
+                    .withHeight(7.0f));
+                g.setFont(pitchNumFont);
+                g.setColour(arrowCol.withAlpha(arrowAlpha * 0.80f));
+                const juce::String pitchStr = (pitchOffset > 0 ? "+" : "") + juce::String(pitchOffset);
+                g.drawText(pitchStr,
+                           juce::Rectangle<float>(lx, y + 13.0f, ledW, 9.0f).toNearestInt(),
+                           juce::Justification::centred, false);
+            }
+
             // Step number (1-indexed, small, bottom-aligned)
             if (inRange)
             {
@@ -506,16 +648,8 @@ private:
             }
         }
 
-        // C3 deferred annotation
-        static const juce::Font deferredFont(juce::FontOptions{}
-            .withName(juce::Font::getDefaultSansSerifFontName())
-            .withHeight(7.5f));
-        g.setFont(deferredFont);
-        g.setColour(juce::Colour(0xFF5E6878));
-        g.drawText("pitch edit in C3", juce::Rectangle<float>(x, y + ledH + 2.0f, areaW, 10.0f).toNearestInt(),
-                   juce::Justification::centredRight, false);
-
-        return ledH + 14.0f; // +14 for the header label + deferred annotation text
+        // C3: section height increased to ledH + 14 (header 14px above + no deferred annotation)
+        return ledH + 14.0f;
     }
 
     //--------------------------------------------------------------------------
@@ -712,6 +846,28 @@ private:
         return -1;
     }
 
+    // C3: returns step index (0-15) if pos is inside the step row area, else -1.
+    // Uses the stepRowBounds_ rect + per-step LED geometry to do per-cell hit testing.
+    int hitTestStepRow(const juce::Point<float>& pos) const
+    {
+        if (!stepRowBounds_.contains(pos))
+            return -1;
+
+        const float areaW  = stepRowBounds_.getWidth();
+        const float gap    = 3.0f;
+        const float ledW   = (areaW - 15.0f * gap) / 16.0f;
+        const float rowX   = stepRowBounds_.getX();
+
+        for (int i = 0; i < 16; ++i)
+        {
+            const float lx = rowX + static_cast<float>(i) * (ledW + gap);
+            const juce::Rectangle<float> cell(lx, stepRowBounds_.getY(), ledW, stepRowBounds_.getHeight());
+            if (cell.contains(pos))
+                return i;
+        }
+        return -1;
+    }
+
     void handlePatternGridClick(const juce::Point<float>& pos)
     {
         const int hit = hitTestPatternGrid(pos);
@@ -885,6 +1041,14 @@ private:
         currentHumanize_  = juce::jlimit(0.0f, 1.0f, readParamFloat("humanize", 0.0f));
         currentVelocity_  = juce::jlimit(0.0f, 1.0f, readParamFloat("baseVel", 0.75f));
         currentEnabled_   = readParamBool("enabled");
+
+        // C3: sync per-step gate overrides and pitch offsets
+        for (int i = 0; i < 16; ++i)
+        {
+            stepGateOverrides_[i] = readParamBool("gate_" + juce::String(i));
+            const int pitch = juce::jlimit(-12, 12, readParamInt("pitch_" + juce::String(i), 0));
+            stepPitchOffsets_[i] = static_cast<int8_t>(pitch);
+        }
     }
 
     //==========================================================================
@@ -933,13 +1097,27 @@ private:
     juce::Rectangle<float> clockDivPill_;
     juce::Rectangle<float> enabledPill_;
 
-    // Drag state
+    // Drag state (controls row sliders)
     SliderTarget activeSlider_ = SliderTarget::None;
     float        dragStartX_   = 0.0f;
     float        dragStartVal_ = 0.0f;
 
+    // C3: Per-step gate override + pitch offset mirrors (message-thread cache; synced from APVTS)
+    // stepGateOverrides_[i] == true means the step has an explicit gate override.
+    // The displayed gate state = stepGateOverrides_[i] OR (algorithmic gate && no override bitmap active).
+    std::array<bool, 16>  stepGateOverrides_ {};
+    std::array<int8_t, 16> stepPitchOffsets_  {};  // ±12 semitones
+
+    // C3: Step LED drag state for Maschine-style vertical pitch editing
+    int          dragStepIdx_      = -1;        // which step is being dragged (-1 = none)
+    float        dragStepStartY_   = 0.0f;      // mouseDown Y position in component coords
+    int          dragStepStartPitch_ = 0;        // pitch offset at drag start
+    StepDragMode stepDragMode_     = StepDragMode::Pending;
+    bool         stepDragConsumed_ = false;     // true once direction locked; suppresses tap action
+
     // Hover state
     int hoveredPattern_ = -1;
+    int hoveredStep_    = -1;   // C3: step LED hover for visual feedback
 
     //==========================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SeqBreakoutComponent)

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1948,6 +1948,8 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         for (int s = 0; s < kNumPrimarySlots; ++s)
         {
             slotSequencers_[s].syncFromApvts(apvts, "slot" + juce::String(s) + "_seq_");
+            // C3: sync per-step gate override + pitch offset from APVTS params.
+            slotSequencers_[s].syncStepOverridesFromApvts(apvts, "slot" + juce::String(s) + "_seq_");
             slotSequencers_[s].processBlock(slotMidi[s], seqBpm, seqPpq, seqPlaying, numSamples);
         }
     }


### PR DESCRIPTION
## Summary

- Adds per-step gate overrides (tap to toggle) and pitch offsets (vertical drag, ±12 semitones) to the Wave 5 per-slot sequencer — Maschine MK3-style step editing
- 128 new APVTS params: `slot[N]_seq_gate_<step>` (bool) + `slot[N]_seq_pitch_<step>` (int -12..12) for 4 slots × 16 steps
- Arrow glyphs (▲/▼ + semitone number) on steps with non-zero pitch; gate override state visually distinct from algorithmic gate

## Files changed

- `Source/DSP/PerEnginePatternSequencer.h` — step bitmap gate mask, pitch offset atomics, `syncStepOverridesFromApvts()`, corrected noteOff to use `lastSoundingNote_` (pitch-offset note release fix), 32 new APVTS params per slot via `addParameters()`
- `Source/UI/Ocean/SeqBreakoutComponent.h` — direction-locked drag (vertical=pitch, horizontal→gate toggle), arrow glyph paint, hover highlight, gate override visual distinction
- `Source/XOceanusProcessor.cpp` — adds `syncStepOverridesFromApvts()` call in Wave 5 C1 processBlock loop

## Deferred (follow-up)

Long-press per-step detail panel (velocity, note length, slide) — see follow-up issue filed.

## Design notes

- Gate bitmap == 0 (default) = no overrides; C1/C2 algorithmic behaviour fully preserved
- Direction lock at first ~5px of drag prevents accidental pitch edits during taps
- `lastSoundingNote_` fix corrects a pre-existing subtle bug: if pitch offset changed mid-phrase, the noteOff would target the wrong MIDI note number

## Test plan

- [ ] Build AU target (0 errors, 0 warnings in changed files)
- [ ] Tap step LED → gate override toggles (darker/lighter visual, mutes note in playback)
- [ ] Vertical drag up → ▲ glyph appears, note pitches upward
- [ ] Vertical drag down → ▼ glyph appears, note pitches downward
- [ ] Load preset, save, reload — step gate + pitch params round-trip via APVTS/state
- [ ] Pattern pill click still changes full pattern (gate overrides persist independently)
- [ ] All 4 slots have independent step overrides (slot0/slot1/slot2/slot3 prefix isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)