### PR TITLE
feat(W10-batch2): 10 engine behavioral genomes — Offering/Ogive/Olvido/Ostracon/Observandum/Oobleck/Ombre/Opaline/Onkolo/Outflow

### DIFF
--- a/Docs/genomes/README.md
+++ b/Docs/genomes/README.md
@@ -1,9 +1,9 @@
 # XOceanus Engine Genomes
 
-**Status:** 25 of 93 genomes complete (Wave 10 added 20 genomes — 2026-04-25)
+**Status:** 35 of 93 genomes complete (Wave 10 batch 2 added 10 genomes — 2026-04-26)
 **Schema:** v0.1 — see `Docs/specs/xogenome-schema-v0.1.md`
 **Project:** VQ 009 — Engine Genome Project
-**Updated:** 2026-04-25
+**Updated:** 2026-04-26
 
 ---
 
@@ -23,7 +23,7 @@ Genomes enable:
 
 ---
 
-## Completed Genomes (25)
+## Completed Genomes (35)
 
 | File | Engine | Category | Seance | Presets |
 |------|--------|----------|--------|---------|
@@ -52,10 +52,20 @@ Genomes enable:
 | `overtone.xogenome` | OVERTONE | spectral | 7.6 | 437 |
 | `overworld.xogenome` | OVERWORLD | lead / chip | 7.6 | 531 |
 | `oxbow.xogenome` | OXBOW | pad | 9.0 | 241 |
+| `offering.xogenome` | OFFERING | drums | 8.8 | 174 |
+| `observandum.xogenome` | OBSERVANDUM | lead | 8.1 | 21 |
+| `ombre.xogenome` | OMBRE | pad | 8.0 | 420 |
+| `ogive.xogenome` | OGIVE | spectral | unscored | 8 |
+| `olvido.xogenome` | OLVIDO | pad | unscored | 8 |
+| `ostracon.xogenome` | OSTRACON | pad | unscored | 8 |
+| `oobleck.xogenome` | OOBLECK | texture | unscored | 8 |
+| `opaline.xogenome` | OPALINE | keys | unscored | 52 |
+| `onkolo.xogenome` | ONKOLO | keys | unscored | 129 |
+| `outflow.xogenome` | OUTFLOW | fx | unscored | 27 |
 
 ---
 
-## Remaining Engines (65)
+## Remaining Engines (58)
 
 The following engines need genomes generated. Source headers are in
 `Source/Engines/{Name}/{Name}Engine.h`. Read each header for real param counts,
@@ -70,22 +80,13 @@ and check `Docs/fleet-seance-scores-2026-03-20.md` for `seance_score`.
 | OddfeliX | `snap_` | lead / pluck |
 | OddOscar | `morph_` | pad / morphing |
 | Overdub | `dub_` | pad / tape |
-| Odyssey | `drift_` | lead / wavetable |
 | Oblong | `bob_` | bass / analog |
 | Obese | `fat_` | lead / saturation |
-| Overworld | `ow_` | lead / chip |
 | Opal | `opal_` | pad / granular |
-| Orbital | `orb_` | pad / spectral |
-| Organon | `organon_` | generative / metabolism |
-| Ouroboros | `ouro_` | lead / chaotic |
 | Obsidian | `obsidian_` | pad / crystal |
 | Overbite | `poss_` | bass / physical |
-| Oracle | `oracle_` | lead / stochastic |
-| Obscura | `obscura_` | pad / physical |
 | Oceanic | `ocean_` | pad / chromatophore |
 | Ocelot | `ocelot_` | lead / biome |
-| Optic | `optic_` | fx / visual |
-| Oblique | `oblq_` | lead / prismatic |
 | Osprey | `osprey_` | pad / coastal |
 | Osteria | `osteria_` | bass / wine |
 | Owlfish | `owl_` | lead / trautonium |
@@ -96,18 +97,6 @@ and check `Docs/fleet-seance-scores-2026-03-20.md` for `seance_score`.
 | Ole | `ole_` | lead / flamenco |
 | Overlap | `olap_` | pad / knot |
 | Outwit | `owit_` | lead / chromatophore |
-| Ombre | `ombre_` | pad / dual-narrative |
-| Orca | `orca_` | lead / apex |
-| Octopus | `octo_` | lead / decentralized |
-| Ostinato | `osti_` | drum-machine / membrane |
-| OpenSky | `sky_` | pad / shimmer |
-| OceanDeep | `deep_` | bass / abyssal |
-| Ouie | `ouie_` | lead / duophonic |
-| Orbweave | `weave_` | pad / topological |
-| Overtone | `over_` | spectral / continued-fraction |
-| Organism | `org_` | generative / cellular-automata |
-| Oxbow | `oxb_` | pad / entangled-reverb |
-| Offering | `ofr_` | drum-machine / psychology |
 | Osmosis | `osmo_` | fx / membrane |
 | Kitchen Collection — XOto | (Kitchen) | organ |
 | Kitchen Collection — XOctave | (Kitchen) | organ |
@@ -116,7 +105,6 @@ and check `Docs/fleet-seance-scores-2026-03-20.md` for `seance_score`.
 | Kitchen Collection — XOven | (Kitchen) | piano |
 | Kitchen Collection — XOchre | (Kitchen) | piano |
 | Kitchen Collection — XObelisk | (Kitchen) | piano |
