### PR TITLE
feat(#1179): sequence layer serialization — DAW state independence (slice B)

### DIFF
--- a/Source/UI/Ocean/TideWaterline.h
+++ b/Source/UI/Ocean/TideWaterline.h
@@ -90,6 +90,69 @@ public:
     };
 
     //==========================================================================
+    // ── Sequence layer serialization (#1179) ──────────────────────────────────
+    //
+    // steps_ is NOT stored in APVTS.  To preserve user-edited patterns across
+    // DAW sessions independently of preset loads, we expose a ValueTree round-
+    // trip.  The processor includes this tree in getStateInformation() /
+    // setStateInformation() via the onGetTideWaterlineState callback.
+    //
+    // Invariant: fromValueTree() does NOT call syncFromApvts() or applyPattern().
+    // This guarantees session restore never re-applies an algorithmic template
+    // on top of user edits — a preset load and a session restore are cleanly
+    // separated code paths.
+
+    /// Serialize current per-step data to a juce::ValueTree ("TideWaterlineSteps").
+    juce::ValueTree toValueTree() const
+    {
+        juce::ValueTree tree("TideWaterlineSteps");
+        tree.setProperty("stepCount", currentSteps_, nullptr);
+        for (int i = 0; i < kMaxSteps; ++i)
+        {
+            juce::ValueTree step("Step");
+            step.setProperty("active",   steps_[i].active ? 1 : 0, nullptr);
+            step.setProperty("velocity", static_cast<double>(steps_[i].velocity), nullptr);
+            step.setProperty("gate",     static_cast<double>(steps_[i].gate),     nullptr);
+            step.setProperty("rootNote", steps_[i].rootNote,                      nullptr);
+            tree.addChild(step, -1, nullptr);
+        }
+        return tree;
+    }
+
+    /// Restore per-step data from a ValueTree produced by toValueTree().
+    /// Does NOT call syncFromApvts() or applyPattern() — pattern is verbatim.
+    /// Returns false without modifying state if the tree type does not match.
+    bool fromValueTree(const juce::ValueTree& tree)
+    {
+        if (!tree.isValid() || tree.getType().toString() != "TideWaterlineSteps")
+            return false;
+
+        if (tree.hasProperty("stepCount"))
+            currentSteps_ = juce::jlimit(1, kMaxSteps, static_cast<int>(tree.getProperty("stepCount")));
+
+        int childIdx = 0;
+        for (auto child : tree)
+        {
+            if (childIdx >= kMaxSteps)
+                break;
+            if (child.getType().toString() == "Step")
+            {
+                steps_[childIdx].active   = (static_cast<int>(child.getProperty("active",   0)) != 0);
+                steps_[childIdx].velocity = juce::jlimit(0.0f, 1.0f,
+                    static_cast<float>(static_cast<double>(child.getProperty("velocity", 0.75))));
+                steps_[childIdx].gate     = juce::jlimit(0.05f, 1.0f,
+                    static_cast<float>(static_cast<double>(child.getProperty("gate",     0.75))));
+                steps_[childIdx].rootNote = static_cast<int>(child.getProperty("rootNote", -1));
+                ++childIdx;
+            }
+        }
+
+        rebuildRootNoteLabels();
+        repaint();
+        return true;
+    }
+
+    //==========================================================================
     explicit TideWaterline(juce::AudioProcessorValueTreeState& apvts,
                            const MasterFXSequencer&            sequencer)
         : apvts_    (apvts)

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -2831,6 +2831,22 @@ void XOceanusProcessor::getStateInformation(juce::MemoryBlock& destData)
         state.removeChild(existing, nullptr);
     state.appendChild(modRoutingModel_.toValueTree(), nullptr);
 
