### PR TITLE
feat(#1282): Sound on First Launch — Settings > Experience + replayFirstBreath()

### DIFF
--- a/Source/UI/Gallery/SettingsPanel.h
+++ b/Source/UI/Gallery/SettingsPanel.h
@@ -11,6 +11,7 @@
 //   5. MIDI Mappings  (variable) — Live CC→param table from MIDILearnManager
 //   6. About          (80pt)   — Version, links
 //   7. Keyboard Shortcuts (36pt) — Z/X/C/V shortcut legend (display-only)
+//   8. Experience     (40pt)   — "Hear the Greeting Again" (Sound on First Launch replay)
 //
 // Architectural notes:
 //   • Header-only (.h), consistent with all Gallery Model components.
@@ -335,6 +336,18 @@ public:
         content.addAndMakeVisible(aboutWebLabel);
         content.addAndMakeVisible(aboutPatreonLabel);
 
+        // ── 8. EXPERIENCE ────────────────────────────────────────────────────
+        // "Hear the Greeting Again" — re-triggers the Sound on First Launch chord.
+        // Wired to processor.replayFirstBreath() (message-thread safe).
+        hearGreetingAgainBtn.setButtonText("Hear the Greeting Again");
+        hearGreetingAgainBtn.setColour(juce::TextButton::buttonColourId, GalleryColors::get(GalleryColors::elevated()));
+        hearGreetingAgainBtn.setColour(juce::TextButton::textColourOffId, GalleryColors::get(GalleryColors::textMid()));
+        hearGreetingAgainBtn.setTooltip("Replay the Sound on First Launch experience (soft Oxbow chord in slot 0)");
+        A11y::setup(hearGreetingAgainBtn, "Hear Greeting Again",
+                    "Replay the Sound on First Launch: a soft Oxbow chord plays in slot 0 for up to 30 seconds");
+        hearGreetingAgainBtn.onClick = [this] { processor.replayFirstBreath(); };
+        content.addAndMakeVisible(hearGreetingAgainBtn);
+
         // ── Accessibility wiring ──────────────────────────────────────────────
         A11y::setup(*this, "Settings", "Plugin settings panel");
     }
@@ -415,6 +428,9 @@ public:
 
         clearAllBtn.setColour(juce::TextButton::buttonColourId, GalleryColors::get(GalleryColors::elevated()));
         clearAllBtn.setColour(juce::TextButton::textColourOffId, GalleryColors::get(GalleryColors::textMid()));
+
+        hearGreetingAgainBtn.setColour(juce::TextButton::buttonColourId, GalleryColors::get(GalleryColors::elevated()));
+        hearGreetingAgainBtn.setColour(juce::TextButton::textColourOffId, GalleryColors::get(GalleryColors::textMid()));
 
         // Refresh URL label color (dark/light link color differs)
         styleUrlLabel(aboutWebLabel, "xo-ox.org", "https://xo-ox.org");
@@ -680,6 +696,14 @@ private:
         aboutPatreonLabel.setBounds(kPad, y, inner, kRowH - 4);
         y += kRowH + kGap;
 
+        y += kSectionGap;
+
+        // ── 8. EXPERIENCE ────────────────────────────────────────────────────
+        sectionY[7] = y;
+        y += kHeaderH + kGap;
+        hearGreetingAgainBtn.setBounds(kPad, y, inner, kRowH + 4); // slightly taller for button
+        y += kRowH + 4 + kGap;
+
         y += kPad; // bottom breathing room
 
         content.setSize(w, y);
@@ -703,8 +727,8 @@ private:
             const int inner = w - SettingsPanel::kPad * 2;
 
             static const char* kTitles[] = {"Theme", "Accessibility",     "MPE", "Performance", "MIDI Mappings",
-                                            "About", "Keyboard Shortcuts"};
-            for (int i = 0; i < 7; ++i)
+                                            "About", "Keyboard Shortcuts", "Experience"};
+            for (int i = 0; i < 8; ++i)
                 owner->drawSectionHeader(g, kTitles[i], SettingsPanel::kPad, owner->sectionY[i], inner);
 
             // MIDI table
@@ -718,7 +742,7 @@ private:
     bool perfLocked = false;
 
     // Layout tracking (set by layoutContent, read by paint callbacks)
-    int sectionY[7] = {};
+    int sectionY[8] = {};
     int midiTableY = 0;
     int midiTableH = 0;
 
@@ -778,6 +802,12 @@ private:
     juce::Label aboutMakerLabel;
     juce::Label aboutWebLabel;
     juce::Label aboutPatreonLabel;
+
+    // ── 8. Experience ─────────────────────────────────────────────────────────
+    // "Hear the Greeting Again" — re-arms the Sound on First Launch experience.
+    // Calls processor.replayFirstBreath() which reloads Oxbow in slot 0 and
+    // injects a soft C3 note.  See spec §8 Option A + §1282.
+    juce::TextButton hearGreetingAgainBtn;
 
     //==========================================================================
     // Factory helper — creates a right-aligned param name label.

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -333,6 +333,45 @@ public:
     // Message-thread only: posts an atomic flag consumed by processBlock.
     void killDelayTails() noexcept { killDelayTailsPending.store(true, std::memory_order_release); }
 
