### PR TITLE
feat(#1172): wire SubmarineOuijaPanel planchette → MIDI note + CC 85/86 output

### DIFF
--- a/Source/UI/Ocean/SurfaceRightPanel.h
+++ b/Source/UI/Ocean/SurfaceRightPanel.h
@@ -64,6 +64,44 @@ public:
         // Embedded ouija panel — shown only in Ouija mode.
         ouijaPanel_.setVisible(false);
         addAndMakeVisible(ouijaPanel_);
+
+        // ── Wire SubmarineOuijaPanel callbacks (#1172) ─────────────────────
+        // Forward planchette-lock events to onNoteOn so the ouija panel drives
+        // the same MIDI output path as the PAD / DRUM surfaces.
+        //
+        // The locked MIDI note is cached in ouijaLockedNote_ so the matching
+        // note-off on release targets the exact note that was fired.
+        ouijaPanel_.onNoteLocked = [this](int /*noteIndex*/, int midiNote)
+        {
+            // Release any previous note before firing the new one.
+            if (ouijaLockedNote_ >= 0 && onNoteOff)
+                onNoteOff(ouijaLockedNote_);
+            ouijaLockedNote_ = midiNote;
+            if (onNoteOn)
+                onNoteOn(midiNote, 0.75f); // fixed velocity — locks to a harmonic node
+        };
+
+        // Planchette release (GOODBYE / unlock click) → note-off for the
+        // currently locked note.
+        ouijaPanel_.onNoteReleased = [this]()
+        {
+            if (ouijaLockedNote_ >= 0 && onNoteOff)
+                onNoteOff(ouijaLockedNote_);
+            ouijaLockedNote_ = -1;
+        };
+
+        // Planchette position → CC output.
+        // emitCCOutput() fires at 30 Hz with (cc=0, circleX) then (cc=1, influenceY).
+        // Map to the canonical CC numbers and forward via onOuijaCCOutput.
+        ouijaPanel_.onCCOutput = [this](int cc, float value)
+        {
+            if (!onOuijaCCOutput)
+                return;
+            const uint8_t ccNum = (cc == 0) ? kOuijaCCCircleX : kOuijaCCInfluenceY;
+            const uint8_t val   = static_cast<uint8_t>(
+                juce::jlimit(0, 127, juce::roundToInt(value * 127.0f)));
+            onOuijaCCOutput(ccNum, val);
+        };
     }
 
     ~SurfaceRightPanel() override = default;
@@ -104,6 +142,25 @@ public:
     std::function<void(int note, float velocity)> onNoteOn;
     std::function<void(int note)>                 onNoteOff;
     std::function<void(float x, float y)>         onXYChanged;
+
+    // CC output from the embedded SubmarineOuijaPanel (Ouija mode only).
+    // Fires at ~30 Hz while the ouija panel is visible.
+    //   cc 0 = circleX   (horizontal planchette position, 0-1 normalised)
+    //   cc 1 = influenceY (radius / depth, 0-1 normalised)
+    // Wire this to processor_->pushCCOutput() in the host (editor / OceanView)
+    // using the CC numbers defined below.
+    //
+    //   circleX   → CC 85 (Undefined controller — XOceanus convention for ouija X)
+    //   influenceY → CC 86 (Undefined controller — XOceanus convention for ouija Y)
+    //
+    // These constants are exposed so the host can label them in any MIDI learn UI.
+    static constexpr uint8_t kOuijaCCCircleX    = 85;
+    static constexpr uint8_t kOuijaCCInfluenceY = 86;
+    static constexpr uint8_t kOuijaMidiChannel  = 1; // 1-indexed, MIDI channel 1
+
+    // Fired each time the ouija panel emits a position CC.
+    // signature: (uint8_t cc, uint8_t value)
+    std::function<void(uint8_t cc, uint8_t value)> onOuijaCCOutput;
 
     // Close button callback
     std::function<void()> onCloseClicked;
@@ -349,6 +406,11 @@ private:
     Mode  mode_            = Mode::Pad;
     bool  open_            = false;
 
+    // Ouija mode: tracks the MIDI note number currently sounding from the
+    // ouija planchette lock, so we can send the correct note-off on release.
+    // -1 = no note currently locked.
+    int   ouijaLockedNote_ = -1;
+
     // Active pad / close button state
     int   pressedPad_      = -1; // -1 = none
     int   hoverPad_        = -1;
@@ -492,6 +554,14 @@ private:
             pressedPad_ = -1;
         }
         xyDragging_ = false;
+
+        // Release any ouija-locked note when switching away from Ouija mode.
+        if (ouijaLockedNote_ >= 0)
+        {
+            if (onNoteOff)
+                onNoteOff(ouijaLockedNote_);
+            ouijaLockedNote_ = -1;
+        }
     }
 
     //==========================================================================


### PR DESCRIPTION
## Summary

Closes part of #1172. The `SubmarineOuijaPanel` inside `SurfaceRightPanel` has had three callbacks (`onNoteLocked`, `onNoteReleased`, `onCCOutput`) since its initial implementation, but they were never assigned — the planchette was purely decorative.

This PR wires them inside `SurfaceRightPanel`'s constructor so the panel is production-ready the moment the HARMONIC tab is re-enabled.

## What changed

**File: `Source/UI/Ocean/SurfaceRightPanel.h`**

- `ouijaPanel_.onNoteLocked` → forwards to `onNoteOn(midiNote, 0.75f)`; caches the note in `ouijaLockedNote_` for clean note-off targeting
- `ouijaPanel_.onNoteReleased` → fires `onNoteOff(ouijaLockedNote_)`, resets to -1; `releaseActive()` also clears it on mode-switch
- `ouijaPanel_.onCCOutput` → maps internal cc 0/1 to **CC 85** (circleX) / **CC 86** (influenceY) — the same pair canonical `XOuijaPanel` uses — then fires new public callback `onOuijaCCOutput`

New public surface on `SurfaceRightPanel`:
```cpp
std::function<void(uint8_t cc, uint8_t value)> onOuijaCCOutput;
static constexpr uint8_t kOuijaCCCircleX    = 85;
static constexpr uint8_t kOuijaCCInfluenceY = 86;
static constexpr uint8_t kOuijaMidiChannel  = 1;
```

## CC mapping rationale

CC 85 / CC 86 are the established XOceanus convention for ouija X/Y — the canonical `XOuijaPanel` (PlaySurface) already uses them. Keeping the same numbers lets DAW automations set up against one XOuija surface continue working when the HARMONIC tab is active.

Debounce: the 30 Hz animation timer inside `SubmarineOuijaPanel` naturally caps CC emission at 30 Hz — no additional debouncing needed.

## Deferred (separate PR, requires OceanView.h)

- Re-enabling the HARMONIC tab in `OceanView::tabBar_.onTabChanged` (a comment at line 443 in `OceanView.h` already documents the gate condition)
- Wiring `surfaceRight_.onOuijaCCOutput → processor.pushCCOutput()` in `XOceanusEditor`

These are intentionally deferred to avoid conflicts with parallel agents currently working on `OceanView.h` and `XOceanusEditor.h`.

## Test plan

- [ ] Build passes (no new compiler errors in `SurfaceRightPanel.h`)
- [ ] In Ouija mode: clicking a note node fires `onNoteOn` with the correct MIDI note; GOODBYE fires the matching `onNoteOff`
- [ ] Switching away from Ouija mode with a note held fires the note-off (no hanging note)
- [ ] `onOuijaCCOutput` fires at ~30 Hz with CC 85 / 86 while the planchette is moving

🤖 Generated with [Claude Code](https://claude.com/claude-code)