+    // #1179 — Persist TideWaterline per-step sequence data as a ValueTree child.
+    // D1 foundation: step patterns survive DAW session recall independently of
+    // preset loads.  onGetTideWaterlineState is registered by OceanView after
+    // waterline_ is initialised.  If the callback is null (editor not open), the
+    // child is simply omitted — setStateInformation stores it for deferred pickup.
+    if (onGetTideWaterlineState)
+    {
+        auto tideState = onGetTideWaterlineState();
+        if (tideState.isValid())
+        {
+            if (auto existing = state.getChildWithName("TideWaterlineSteps"); existing.isValid())
+                state.removeChild(existing, nullptr);
+            state.appendChild(tideState, nullptr);
+        }
+    }
+
     std::unique_ptr<juce::XmlElement> xml(state.createXml());
     if (xml)
     {
@@ -3060,6 +3076,22 @@ void XOceanusProcessor::setStateInformation(const void* data, int sizeInBytes)
             {
                 modRoutingModel_.fromValueTree(modRoutesTree);
                 flushModRoutesSnapshot();
+            }
+        }
+
+        // #1179 — Restore TideWaterline per-step sequence data (D1 foundation).
+        // "TideWaterlineSteps" child is absent in sessions predating this feature
+        // — no-op in that case (algorithmic default pattern is kept on construction).
+        // Case A: editor already open → callback registered, dispatch immediately.
+        // Case B: editor not yet open → store for deferred pickup in initWaterline().
+        {
+            auto tideTree = apvts.state.getChildWithName("TideWaterlineSteps");
+            if (tideTree.isValid())
+            {
+                if (onSetTideWaterlineState)
+                    onSetTideWaterlineState(tideTree);
+                else
+                    persistedTideWaterlineState_ = tideTree;
             }
         }
 

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -185,6 +185,29 @@ public:
     std::function<juce::ValueTree()> onGetXOuijaState;
     std::function<void(const juce::ValueTree& /*state*/)> onSetXOuijaState;
 
+    // ── TideWaterline sequence layer persistence bridge (#1179) ───────────────
+    // OceanView registers these callbacks so the processor can include per-step
+    // data (active, velocity, gate, rootNote for all 16 steps) in DAW state.
+    // This is the D1 architectural foundation: step patterns survive DAW session
+    // recall independently of any preset load.
+    //
+    // Usage (in OceanView::initWaterline(), after waterline_ construction):
+    //   processor_.onGetTideWaterlineState = [this]() {
+    //       return waterline_ ? waterline_->toValueTree() : juce::ValueTree{};
+    //   };
+    //   processor_.onSetTideWaterlineState = [this](const juce::ValueTree& t) {
+    //       if (waterline_) waterline_->fromValueTree(t);
+    //   };
+    //   // Consume state that arrived before the editor was open:
+    //   auto deferred = processor_.getPersistedTideWaterlineState();
+    //   if (deferred.isValid() && waterline_)
+    //   {
+    //       waterline_->fromValueTree(deferred);
+    //       processor_.clearPersistedTideWaterlineState();
+    //   }
+    std::function<juce::ValueTree()> onGetTideWaterlineState;
+    std::function<void(const juce::ValueTree& /*state*/)> onSetTideWaterlineState;
+
     // ── Field Map note event queue ─────────────────────────────────────────────
     // Lock-free SPSC ring: audio thread writes (pushNoteEvent), UI thread drains
     // (drainNoteEvents). Both ends use only std::atomic<size_t> indices — no mutex,
@@ -371,6 +394,18 @@ public:
     bool getPersistedRegisterLocked() const noexcept { return persistedRegisterLocked; }
     void setPersistedRegisterCurrent(int r) noexcept { persistedRegisterCurrent = r; }
     int  getPersistedRegisterCurrent() const noexcept { return persistedRegisterCurrent; }
+
+    // #1179 — TideWaterline deferred state pickup.
+    // OceanView calls this in initWaterline() to apply state that arrived via
+    // setStateInformation() before the editor window was first opened.
+    juce::ValueTree getPersistedTideWaterlineState() const noexcept
+    {
+        return persistedTideWaterlineState_;
+    }
+    void clearPersistedTideWaterlineState() noexcept
+    {
+        persistedTideWaterlineState_ = juce::ValueTree{};
+    }
 
 private:
     juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