+    // ── Sound on First Launch — replay (§1282 Settings > Experience) ─────────
+    // Re-arms the first-breath experience on demand (called from SettingsPanel's
+    // "Hear the Greeting Again" button).  Message-thread safe: re-loads Oxbow in
+    // slot 0 with the Breath Mist parameters, then sets firstBreathPending_ so
+    // processBlock injects the C3 note on the next audio block.
+    // Note: this does NOT reset hasLaunchedBefore_ — it only re-arms one play.
+    // Idempotent: calling while a breath is already pending is a no-op.
+    void replayFirstBreath()
+    {
+        if (firstBreathPending_.load(std::memory_order_relaxed))
+            return; // already armed — don't double-arm
+        // Re-load Oxbow in slot 0 so the engine is ready for the note.
+        loadEngine(0, "Oxbow");
+        // Re-apply the Breath Mist preset parameters inline (same values as first launch).
+        struct BreathMistParam { const char* id; float value; };
+        static const BreathMistParam kBreathMistParams[] = {
+            {"oxb_size",          0.1f},
+            {"oxb_decay",         0.5f},
+            {"oxb_entangle",      0.06f},
+            {"oxb_erosionRate",   0.05f},
+            {"oxb_erosionDepth",  0.08f},
+            {"oxb_convergence",   4.0f},
+            {"oxb_resonanceQ",    3.5f},
+            {"oxb_resonanceMix",  0.15f},
+            {"oxb_cantilever",    0.12f},
+            {"oxb_damping",       7000.0f},
+            {"oxb_predelay",      0.0f},
+            {"oxb_dryWet",        0.15f},
+            {"oxb_exciterDecay",  0.05f},
+            {"oxb_exciterBright", 0.5f},
+        };
+        for (const auto& p : kBreathMistParams)
+        {
+            if (auto* param = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter(p.id)))
+                param->setValueNotifyingHost(param->convertTo0to1(p.value));
+        }
+        firstBreathPending_.store(true, std::memory_order_release);
+    }
+
     // CPU processing load as a fraction 0.0–1.0 (or higher during overload).
     // Measured in processBlock() as elapsed wall time / buffer duration.
     // Safe to call from any thread.


### PR DESCRIPTION
## Summary

- Adds `replayFirstBreath()` public method to `XOceanusProcessor` so users can re-trigger the first-launch experience on demand
- Adds **Settings > Experience** section to `SettingsPanel` with a "Hear the Greeting Again" button wired to the new method
- The core first-breath audio engine (Oxbow Breath Mist, C3 vel-60, 30s failsafe, user-input cancellation) was already fully implemented in the processor; this PR wires the two missing UI surfaces from `Docs/specs/sound-on-first-launch.md`

## Design decisions (autonomous)

| Decision | Choice | Rationale |
|---|---|---|
| **Repeatability (spec §8)** | Option A — first-launch-only auto-play; manual "Hear Again" button | Rarity of the first-time discovery preserved; the button satisfies the "share it with someone" affordance without making cold-boot noisy for all subsequent sessions |
| **Audio routing (spec §10)** | Option A — DAW bus | Simplest path, no platform permission issues, consistent AU/VST3/Standalone behaviour |

## Implementation notes

**`XOceanusProcessor.h`** — `replayFirstBreath()`:
- Calls `loadEngine(0, "Oxbow")` then applies the 14 Breath Mist parameters inline (identical values to the first-launch path in `prepareToPlay`)
- Sets `firstBreathPending_` (atomic release) so `processBlock` injects the C3 note on the next audio block
- Idempotent: no-ops if `firstBreathPending_` is already set
- Not `noexcept` (calls `dynamic_cast` + APVTS setValueNotifyingHost)

**`Source/UI/Gallery/SettingsPanel.h`** — Experience section:
- New section 8 (index 7) appended after About
- `sectionY[7]` to `sectionY[8]`, `kTitles` loop count 7 to 8
- `hearGreetingAgainBtn` TextButton: `onClick` → `processor.replayFirstBreath()`
- Theme-refresh in `lookAndFeelChanged()`
- Full A11y label for screen-reader accessibility

## Test plan

- [ ] Fresh install (no saved state): Oxbow plays a soft C3 note for ~30 seconds on first load, then stops
- [ ] Subsequent loads: no auto-play (hasLaunchedBefore_ persisted via APVTS XML)
- [ ] Settings > Experience > "Hear the Greeting Again": replays Oxbow C3 note; existing engines in other slots unaffected
- [ ] Playing any note while the greeting is active: greeting stops immediately (user-input cancellation)
- [ ] Button click while greeting is active (pending): no double-arm (idempotent guard)
- [ ] Dark/light theme switch: button colors update correctly via `lookAndFeelChanged()`
- [ ] DAW session restore: no replay on re-open (hasLaunchedBefore saved in state XML)

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)