-| Kitchen Collection — XOpaline | (Kitchen) | piano |
 | Kitchen Collection — XOgre | (Kitchen) | bass |
 | Kitchen Collection — XOlate | (Kitchen) | bass |
 | Kitchen Collection — XOaken | (Kitchen) | bass |
@@ -131,7 +119,6 @@ and check `Docs/fleet-seance-scores-2026-03-20.md` for `seance_score`.
 | Kitchen Collection — XOvercast | (Kitchen) | pad |
 | Kitchen Collection — XOasis | (Kitchen) | ep |
 | Kitchen Collection — XOddfellow | (Kitchen) | ep |
-| Kitchen Collection — XOnkolo | (Kitchen) | ep |
 | Kitchen Collection — XOpcode | (Kitchen) | ep |
 
 ---

--- a/Docs/genomes/observandum.xogenome
+++ b/Docs/genomes/observandum.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OBSERVANDUM",
+  "engine_prefix": "obs_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "hybrid",
+    "polyphony": 8,
+    "architecture": "Polychromatic Phase Distortion synthesis — variable 2-8 phase distortion oscillators (facets) per voice, each at unique detune and phase offset; 8 mathematically-derived transfer-function distortion curves stored in 1024-point LUTs; the active curve is a lerp blend between any two basis curves controlled in real time; an environmental coupling bus warps the active curve position continuously; 2x oversampling with averaging downsample for anti-aliasing; 3 independent ADSRs per voice (amplitude, filter, distortion amount) allowing time-variant blend between pure and distorted signal."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "multi_stage",
+    "stages": 4,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 3,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.80,
+    "velocity_targets": ["amplitude", "brightness", "morph"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 72
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Simultaneously controls transfer-function curve morph position and distortion depth blend — at low CHARACTER the oscillators play near-pure phase, at high CHARACTER the morph position sweeps toward extreme curves (exponential, triangular, hyperbolic) while distortion depth increases, transforming tone into aggressive phase-warped timbre."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Drives the distortion ADSR envelope depth and LFO rate — controls how aggressively the distortion envelope breathes over time. High MOVEMENT means each note's distortion character evolves dramatically from attack to release; low MOVEMENT holds a steady timbral state."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Scales the phase spread between facets via coupling input — AudioToFM modulates facet phase spread directly, creating different inter-facet interference patterns. High COUPLING opens the engine to external harmonic influence, allowing another engine's audio to reorganize OBSERVANDUM's chromatophore display."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls the filter envelope depth and overall spectral spread of the facets — high SPACE widens the detune spread between all N facets and deepens filter modulation, creating the wide chromatophore field effect; low SPACE focuses all facets to near-unison for a dense monolithic tone."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "lead",
+    "brightness": 0.62,
+    "warmth": 0.42,
+    "movement": 0.68,
+    "density": 0.55,
+    "transient_character": "electronic"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AmpToFilter", "AudioToFM", "SpectralShaping"],
+    "best_as_target": ["AudioToFM", "EnvToMorph", "AmpToFilter"],
+    "recommended_partners": ["OBSCURA", "OGIVE", "OBLIQUE", "ORBWEAVE"],
+    "coupling_personality": "The chromatophore network — OBSERVANDUM changes its timbral color in response to incoming coupling signals the way a cuttlefish changes skin pattern; EnvToMorph coupling from another engine's envelope drives curve morph in real time, creating responsive spectral transformation. Best as a target for slow evolving sources."
+  },
+
+  "mythology": {
+    "creature": "The Cuttlefish — master of chromatophore color-phase shifts in the Epipelagic zone; every frequency is a different color, every passing shadow triggers an instantaneous timbral repainting",
+    "depth_zone": "epipelagic",
+    "felix_oscar_polarity": 0.42,
+    "accent_color": "#4ECDC4"
+  },
+
+  "metadata": {
+    "param_count": 41,
+    "preset_count": 21,
+    "seance_score": 8.1,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/offering.xogenome
+++ b/Docs/genomes/offering.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OFFERING",
+  "engine_prefix": "ofr_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "drum_circuit",
+    "polyphony": 8,
+    "architecture": "Psychology-driven boom bap drum synthesis — 8 fixed GM-mapped voices (kick/snare/hat/tom/clap/rim/tom/perc), each running through a 4-stage pipeline: TransientGenerator (per-type circuit topology: bridged-T for kick, noise burst for snare) → TextureLayer (vinyl/tape/bit/wobble via DUST macro) → CollageEngine (layers/chop/stretch/ring-mod via FLIP macro) → CityProcessingChain (5 cities × distinct spectral character via CITY macro); Curiosity Engine (Berlyne/Wundt/Csikszentmihalyi aesthetic judgment) rides the master output via DIG macro."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "ahd",
+    "stages": 3,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 2,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 2,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.85,
+    "velocity_targets": ["amplitude", "transient", "brightness", "body_resonance"],
+    "pitch_bend_range": 0,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 78
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "DIG",
+      "behavior": "Controls the Curiosity Engine — at zero, the drums sit steady; as DIG increases, aesthetic complexity rises through Berlyne's inverted-U (novelty peak then boredom plateau), Wundt's arousal curve, and Csikszentmihalyi's flow channel. High DIG morphs the city processing toward the ragged edge of recognition, where patterns almost repeat but never quite do."
+    },
+    "macro2": {
+      "name": "CITY",
+      "behavior": "Morphs the active city processing chain through 5 cities (each with its own spectral character, compression philosophy, and saturation topology). At low values the drums are dry and deconstructed; at high values the city bleeds in its own color — a fully-saturated urban processing identity applied to each voice."
+    },
+    "macro3": {
+      "name": "FLIP",
+      "behavior": "Drives the Collage Engine — adds layers (1-4), introduces chop (slice-and-gate), applies stretch artifacts, and bleeds in ring modulation at high values. Low FLIP is a clean 4-bar loop; high FLIP disassembles the loop into flickering fragments of itself."
+    },
+    "macro4": {
+      "name": "DUST",
+      "behavior": "Applies the Texture Layer — at low values the drums are clean and studio-neutral; increasing DUST simultaneously fades in vinyl crackle, tape wobble, bit-depth reduction, and sample-rate decimation. Maximum DUST crushes the drums to lo-fi soil: 4-bit, warped, scratchy, and sacred."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "drums",
+    "brightness": 0.62,
+    "warmth": 0.55,
+    "movement": 0.35,
+    "density": 0.72,
+    "transient_character": "sharp"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["RhythmToBlend", "AmpToFilter", "EnvToDecay"],
+    "best_as_target": ["AudioToBuffer", "AmpToFilter", "FilterToFilter"],
+    "recommended_partners": ["OSTINATO", "OMBRE", "ONSET", "ONKOLO"],
+    "coupling_personality": "Natural rhythm-source: OSTINATO's RhythmToBlend coupling is fleet-optimized for OFFERING's transient architecture. OFFERING sends its envelope follower into the network; other engines ride its groove. Best in an ensemble slot where it sets the tempo and character of the whole coupling chain."
+  },
+
+  "mythology": {
+    "creature": "The Mantis Shrimp — 16 photoreceptor types perceiving colors no other creature can see, living in the Rubble Zone (5-15m); OFFERING processes drum sounds through psychoacoustic dimensions that simpler engines cannot perceive",
+    "depth_zone": "rubble",
+    "felix_oscar_polarity": 0.65,
+    "accent_color": "#E5B80B"
+  },
+
+  "metadata": {
+    "param_count": 42,
+    "preset_count": 174,
+    "seance_score": 8.8,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/ogive.xogenome
+++ b/Docs/genomes/ogive.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OGIVE",
+  "engine_prefix": "ogv_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "physical_model",
+    "polyphony": 8,
+    "architecture": "Scanned glass synthesis — a spring-mass glass surface initialized with synthwave waveforms (saw/pulse/tri/sine/noise) and scanned by a read-head moving along an ogive (Gothic arch) trajectory; Verlet integration with nonlinear cubic springs drives each pane; the read head's lancet curvature and scan rate are musically controllable; up to 64 glass panes per voice; output passes through a Neon tanh saturation stage, Juno-style stereo chorus, and a gated nave reverb."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [1.0, 200.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "adsr",
+    "stages": 4,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 1,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.75,
+    "velocity_targets": ["amplitude", "brightness", "morph"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 66
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Controls glass stiffness and the Neon filter Q simultaneously — at low values the surface is flexible and resonance is gentle, producing warm glossy tones; at high values the springs stiffen into crystalline resonance and the Neon Q soars, yielding cathedral-glass tones that ring for seconds."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Modulates the read-head scan rate and lancet arch curvature — slow movement reads the glass surface lazily, extracting broad timbral sweeps; fast movement creates shimmering metallic motion as the ogive trajectory accelerates through constructive and destructive glass interference."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Scales inter-engine coupling input depth; AudioToFM modulates scan rate from an external source; SpectralShaping adds direct excitation energy to the glass surface; PhaseSync nudges the read-head phase. Increasing COUPLING opens the glass cathedral to the rest of the engine network."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls the chorus depth and nave reverb mix simultaneously — at zero OGIVE is dry and direct; increasing SPACE first widens with chorus, then the nave bloom opens behind the glass tracery, turning individual notes into architectural resonance events."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "spectral",
+    "brightness": 0.68,
+    "warmth": 0.38,
+    "movement": 0.58,
+    "density": 0.52,
+    "transient_character": "struck"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["SpectralShaping", "AmpToFilter", "AudioToFM"],
+    "best_as_target": ["AudioToFM", "SpectralShaping", "PhaseSync", "AmpToFilter"],
+    "recommended_partners": ["OVERTONE", "OBSCURA", "OXBOW", "ORIGAMI"],
+    "coupling_personality": "A spectral radiator — OGIVE's glass architecture emits rich frequency content ideal for SpectralShaping into slower, denser engines. Receives AudioToFM elegantly (scan rate responds smoothly to audio-rate FM). Best paired with reverb-heavy or spectral partners where the glass overtones can diffuse into the space."
+  },
+
+  "mythology": {
+    "creature": "Hexactinellid glass sponge — a living cathedral of silica lattice in the Twilight Zone; sound passes through its body as light through stained glass, channeling ocean current into tracery geometry",
+    "depth_zone": "twilight",
+    "felix_oscar_polarity": 0.45,
+    "accent_color": "#9B1B30"
+  },
+
+  "metadata": {
+    "param_count": 33,
+    "preset_count": 8,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/olvido.xogenome
+++ b/Docs/genomes/olvido.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OLVIDO",
+  "engine_prefix": "olv_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "spectral_stft",
+    "polyphony": 8,
+    "architecture": "Spectral erosion synthesis — PolyBLEP oscillator (saw/pulse/tri/sine/FM) feeds a 6-band Linkwitz-Riley crossover bank (split at ~80/320/650/1300/5000 Hz); each band has independent f²-scaled amplitude decay (Phillips 1977 ocean wave dissipation), so high frequencies dissolve first while low frequencies persist; per-band abyss_hold floor prevents total silence; anchor band immunity protects the fundamental; reconstruction sums band × amplitude; output feeds CytomicSVF LP filter, amplitude envelope, Patina sample-rate decimation, and FDN reverb."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "adsr",
+    "stages": 4,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 1,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.70,
+    "velocity_targets": ["amplitude", "brightness", "decay"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 72
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Simultaneously adjusts FM depth and foam (high-band noise injection) — at low CHARACTER the sound is clean and pure, at high CHARACTER FM sidebands multiply into the spectrum and foam noise fills the high bands, transforming tonal erosion into turbulent spectral weather."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Controls erosion depth and LFO rate — low MOVEMENT holds frequency content intact; increasing MOVEMENT accelerates band decay rates, pushing sound faster into abyss-floor frequencies. The erosion analogy: high MOVEMENT is strong current stripping paint from a submerged hull."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Opens the AudioToBuffer coupling path — external engine audio enters the highest spectral bands as additional content that is then subject to erosion decay. Coupling allows another engine's brightness to feed OLVIDO and gradually dissolve, creating shared-memory timbral archaeology."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls the FDN reverb size and the Patina (sample-rate reduction) amount simultaneously — at zero OLVIDO is dry and present; high SPACE extends the decay into a vast abyssal reverb while Patina adds lo-fi grit, creating the sensation of listening through kilometers of ocean water."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "pad",
+    "brightness": 0.25,
+    "warmth": 0.55,
+    "movement": 0.62,
+    "density": 0.48,
+    "transient_character": "soft"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["SpectralShaping", "AmpToFilter", "EnvToDecay"],
+    "best_as_target": ["AudioToBuffer", "SpectralShaping", "EnvToDecay", "AmpToFilter"],
+    "recommended_partners": ["OGIVE", "OSTRACON", "OBSCURA", "OXBOW"],
+    "coupling_personality": "The spectral archaeologist — OLVIDO decays everything it receives, making it a destructive but poetic target for AudioToBuffer input. Best paired with bright, rich sources (OGIVE, OSTRACON) whose content OLVIDO slowly erodes into memory traces. Also productive as a source: its envelope-follower output tracks erosion progress and can drive EnvToDecay in other engines."
+  },
+
+  "mythology": {
+    "creature": "The Coelacanth (Latimeria chalumnae) — living fossil of the Midnight Zone (1000-4000m), thought extinct for 65 million years; sound erodes like memory in deep water, higher frequencies dissolving first, leaving only the abyssal low end intact",
+    "depth_zone": "midnight",
+    "felix_oscar_polarity": 0.72,
+    "accent_color": "#3B6E8F"
+  },
+
+  "metadata": {
+    "param_count": 33,
+    "preset_count": 8,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/ombre.xogenome
+++ b/Docs/genomes/ombre.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OMBRE",
+  "engine_prefix": "ombre_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "hybrid",
+    "polyphony": 8,
+    "architecture": "Dual-narrative synthesis — each voice contains two simultaneous sound sources: Oubli (a circular memory buffer recording and fading over time, reconstructed by multiple staggered read-heads with age-based exponential decay via O(1) lazy attenuation) and Opsis (a direct PolyBLEP oscillator reacting immediately to notes); Blend parameter crossfades between them; Interference parameter feeds one narrative into the other; two LFOs — one modulates blend (CHARACTER shimmer/darkness axis), one modulates oscillator pitch (MOVEMENT) — creating a four-dimensional timbral space of memory vs. presence."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "adsr",
+    "stages": 4,
+    "curve": "linear_attack_exp_decay"
+  },
+
+  "modulation": {
+    "lfo_count": 2,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 2,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.72,
+    "velocity_targets": ["amplitude", "brightness", "decay"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 66
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Drives LFO1 modulation of the Oubli/Opsis blend — at zero the blend is fixed (SPACE sets the static position); increasing CHARACTER adds shimmer and shadow cycling between the memory and presence poles, creating the gradient-fading quality that defines OMBRE's identity."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Scales both LFO depths simultaneously — zero is completely frozen (no modulation from either LFO); one gives full motion to both blend LFO and pitch LFO. MOVEMENT controls how much OMBRE breathes versus how much it holds a still, gradient-painted tone."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Controls inter-engine coupling input depth — incoming audio can be fed into the Oubli memory buffer directly, allowing another engine's voices to write into OMBRE's fading memory and become part of the dual narrative. High COUPLING creates deep cross-engine entanglement."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Sets the static Oubli/Opsis blend position and the memory buffer decay rate — low SPACE sits near Opsis (direct, immediate, bright); high SPACE shifts toward Oubli (delayed, fading, deep) and extends memory decay so past notes linger as ghost echoes behind present ones."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "pad",
+    "brightness": 0.35,
+    "warmth": 0.62,
+    "movement": 0.55,
+    "density": 0.68,
+    "transient_character": "soft"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AudioToBuffer", "AmpToFilter", "EnvToDecay"],
+    "best_as_target": ["AudioToBuffer", "AmpToFilter", "FilterToFilter"],
+    "recommended_partners": ["OSTRACON", "OLVIDO", "OBSCURA", "OXBOW"],
+    "coupling_personality": "A dual-narrative dreamer — OMBRE's Oubli/Opsis architecture naturally receives external voices into its memory. AudioToBuffer coupling feeds external audio into the fading buffer; OMBRE then reconstructs it through its blend narrative. Best paired with OSTRACON (shared memory philosophies) and OLVIDO (both engines process forgetting through different mechanisms)."
+  },
+
+  "mythology": {
+    "creature": "Shadow Mauve Wrasse — gradient-fading fish of the Twilight Zone; two simultaneous narratives: what the creature remembers and what it is now, both present, neither dominant",
+    "depth_zone": "twilight",
+    "felix_oscar_polarity": 0.68,
+    "accent_color": "#7B6B8A"
+  },
+
+  "metadata": {
+    "param_count": 24,
+    "preset_count": 420,
+    "seance_score": 8.0,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/onkolo.xogenome
+++ b/Docs/genomes/onkolo.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "ONKOLO",
+  "engine_prefix": "onko_",
+  "collection": "Kitchen Collection",
+
+  "oscillator": {
+    "type": "physical_model",
+    "polyphony": 8,
+    "architecture": "Clavinet D6 physical model — a rubber pad strikes a tensioned string, which vibrates between two magnetic pickups (bridge: bright and cutting; neck: warm and full); pickup position determines timbre; the defining characteristic is aggressive percussive attack and controlled sustain; key-off produces a mechanical damper-pad clunk; auto-wah (envelope-following CytomicSVF filter) is the iconic Clavinet effect; mod wheel → funk (wah depth); aftertouch → pickup brightness; per-voice glide processor; design lineage traces from West African nkolo ancestor to Hohner D6 to Stevie Wonder's funk."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": true
+  },
+
+  "envelope": {
+    "type": "ad",
+    "stages": 2,
+    "curve": "linear_attack_exp_decay"
+  },
+
+  "modulation": {
+    "lfo_count": 2,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 2,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.88,
+    "velocity_targets": ["amplitude", "transient", "brightness", "attack"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "custom",
+    "dynamic_range_db": 72
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Controls rubber pad hardness and string tension — low CHARACTER is loose and warm (West African kalimba timbres); high CHARACTER is tight and bright (Clavinet bridge pickup at full extension), sharpening the percussive attack and reducing sustain."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Drives auto-wah envelope follower sensitivity and LFO rates — at low MOVEMENT the filter holds still after attack; increasing MOVEMENT animates the wah response and LFO modulation, creating the involuntary-movement funk that defines the Clavinet at its most iconic."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Scales coupling filter modulation depth — incoming AmpToFilter or FilterToFilter coupling drives the auto-wah cutoff, allowing rhythmic signals from another engine (OSTINATO, ONSET) to trigger the wah envelope externally, creating sidechain funk."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls pickup position blend and stereo width — low SPACE is pure bridge pickup (cutting, present); high SPACE blends in neck pickup (warm, full) and widens the stereo image, adding the room and body of a well-recorded studio Clavinet."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "keys",
+    "brightness": 0.72,
+    "warmth": 0.45,
+    "movement": 0.48,
+    "density": 0.38,
+    "transient_character": "struck"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AmpToFilter", "RhythmToBlend", "EnvToDecay"],
+    "best_as_target": ["AmpToFilter", "FilterToFilter", "AudioToFM"],
+    "recommended_partners": ["OSTINATO", "ONSET", "OFFERING", "OWARE"],
+    "coupling_personality": "The funk anchor — ONKOLO sends its sharp percussive envelope outward via AmpToFilter coupling to drive other engines' filter movement (sidechain wah). Receives rhythmic coupling from OSTINATO/ONSET beautifully, turning external drum patterns into auto-wah triggers. In Kitchen Quad: amber spectral resonance core, Sunlit zone Dungeness Crab."
+  },
+
+  "mythology": {
+    "creature": "The Dungeness Crab — amber-colored, Sunlit Zone (5m depth); nkolo ancestor carries West African diaspora through the thumb piano lineage into the Clavinet's strings, centuries of percussive sophistication arriving in a rubber pad and two magnetic pickups",
+    "depth_zone": "sunlit",
+    "felix_oscar_polarity": 0.38,
+    "accent_color": "#FFBF00"
+  },
+
+  "metadata": {
+    "param_count": 21,
+    "preset_count": 129,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/oobleck.xogenome
+++ b/Docs/genomes/oobleck.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OOBLECK",
+  "engine_prefix": "oobl_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "cellular_automata",
+    "polyphony": 8,
+    "architecture": "Reaction-diffusion wavetable synthesis — per-voice 128-cell 1D Gray-Scott ring grid (Gray & Scott 1984, Pearson 1993 adapted for 1D); U and V chemical concentrations are evolved each audio block; V concentration is read directly as the waveform, so chemistry generates timbre in real time; diffusion rates and feed/kill parameters select distinct chemical patterns (spots, stripes, spirals, chaos); the RD grid is initialized on note-on and runs continuously; output passes through CytomicSVF LP filter, amplitude ADSR, and LFO modulation; non-Newtonian aftertouch response jams (freezes) the simulation under sustained pressure."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "adsr",
+    "stages": 4,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h"],
+    "mod_matrix_depth": 1,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.70,
+    "velocity_targets": ["amplitude", "brightness", "filter"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "custom",
+    "dynamic_range_db": 64
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Blends between clean synthesis output and the raw RD chemistry grid — at low CHARACTER the sound is dominated by the conventional oscillator path; at high CHARACTER the Gray-Scott V concentration drives more of the output, introducing chemical waveform irregularities that have no analog in traditional synthesis. Non-additive blend as per QDD mandate."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Controls the RD evolution rate (how many Gray-Scott steps per audio block) — slow MOVEMENT holds the chemical pattern nearly frozen, reading one timbral snapshot per note; fast MOVEMENT lets the chemistry run at full speed, creating organic evolving waveforms that shift morphology over seconds."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Scales inter-engine coupling input into the RD feed parameter — incoming audio can perturb the chemical feed rate, causing the spot/stripe pattern to reorganize in response to external stimulation. OOBLECK can receive audio from another engine and convert it into chemistry disturbance."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls filter cutoff and resonance simultaneously — at zero the output is narrow and focused; increasing SPACE opens the LP filter and raises Q, allowing the full RD spectral content to emerge. High SPACE on a fast-moving RD grid produces dense, swirling spectral complexity."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "texture",
+    "brightness": 0.48,
+    "warmth": 0.35,
+    "movement": 0.82,
+    "density": 0.62,
+    "transient_character": "complex"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AmpToFilter", "SpectralShaping", "AudioToFM"],
+    "best_as_target": ["AudioToFM", "AmpToFilter", "EnvToDecay"],
+    "recommended_partners": ["ORGANISM", "OUROBOROS", "OLVIDO", "OBSERVANDUM"],
+    "coupling_personality": "A chemical reactor — OOBLECK generates organic, unpredictable timbral motion that pairs well with engines that thrive on spectral feed (OLVIDO, OBSERVANDUM). The non-Newtonian aftertouch behavior makes OOBLECK uniquely expressive in live-coupling contexts where pressure becomes chemistry jam."
+  },
+
+  "mythology": {
+    "creature": "Non-Newtonian Nudibranch — morphing between fluid and solid states in the Midnight Zone; slime-green, pressure-sensitive, neither liquid nor solid, belonging to no phase in particular",
+    "depth_zone": "midnight",
+    "felix_oscar_polarity": 0.55,
+    "accent_color": "#B4FF39"
+  },
+
+  "metadata": {
+    "param_count": 33,
+    "preset_count": 8,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/opaline.xogenome
+++ b/Docs/genomes/opaline.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OPALINE",
+  "engine_prefix": "opal2_",
+  "collection": "Kitchen Collection",
+
+  "oscillator": {
+    "type": "physical_model",
+    "polyphony": 8,
+    "architecture": "Glass and porcelain modal synthesis — the most delicate engine in the XOceanus fleet; four instrument models (Celesta, Toy Piano, Glass Harp, Porcelain Cups) each with distinct modal ratios, decay profiles, and material physics (borosilicate glass / porcelain, rho=2230 kg/m³); the defining mechanic is FRAGILITY — hard velocity cracks the sound, injecting noise bursts and modal detuning; Kitchen Quad position: fourth engine (lowest impedance Z=12.6M, best energy crossing, narrowest mode bandwidth, most breakable contrast to XOven's massive darkness)."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": true
+  },
+
+  "envelope": {
+    "type": "ad",
+    "stages": 2,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine", "triangle", "saw", "square"],
+    "mod_matrix_depth": 1,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.92,
+    "velocity_targets": ["amplitude", "brightness", "transient", "morph"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 60
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Selects and blends between the four glass/porcelain instrument models — Celesta, Toy Piano, Glass Harp, Porcelain Cups — each with its own modal ratio signature and decay profile. Low CHARACTER is celesta warmth; high CHARACTER is porcelain cups' brittle ring. The blend reveals different fractional modal overtones."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Controls modal shimmer LFO depth and filter frequency modulation — at low MOVEMENT the tones ring out pure and still; at high MOVEMENT the modes breathe with slow AM shimmer and the filter sweeps gently through the porcelain spectrum."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Scales inter-engine coupling input — incoming energy from a neighboring engine is routed into the modal excitation stage, effectively striking the glass body with an external signal rather than the internal hammer. Allows external engines to play OPALINE's resonators."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls the fragility threshold and reverb size — at low SPACE the glass is robust and rings cleanly; increasing SPACE lowers the fracture threshold so lower velocities can crack the sound, and simultaneously opens the reverb bloom, letting broken overtones ring in a larger room."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "keys",
+    "brightness": 0.78,
+    "warmth": 0.22,
+    "movement": 0.28,
+    "density": 0.32,
+    "transient_character": "struck"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AmpToFilter", "EnvToDecay", "SpectralShaping"],
+    "best_as_target": ["AudioToFM", "AmpToFilter", "KnotTopology"],
+    "recommended_partners": ["ONSET", "OWARE", "OGIVE", "OBSERVANDUM"],
+    "coupling_personality": "The crystal bell — OPALINE responds to coupling input as a resonant body responds to an external mallet; it sings most purely in combination with percussive or rhythmic sources (ONSET, OWARE) that can strike its glass structure repeatedly. In Kitchen Quad context, OPALINE sits at the fragile tip of the impedance chain, receiving energy from the other three."
+  },
+
+  "mythology": {
+    "creature": "The Glass Shrimp (Palaemon serratus) — transparent crystalline crustacean of the Sunlit Zone; every internal organ visible through the glass body; porcelain-fragile, beautiful because breakable",
+    "depth_zone": "sunlit",
+    "felix_oscar_polarity": 0.28,
+    "accent_color": "#B7410E"
+  },
+
+  "metadata": {
+    "param_count": 25,
+    "preset_count": 52,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/ostracon.xogenome
+++ b/Docs/genomes/ostracon.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OSTRACON",
+  "engine_prefix": "ostr_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "hybrid",
+    "polyphony": 8,
+    "architecture": "Corpus-buffer synthesis — a shared circular buffer acts as communal tape; all active voices write their PolyBLEP oscillator output (saw/square/tri/noise) into one tape reel simultaneously; each voice then reads back via 1-4 independent per-voice read heads with Mellotron-style physical degradation: oxide filtering (distance-scaled bandwidth loss via Jorgensen frequency response), flutter pitch instability (Pressnitzer & McAdams threshold), and print-through ghost bleed from previous revolutions (Camras 1988 oxide shedding); the longer the reel, the deeper the communal memory."
+  },
+
+  "filter": {
+    "topology": "svf",
+    "modes": ["lowpass", "highpass", "bandpass"],
+    "resonance_range": [0.0, 1.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "adsr",
+    "stages": 4,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine", "triangle", "saw", "square", "s_and_h", "random"],
+    "mod_matrix_depth": 6,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.65,
+    "velocity_targets": ["amplitude", "brightness", "transient"],
+    "pitch_bend_range": 2,
+    "aftertouch_response": "multi",
+    "dynamic_range_db": 64
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Controls oxide level and source oscillator mix — low CHARACTER plays the waveform cleanly with minimal tape degradation; high CHARACTER increases oxide shedding (bandwidth loss proportional to read-head distance from write-head), blending in worn-tape tonality and smearing transient edges."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Drives flutter depth and read-head spread simultaneously — at zero the tape runs perfectly steady; increasing MOVEMENT adds Pressnitzer pitch instability (wow and flutter) and spreads the read heads further apart in time, creating the sensation of multiple parallel tape machines reading the same reel from different positions."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Scales coupling input depth — external audio via AudioToBuffer can be written into the shared tape reel, entangling another engine's voice with OSTRACON's communal memory. High COUPLING allows deep external contamination of the tape record."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Controls print-through (ghost bleed from previous revolution) and LFO depth — low SPACE is clean; high SPACE increases oxide print-through until ghost voices emerge from past revolutions, adding a soft ambiguity between what is playing now and what was played before."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "pad",
+    "brightness": 0.38,
+    "warmth": 0.72,
+    "movement": 0.55,
+    "density": 0.65,
+    "transient_character": "soft"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AudioToBuffer", "AmpToFilter", "EnvToDecay"],
+    "best_as_target": ["AudioToBuffer", "AmpToFilter", "KnotTopology"],
+    "recommended_partners": ["OLVIDO", "OMBRE", "OBSCURA", "OXBOW"],
+    "coupling_personality": "The communal memory hub — OSTRACON's shared tape architecture makes it the best AudioToBuffer target and source in the fleet; two OSTRACON instances coupled via AudioToBuffer create interlocking tape histories. Pairs beautifully with OLVIDO (OSTRACON records; OLVIDO erodes the playback), and with OMBRE (dual-narrative forgetting deepened by OSTRACON's physical tape artifacts)."
+  },
+
+  "mythology": {
+    "creature": "The Hermit Crab — carries its tape-reel shell on its back in the Surface Zone; Mellotron physics, the shell contains all previous sounds, and when the crab moves to a new shell it takes its recorded history with it",
+    "depth_zone": "surface",
+    "felix_oscar_polarity": 0.58,
+    "accent_color": "#C0785A"
+  },
+
+  "metadata": {
+    "param_count": 32,
+    "preset_count": 8,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}

--- a/Docs/genomes/outflow.xogenome
+++ b/Docs/genomes/outflow.xogenome
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "engine_id": "OUTFLOW",
+  "engine_prefix": "out_",
+  "collection": null,
+
+  "oscillator": {
+    "type": "hybrid",
+    "polyphony": 1,
+    "architecture": "Predictive spatial synthesis — monophonic; a 20ms lookahead delay line enables pre-transient detection; Bayesian envelope predictor anticipates upcoming transients before they arrive; when a transient is predicted, the VCA drops to zero just before impact (Pre-Wake Vacuum) creating an acoustic void that the Undertow reverb then fills with optically-saturated tail; the harder the gate clamps, the warmer the reverb tail; Tidal Drift ages the room geometry over minutes via sub-audible LFO; the engine processes its own exciter signal or coupling input audio."
+  },
+
+  "filter": {
+    "topology": "none",
+    "modes": [],
+    "resonance_range": [0.0, 0.0],
+    "key_tracking": false
+  },
+
+  "envelope": {
+    "type": "custom",
+    "stages": 2,
+    "curve": "exponential"
+  },
+
+  "modulation": {
+    "lfo_count": 1,
+    "lfo_shapes": ["sine"],
+    "mod_matrix_depth": 1,
+    "audio_rate_mod": false
+  },
+
+  "response_surface": {
+    "velocity_sensitivity": 0.55,
+    "velocity_targets": ["amplitude", "transient"],
+    "pitch_bend_range": 0,
+    "aftertouch_response": "none",
+    "dynamic_range_db": 60
+  },
+
+  "macro_personality": {
+    "macro1": {
+      "name": "CHARACTER",
+      "behavior": "Controls predictor sensitivity and optical saturation character — low CHARACTER is a gentle predictor that occasionally misses transients; high CHARACTER is highly sensitive, detecting and gating more frequently with more pronounced optical saturation shaping the reverb tail color."
+    },
+    "macro2": {
+      "name": "MOVEMENT",
+      "behavior": "Drives Tidal Drift LFO depth — controls how much the room geometry ages over time; low MOVEMENT holds a static room; increasing MOVEMENT slowly morphs reverb size and decay over minutes, creating the impression of being carried on a tide through changing acoustic spaces."
+    },
+    "macro3": {
+      "name": "COUPLING",
+      "behavior": "Controls undertow pull — vacuum aggressiveness; high COUPLING makes the pre-transient vacuum deeper and more abrupt, maximizing the prediction-reality gap that becomes the instrument. Also scales coupling input audio depth for processing external signals."
+    },
+    "macro4": {
+      "name": "SPACE",
+      "behavior": "Sets Undertow reverb size and pre-delay — at zero OUTFLOW is tight and present; increasing SPACE opens the room from a small chamber to a vast ocean cavern, extending the saturated tail that fills the pre-transient vacuums."
+    }
+  },
+
+  "sonic_character": {
+    "primary_category": "fx",
+    "brightness": 0.28,
+    "warmth": 0.62,
+    "movement": 0.72,
+    "density": 0.45,
+    "transient_character": "complex"
+  },
+
+  "coupling_affinity": {
+    "best_as_source": ["AmpToFilter", "EnvToDecay", "AudioToBuffer"],
+    "best_as_target": ["AudioToBuffer", "AudioToFM", "AmpToFilter"],
+    "recommended_partners": ["ONSET", "OFFERING", "OBSCURA", "OXBOW"],
+    "coupling_personality": "The vacuum architect — OUTFLOW is most powerful in sidechain positions where it processes audio from a transient-rich source (ONSET, OFFERING) via AudioToBuffer coupling; it predicts those transients and creates vacuums around them. A unique FX-role engine that fundamentally changes the rhythmic feel of whatever it processes."
+  },
+
+  "mythology": {
+    "creature": "The Vampire Squid (Vampyroteuthis infernalis) — the Midnight Zone predator that inverts its tentacled web to trap marine snow; OUTFLOW creates acoustic vacuums the way the vampire squid creates physical ones, filling the void with something stranger than the absence",
+    "depth_zone": "midnight",
+    "felix_oscar_polarity": 0.78,
+    "accent_color": "#1A1A40"
+  },
+
+  "metadata": {
+    "param_count": 14,
+    "preset_count": 27,
+    "seance_score": null,
+    "guru_bin_retreat": false,
+    "version_added": "V1.0"
+  }
+}


### PR DESCRIPTION
## Summary

Wave 10 batch 2 — advances the VQ 009 Engine Genome Project from 25/93 to **35/93 complete**.

- **10 new `.xogenome` behavioral fingerprints** for engines in the adaptable/unscored tier, derived directly from source headers (`Source/Engines/{Name}/{Name}Engine.h`)
- **`Docs/genomes/README.md` updated**: status 25→35, completed table expanded, remaining list 65→58

## Engines covered (with key architecture notes)

| Engine | Oscillator type | Params | Presets | Seance |
|--------|----------------|--------|---------|--------|
| OFFERING | drum_circuit (8-voice boom bap) | 42 | 174 | 8.8 |
| OBSERVANDUM | hybrid (polychromatic phase distortion, 8 transfer curves) | 41 | 21 | 8.1 |
| OMBRE | hybrid (dual-narrative Oubli/Opsis) | 24 | 420 | 8.0 |
| OGIVE | physical_model (scanned glass, Verlet springs) | 33 | 8 | — |
| OLVIDO | spectral (f²-scaled band erosion, 6-band LR crossover) | 33 | 8 | — |
| OSTRACON | hybrid (corpus-buffer/tape, shared circular reel) | 32 | 8 | — |
| OOBLECK | cellular_automata (Gray-Scott reaction-diffusion) | 33 | 8 | — |
| OPALINE | physical_model (glass/porcelain modal, Kitchen Quad) | 25 | 52 | — |
| ONKOLO | physical_model (Clavinet D6, Kitchen Fusion quad) | 21 | 129 | — |
| OUTFLOW | hybrid (predictive spatial, 20ms lookahead vacuum) | 14 | 27 | — |

## Approach

- **Slice A (spec generation)**: No rendering pipeline in repo — assets are user-local at `~/pixel-art-output/`. Work here is the Track B (genome + behavioral spec) side of Wave 10.
- All genomes validated: `python3 -m json.tool` VALID on all 10 files.
- Architecture strings, macro names, and parameter counts derived from real source headers — not from documentation assumptions.
- 4-macro personality documented for each engine: CHARACTER/MOVEMENT/COUPLING/SPACE behaviors pulled from source code macro application blocks.

## Test plan

- [ ] `python3 -m json.tool Docs/genomes/*.xogenome | grep -c '{'` — should equal 10+ new genomes
- [ ] `jq -rs '[.[].engine_id] | sort' Docs/genomes/*.xogenome` — all 10 new engine IDs appear
- [ ] `jq -rs 'map(select(.coupling_affinity.recommended_partners | length > 0)) | length' Docs/genomes/*.xogenome` — all 10 have coupling recommendations
- CI skips non-source changes — no build check required

🤖 Generated with [Claude Code](https://claude.com/claude-code)