@@ -749,6 +784,13 @@ private:
     bool persistedCockpitBypass = false; // #357: Dark Cockpit bypass state
     bool persistedRegisterLocked = false; // D4: register lock toggle
     int  persistedRegisterCurrent = 0;   // D4: current register index (0=Gallery, 1=Performance, 2=Coupling)
+
+    // ── #1179: TideWaterline deferred step-sequence state ────────────────────
+    // Holds the "TideWaterlineSteps" tree from setStateInformation() when the
+    // editor was not yet open at restore time.  OceanView picks it up in
+    // initWaterline() via getPersistedTideWaterlineState().
+    // Message-thread only — no atomic needed.
+    juce::ValueTree persistedTideWaterlineState_;
 
     // ── External MIDI Clock state — audio thread only (closes #359) ──────────
     // Used to derive BPM from incoming 0xF8 pulses.


### PR DESCRIPTION
## Problem

Issue #1179 (D1): step sequences should be independent of presets. Currently TideWaterline's `steps_[]` array (16 per-step records: active, velocity, gate, rootNote) is purely local with no persistence path. Every DAW session restart silently regenerates steps from an algorithmic pattern, destroying any user edits.

## Architectural diagnosis

After reading the full stack:
- `applyPreset()` iterates only over `parametersByEngine` keys — `master_seq*` and `slot*_seq_*` APVTS params are NOT touched by preset loads
- The entanglement is a different problem: TideWaterline's `steps_[]` is re-generated from an algorithmic template on every APVTS param listener fire, erasing manual edits
- No save/load path exists for custom per-step data at all — not in APVTS, not in preset files, not in DAW state

## What this PR does (Slice B: separate serialization namespace)

Adds a clean ValueTree round-trip so the processor can include per-step data in DAW state (`getStateInformation` / `setStateInformation`), independent of the preset file format.

**Key architectural invariant:** `fromValueTree()` does NOT call `syncFromApvts()` or `applyPattern()`. Preset loads regenerate steps algorithmically (existing behavior); session restores reconstruct verbatim user-edited data. The two paths are cleanly separated.

### Files changed

| File | Change |
|------|--------|
| `Source/UI/Ocean/TideWaterline.h` | Add `toValueTree()` and `fromValueTree()` public API |
| `Source/XOceanusProcessor.h` | Add `onGetTideWaterlineState` / `onSetTideWaterlineState` callbacks (same pattern as existing XOuija bridge); `getPersistedTideWaterlineState()` for deferred-init; `persistedTideWaterlineState_` storage member |
| `Source/XOceanusProcessor.cpp` | Wire callbacks in `getStateInformation()` and `setStateInformation()`, including deferred case (editor not open at restore time) |

## What this PR does NOT do (intentionally deferred)

- **OceanView.h wiring**: registering the callbacks in `initWaterline()` is a follow-up (OceanView.h is shared chrome; parallel agents are active). Full wiring code is documented in the processor header with a copy-paste snippet.
- **Preset file format change**: per-step data is NOT stored in `.xometa` files. That is a separate user decision.
- **Sequence browser UI**: a named sequence list/dropdown is a later milestone.
- **`sequencerData` in PresetData**: still used only for ChordMachine (unchanged).

## Follow-up wiring (in OceanView::initWaterline, after waterline_ construction)

```cpp
processor_.onGetTideWaterlineState = [this]() {
    return waterline_ ? waterline_->toValueTree() : juce::ValueTree{};
};
processor_.onSetTideWaterlineState = [this](const juce::ValueTree& t) {
    if (waterline_) waterline_->fromValueTree(t);
};
auto deferred = processor_.getPersistedTideWaterlineState();
if (deferred.isValid() && waterline_)
{
    waterline_->fromValueTree(deferred);
    processor_.clearPersistedTideWaterlineState();
}
```

Progresses #1179 (first of 2-3 PRs to fully resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)