### PR TITLE
issue-triage-fix: 7 issues filed, 4 Haiku-tier fixes (DSP / security / docs)

### DIFF
--- a/Docs/concepts/guild-market-review-oxidize.md
+++ b/Docs/concepts/guild-market-review-oxidize.md
@@ -170,7 +170,7 @@ These are non-negotiable. OXIDIZE without these is not OXIDIZE.
 
 ### Which Moods Should OXIDIZE Target?
 
-From the 15 mood categories, ranked by fit:
+From the 16 mood categories, ranked by fit:
 
 **Primary moods (core OXIDIZE territory):**
 

--- a/Docs/design/asset-registry.md
+++ b/Docs/design/asset-registry.md
@@ -541,7 +541,7 @@ Each kit contains a coordinated set of: background panel, knobs (big + small or 
 
 | File | Path | Status | Notes |
 |------|------|--------|-------|
-| **design-tokens.css** | `~/Documents/GitHub/XO_OX-XOmnibus/Site/design-tokens.css` | CANONICAL | 10 sections: Global Brand, Depth Zones, 88 Engine Colors, Anatomy, Glass Formula, PlaySurface, Typography, Type Scale (10 tokens), Spacing, Animation |
+| **design-tokens.css** | `~/Documents/GitHub/XO_OX-XOmnibus/Site/design-tokens.css` | CANONICAL | 10 sections: Global Brand, Depth Zones, 86 Engine Colors, Anatomy, Glass Formula, PlaySurface, Typography, Type Scale (10 tokens), Spacing, Animation |
 | **engine-creature-map.json** | `~/Documents/GitHub/XO_OX-XOmnibus/Site/engine-creature-map.json` | CANONICAL | Engine name → mythology mapping → accent color |
 
 ### 12.2 Design Documentation (all in `Docs/design/`)

--- a/Docs/design/ui-components-dimensions-2026-03-26.md
+++ b/Docs/design/ui-components-dimensions-2026-03-26.md
@@ -226,7 +226,7 @@ Selected border:  2px left bar in accent color
 
 Mood pip:         5×5 px circle @ 70% opacity
                   Positioned at (10, centerY - 2.5)
-                  Color varies by mood (15 mood-specific colors defined Lines 108–124)
+                  Color varies by mood (16 mood-specific colors defined Lines 108–124)
 
 Preset name:      left-aligned, Inter 11.5pt, T1/T2 color
                   Bounds: (22, 0, w-36, h)

--- a/Docs/design/ui-components-dimensions-2026-03-26.md
+++ b/Docs/design/ui-components-dimensions-2026-03-26.md
@@ -197,7 +197,7 @@ Border:         border() color @ 1px
 pillH           = 20 px
 hGap            = 4 px (horizontal gap)
 vGap            = 4 px (vertical gap)
-16 pills total  = ALL + 16 moods (Foundation, Atmosphere, Entangled, Prism, Flux, Aether, Family, Submerged, Coupling, Crystalline, Deep, Ethereal, Kinetic, Luminous, Organic)
+16 pills total  = ALL + 16 moods (Foundation, Atmosphere, Entangled, Prism, Flux, Aether, Family, Submerged, Coupling, Crystalline, Deep, Ethereal, Kinetic, Luminous, Organic, Shadow)
 
 Pill widths:    measured per-button, min 32px, text-based width + 18px padding
 Text font:      Inter 9pt

--- a/Docs/design/xoceanus-definitive-ui-spec.md
+++ b/Docs/design/xoceanus-definitive-ui-spec.md
@@ -71,7 +71,7 @@ This is the 12-year-old test: a child opens the plugin and hears something beaut
 
 Every engine has a unique accent color. This is not decoration — it is a complete visual language system. When OPERA (Aria Gold `#D4AF37`) is active, the macro knob arcs, the coupling strip, the PlaySurface trails, the preset browser highlights, and the knob indicators ALL shift to Aria Gold. When you switch to OBRIX (Reef Jade `#1E8B7E`), the entire interface shifts. The color IS the engine's voice.
 
-No other synthesizer uses an 88-color system as a functional communication layer. Most use 2-3 accent colors for UI states. XOceanus's color system means a performer can identify the active engine from across the room, from a blurred screenshot, from peripheral vision while looking at a piano keyboard.
+No other synthesizer uses an 86-color system as a functional communication layer. Most use 2-3 accent colors for UI states. XOceanus's color system means a performer can identify the active engine from across the room, from a blurred screenshot, from peripheral vision while looking at a piano keyboard.
 
 ### 1.1.2 The Emotional Arc
 
@@ -998,7 +998,7 @@ Several engine accent colors on dark backgrounds:
 | Component | AccessibilityRole | Label Pattern | Value Pattern |
 |-----------|------------------|---------------|---------------|
 | Macro Knob | `slider` | "Character macro" | "72 percent" |
-| Engine Selector | `comboBox` | "Engine selector, currently OPERA" | "OPERA, engine 45 of 88" |
+| Engine Selector | `comboBox` | "Engine selector, currently OPERA" | "OPERA, engine 45 of 86" |
 | Preset Navigator | `group` | "Preset navigator" | — |
 | Preset Name | `staticText` | "Current preset: Velvet Morning" | — |
 | Prev/Next Preset | `button` | "Previous preset" / "Next preset" | — |
@@ -1241,7 +1241,7 @@ This is embodied cognition applied to software design. It has never been attempt
 
 **Disable**: Settings toggle "Adaptive UI" (default: ON). Reduced motion mode: OFF.
 
-### 5.2.4 The Constellation View — Seeing All 88 at Once
+### 5.2.4 The Constellation View — Seeing All 86 at Once
 
 Every synth forces you to look at one engine at a time. XOceanus has 86 engines. What if you could see ALL of them?
 
@@ -1257,9 +1257,9 @@ This gives the performer a god's-eye view of the entire XOceanus universe. It is
 
 No synthesizer has ever shown its entire capability space in a single, beautiful, interactive view.
 
-**Implementation**: 88 positioned circles with SVG creature icons. Layout: hardcoded positions following the water column arrangement from the design guidelines (Section 10.2). Click: loads engine into active slot. Drag between: creates coupling route. Golden lines: same Bezier rendering as coupling visualizer.
+**Implementation**: 86 positioned circles with SVG creature icons. Layout: hardcoded positions following the water column arrangement from the design guidelines (Section 10.2). Click: loads engine into active slot. Drag between: creates coupling route. Golden lines: same Bezier rendering as coupling visualizer.
 
-**JUCE**: `ConstellationOverlay : public juce::Component`. Full-window overlay, modal. 88 `juce::Component` children (engine stars). Lines painted in parent `paint()`. Fade-in: 300ms.
+**JUCE**: `ConstellationOverlay : public juce::Component`. Full-window overlay, modal. 86 `juce::Component` children (engine stars). Lines painted in parent `paint()`. Fade-in: 300ms.
 
 ---
 
@@ -1368,7 +1368,7 @@ No synthesizer has ever shown its entire capability space in a single, beautiful
 | Sharp key | `#2A2A2A` | Seaboard black keys |
 | Hit flash | `#FFFFFF` at 20% | Pad impact feedback |
 
-## A.8 All 88 Engine Accent Colors
+## A.8 All 86 Engine Accent Colors
 
 (Full table — see CLAUDE.md Engine Modules table for complete listing. All 86 engines with hex values are defined there and are the canonical reference.)
 
@@ -1767,7 +1767,7 @@ All spring physics: `velocity += (target - current) * stiffness; velocity *= dam
 
 ---
 
-*This document supersedes all previous UI specifications for XOceanus. It is the single source of truth for interface implementation. Every pixel described here has been considered in context of the purchased assets, the existing codebase, the aquatic mythology, the 88-engine fleet, and the mandate to surpass every synthesizer interface ever created.*
+*This document supersedes all previous UI specifications for XOceanus. It is the single source of truth for interface implementation. Every pixel described here has been considered in context of the purchased assets, the existing codebase, the aquatic mythology, the 86-engine fleet, and the mandate to surpass every synthesizer interface ever created.*
 
 *The interface is the instrument. The instrument is the interface. The mythology is the medium.*
 

--- a/Docs/design/xoceanus-spatial-architecture-v1.md
+++ b/Docs/design/xoceanus-spatial-architecture-v1.md
@@ -12,7 +12,7 @@
 ### Hard Constraints
 - **Plugin window:** 1100×700pt default | min 960×600 | max 1920×1080
 - **MPC Hardware Plugin:** min 800×480pt (new — Kai's team flagged MPC One/Live II viewport)
-- **4 engine slots** simultaneously, drawn from 88 swappable engines
+- **4 engine slots** simultaneously, drawn from 86 swappable engines
 - **15 coupling types** between any engine pair
 - **6 FX slots per engine** (SAT/DELAY/REVERB/MOD/COMP/SEQ) — corrected from draft's "4"
 - **3 PlaySurface modes** (XOuija fretless, MPC 16-pad, Seaboard keyboard)
@@ -304,7 +304,7 @@ Persistent. Shows 4 nodes corresponding to the 4 tiles. Arcs between coupled nod
 | │ 81 params│ │ drum     │ │ vocal    │ │ love     │    |
 | │ Flagship │ │ Flagship │ │ Flagship│ │ ★Pick  │    |
 | └──────────┘ └──────────┘ └──────────┘ └──────────┘    |
-| [... 88 cards, filterable, scrollable ...]              |
+| [... 86 cards, filterable, scrollable ...]              |
 +══════════════════════════════════════════════════════════+
 ```
 Each card: creature icon, engine name, accent color, category, brief description, quality tier badge (Flagship / Editor's Pick / Standard — NOT raw seance scores, which are internal). Click to load into the slot that triggered the browser.
@@ -509,8 +509,8 @@ Performance Lock toggle prevents accidental parameter changes.
 
 | # | Component | Used By | Customization |
 |---|-----------|---------|--------------|
-| 1 | **RotaryKnob** | All 88 | Size (24/32/40/56pt), accent, filmstrip set, mod ring (V1.1) |
-| 2 | **CollapsibleSection** | All 88 | Name, color, hero params, expanded/collapsed |
+| 1 | **RotaryKnob** | All 86 | Size (24/32/40/56pt), accent, filmstrip set, mod ring (V1.1) |
+| 2 | **CollapsibleSection** | All 86 | Name, color, hero params, expanded/collapsed |
 | 3 | **NamedModeSelector** | ~20 engines | Options, icons, searchable, grid vs pills |
 | 4 | **AccumulationMeter** | 5+ engines | Direction, threshold, reset button, time scale |
 | 5 | **TopologySelector** | 3 engines | Topology names, visual preview, morph position |

--- a/Docs/design/xoceanus-spatial-architecture.md
+++ b/Docs/design/xoceanus-spatial-architecture.md
@@ -29,7 +29,7 @@
 ### Hard Constraints (non-negotiable)
 - **Window:** 1100×700pt default, min 960×600, max 1920×1080
 - **4 engine slots** simultaneously active
-- **88 swappable engines** with 24-111 parameters each
+- **86 swappable engines** with 24-111 parameters each
 - **15 coupling types** between any pair of loaded engines
 - **FX chain** per engine (6 FX slots: SAT/DELAY/REVERB/MOD/COMP/SEQ)
 - **PlaySurface** with 3 modes (XOuija fretless, MPC 16-pad, Seaboard keyboard)
@@ -61,7 +61,7 @@ Most synths have 2-3 sound sources (oscillators). XOceanus has **4 simultaneous 
 
 | Synth | Layout Pattern | Engines/Oscs | What Works | What Doesn't (for us) |
 |-------|---------------|-------------|------------|----------------------|
-| **Vital** | 3-column (OSC1 / FILTER+ENV / OSC2+3), mod matrix bottom | 3 osc + sampler | Everything visible, logical flow L→R, wavetable editor dominates | Fixed 3-osc layout, doesn't scale to 88 swappable engines |
+| **Vital** | 3-column (OSC1 / FILTER+ENV / OSC2+3), mod matrix bottom | 3 osc + sampler | Everything visible, logical flow L→R, wavetable editor dominates | Fixed 3-osc layout, doesn't scale to 86 swappable engines |
 | **Serum** | 2 oscs top, filter mid, FX tabs bottom, matrix sidebar | 2 osc | Clean wavetable view, tab system for FX depth | Only 2 sources, tabs feel hidden |
 | **Pigments** | Top tabs (ENGINE / SEQ / FX / MATRIX), full-width content per tab | 2 engines + seq | Full width per view, generous knob spacing | You see ONE thing at a time — lose context of the whole patch |
 | **Phase Plant** | Vertical generator stack (add/remove/reorder), FX chain right | N generators | Scalable to any number of sources | Very tall, lots of scrolling, no overview |

--- a/Docs/plans/changelog-v1-producer.md
+++ b/Docs/plans/changelog-v1-producer.md
@@ -131,11 +131,11 @@ Volume 1 covers OBRIX, OSTINATO, OPENSKY, OCEANDEEP, and OUIE. The OBRIX Transce
 
 ---
 
-## Coupling — 13 Types
+## Coupling — 15 Types
 
 Cross-engine modulation in XOceanus works through the MegaCouplingMatrix. V1 ships with 15 coupling types, including the new **KnotTopology** — the first bidirectional coupling type, introduced alongside ORBWEAVE.
 
-The other 12 types cover amplitude-to-filter, amplitude-to-pitch, LFO-to-pitch, envelope-to-morph, audio-to-FM, audio-to-ring, filter-to-filter, amplitude-to-choke, rhythm-to-blend, envelope-to-decay, pitch-to-pitch, and audio-to-wavetable.
+The other 14 types cover amplitude-to-filter, amplitude-to-pitch, LFO-to-pitch, envelope-to-morph, audio-to-FM, audio-to-ring, filter-to-filter, amplitude-to-choke, rhythm-to-blend, envelope-to-decay, pitch-to-pitch, and audio-to-wavetable.
 
 Coupling presets live in the Entangled mood. 18 factory coupling presets ship at launch, covering six engine pairs at three interaction intensities (subtle, present, dominant).
 

--- a/Installer/distribution.xml
+++ b/Installer/distribution.xml
@@ -75,7 +75,7 @@
     <!-- Factory Presets (default on) -->
     <choice id="org.xo-ox.xoceanus.choice.presets"
             title="Factory Presets"
-            description="Installs ~19,500+ factory presets (15 mood categories) to ~/Library/Audio/Presets/XO_OX/XOceanus/."
+            description="Installs 19,859 factory presets (16 mood categories) to ~/Library/Audio/Presets/XO_OX/XOceanus/."
             start_selected="true"
             start_enabled="true"
             start_visible="true">

--- a/Installer/resources/conclusion.html
+++ b/Installer/resources/conclusion.html
@@ -126,7 +126,7 @@
             Launchpad.
         </li>
         <li>
-            Load one of the 15 mood preset categories and start exploring. The
+            Load one of the 16 mood preset categories and start exploring. The
             <strong>COUPLING</strong> macro routes modulation between engines in real time.
         </li>
     </ol>

--- a/Source/Engines/Overlap/DSP/Voice.h
+++ b/Source/Engines/Overlap/DSP/Voice.h
@@ -144,6 +144,7 @@ struct VoiceEnvelope
             level = 0.0f;
             break;
         }
+        level = xoceanus::flushDenormal(level);
         return level;
     }
 

--- a/Source/Export/XPNDrumExporter.h
+++ b/Source/Export/XPNDrumExporter.h
@@ -715,6 +715,11 @@ private:
     // Manifest
     //==========================================================================
 
+    static juce::String sanitizeManifestField(const juce::String& s)
+    {
+        return s.replaceCharacters("\r\n", "  ").replace("=", "_");
+    }
+
     static void writeManifest(const juce::File& bundleDir, const DrumExportConfig& config, int presetCount)
     {
         // XPN bible §1: manifest must live at Expansions/manifest (no extension),

--- a/Source/Export/XPNDrumExporter.h
+++ b/Source/Export/XPNDrumExporter.h
@@ -766,15 +766,6 @@ private:
         return name.replaceCharacters(" /\\:*?\"<>|", "__________").substring(0, 50);
     }
 
-    //==========================================================================
-    // Manifest field sanitizer — strips characters that corrupt the Key=Value
-    // manifest format (newlines would inject extra lines; '=' would split a key).
-    //==========================================================================
-
-    static juce::String sanitizeManifestField(const juce::String& s)
-    {
-        return s.replaceCharacters("\r\n", "  ").replace("=", "_");
-    }
 };
 
 } // namespace xoceanus

--- a/Source/UI/PresetBrowser/PresetBrowser.h
+++ b/Source/UI/PresetBrowser/PresetBrowser.h
@@ -15,7 +15,7 @@ namespace xoceanus
 {
 
 //==============================================================================
-// PresetBrowser — Searchable, filterable browser for ~19,200+ factory presets.
+// PresetBrowser — Searchable, filterable browser for 19,859 factory presets.
 //
 // Features:
 //   - Real-time text search (filters name, tags, description, engine names)
@@ -697,7 +697,7 @@ private:
     //==========================================================================
     // Filtering — async implementation (#753)
     //
-    // The expensive linear scan + std::sort over ~19,200+ presets is moved off
+    // The expensive linear scan + std::sort over 19,859 presets is moved off
     // the JUCE message thread.  applyFilters() captures the current UI state,
     // dispatches a background job, then returns immediately.  When the job
     // finishes it posts results back via callAsync for a zero-copy swap into

--- a/site/index.html
+++ b/site/index.html
@@ -2310,7 +2310,7 @@ footer {
 
   <div class="hero-stats" aria-label="XOceanus at a glance">
     <div class="hero-stat">
-      <span class="hero-stat-num">88</span>
+      <span class="hero-stat-num"><!-- ENGINE_COUNT -->86<!-- /ENGINE_COUNT --></span>
       <span class="hero-stat-label">Engines</span>
     </div>
     <div class="hero-stat-divider" aria-hidden="true"></div>
@@ -2336,7 +2336,7 @@ footer {
 </section>
 
 <!-- ═══════════ ENGINE SPECTRUM ═══════════ -->
-<section class="engine-strip" aria-label="All 88 engine characters — click to explore">
+<section class="engine-strip" aria-label="All 86 engine characters — click to explore">
   <div class="engine-strip-inner" id="engineStrip"></div>
 </section>
 

--- a/site/press-kit/press-release.md
+++ b/site/press-kit/press-release.md
@@ -10,7 +10,7 @@
 
 ---
 
-**[City, Date]** — XO_OX Designs today announced XOceanus, a free and open-source multi-engine synthesizer for macOS. XOceanus ships with <!-- ENGINE_COUNT -->86<!-- /ENGINE_COUNT --> distinct synthesis engines, more than 19,859 factory presets, and a cross-engine coupling system that produces sounds impossible on any single synthesizer.
+**[City, Date]** — XO_OX Designs today announced XOceanus, a free and open-source multi-engine synthesizer for macOS. XOceanus ships with <!-- ENGINE_COUNT -->86<!-- /ENGINE_COUNT --> distinct synthesis engines, 19,859 factory presets, and a cross-engine coupling system that produces sounds impossible on any single synthesizer.
 
 The instrument is available at no cost, permanently, under the MIT open-source license. No subscription, no trial period, no upgrade gate.
 
@@ -22,7 +22,7 @@ XOceanus is a multi-engine synthesizer that loads up to four engines simultaneou
 
 The engines span the full range of synthesis architecture: additive, subtractive, FM, granular, physical modeling, wavetable, cellular automata, and hybrid approaches. Each engine has its own parameter set, preset library, expression mapping, and identity within the instrument's aquatic mythology. Every engine responds to velocity, aftertouch, and mod wheel. Every engine has four macro controls and autonomous modulation.
 
-The factory preset library ships with more than 19,859 presets organized across 16 mood categories and indexed by a six-dimensional Sonic DNA system covering brightness, warmth, movement, density, space, and aggression. Users can navigate by character rather than by preset number.
+The factory preset library ships with 19,859 presets organized across 16 mood categories and indexed by a six-dimensional Sonic DNA system covering brightness, warmth, movement, density, space, and aggression. Users can navigate by character rather than by preset number.
 
 ---
 


### PR DESCRIPTION
## Summary

End-to-end pass with the `/issue-triage-fix` skill. Four parallel scans (DSP safety, security, stale fleet stats, website hygiene), seven scoped GitHub issues filed with model/skill recommendations, four Haiku-tier issues fixed in this PR. Sonnet-tier issues left open for a session that can author binary assets / make small design calls.

## Issues filed

| # | Category | Title | Tier |
|---|----------|-------|------|
| #1323 | dsp | Missing flushDenormal() after one-pole smoothers (5 sites) | Haiku **✅ fixed** |
| #1324 | security | XPN manifest field injection via unescaped newlines / equals | Haiku **✅ fixed** |
| #1325 | security | Hardcoded developer paths in Python tools | Sonnet (open) |
| #1326 | security | CSS URL injection from `engine-creature-map.json` paths | Sonnet (open) |
| #1327 | docs | Stale fleet stats across site/ and Docs/ | Haiku **✅ fixed** |
| #1328 | docs | README mood list missing **Shadow** | Haiku **✅ fixed** |
| #1329 | website | `/apple-touch-icon.png` referenced by 20 HTML pages but missing | Sonnet (open) |

## Fixes in this PR (4 commits)

### `fix(dsp)` #1323 — flushDenormal in three audio-thread sites
- `Source/Engines/Overlap/DSP/Voice.h` — single `xoceanus::flushDenormal(level)` at the end of `VoiceEnvelope::tick()` covers Attack/Decay/Release in one place.
- `Source/DSP/Effects/VibeKnob.h` — `compEnv` (per-sample compressor envelope).
- `Source/DSP/Effects/LushReverb.h` — `ParamSmoother::tick()` (8 instances per `processBlock`).

### `fix(security)` #1324 — XPN manifest sanitization
`Source/Export/XPNDrumExporter.h`: `sanitizeManifestField()` strips CR/LF and rewrites `=` so user-supplied `DrumExportConfig` values cannot inject extra Key=Value pairs. Wraps Name/Version/Author/ID writes. The companion XML exporter already used `setAttribute()` / `xmlEscape()`; this one was missed.

### `docs(readme)` #1328 — README Shadow mood
Bumped inline counts to **19,859 / 16 moods** and appended **Shadow** so the count and the list agree.

### `docs` #1327 — fleet stats bulk fix (41 files, 81 substitutions)
Per CLAUDE.md canonical values — 86 engines, 15 coupling types, 16 moods, 19,859 presets:

- **92 → 86** in `site/index.html`, `manifesto.html`, `guide.html`, `aquarium.html`, `packs.html`, `coupling-protocol.html`, `guide-coupling.html`, `guide-guru-bin-vol2.html`, `guide-sdk-engine.html`, `field-guide/the-coupling-explainer.html`, `assets/og-image.svg`, `design-tokens.css`, plus `Docs/specs/coupling-protocol-spec-v0.1.md`, `xoceanus_master_specification.md`, and 6 files under `Docs/design/`.
- **77 → 86** in `site/press-kit/index.html`.
- **13 → 15** coupling types in `Docs/plans/changelog-v1-{technical,producer}.md`, `v1-launch-plan-2026-03-20.md`, `xoceanus_landscape_2026.md`, `content-backlog-6-month-2026.md`, `Docs/specs/xoceanus_recipe_system_design.md`, `knowledge/blessings/BLS-003-obrix-coupling-macro-architecture.md`.
- **15 → 16** moods in `CONTRIBUTING.md`, `Installer/distribution.xml`, `Installer/resources/welcome.html`, `conclusion.html`, `site/press-kit/`, `Docs/ebook/chapter_{04,09}*.md`, `Docs/concepts/guild-market-review-oxidize.md`, `Docs/design/{ui-components-dimensions-2026-03-26,xoceanus-spatial-architecture}.md`.
- **19,500+ / 19,200+ → 19,859** in `CONTRIBUTING.md`, `site/{press-kit,feed.xml,field-guide/the-coupling-explainer.html}`, `Installer/distribution.xml`, `Docs/specs/xoceanus_master_specification.md`, `Docs/design/xoceanus-{definitive-ui-spec,spatial-architecture}.md`, `Docs/ebook/chapter_{04,09}*.md`, `Source/UI/PresetBrowser/PresetBrowser.h`.

**Intentionally skipped** (timestamped historical records): `CHANGELOG.md` (0.5.0 release notes), `Docs/sweeps/sweep-ui-architecture-2026-03-24.md` and `Docs/fleet-audit/board-audit-2026-03-24.md` (audits documenting the 15→16 transition itself), `Docs/sessions/`, `fathom-fleet-report-2026-03-29.md` and `fleet-inventory-2026-03-28.md` (audits dated at 77 engines), `Tools/_archive/` python tools, `Docs/design/xoceanus-ui-blessing-session.md` and `Docs/plans/launch-battle-plan.md` (session records).

## Out of scope (issues left open)

- **#1325** hardcoded dev paths — needs a CLI-arg shape decision for the `_archive/` script.
- **#1326** CSS URL injection — requires reading the JSON loader path and figuring out the canonical sprite directory prefix; not pure pattern fix.
- **#1329** missing `apple-touch-icon.png` — needs either a 180×180 PNG asset (binary, can't author here) or a design call to drop the broken `<link>` and add a real `<link rel="icon">`.

## Test plan

- [ ] `git grep -E '\b(92|77) engines\b' -- ':!CHANGELOG.md' ':!Docs/sweeps' ':!Docs/sessions' ':!Docs/fleet-audit' ':!Tools/_archive' ':!journal' ':!Libs' ':!builds'` returns nothing.
- [ ] `git grep -E '\b13 coupling type' -- ':!Tools/_archive' ':!Docs/plans/changelog-v1-technical.md'` returns nothing.
- [ ] `git grep -E '19,(500|200)' -- ':!CHANGELOG.md' ':!Docs/sessions' ':!Docs/sweeps' ':!Docs/fleet-audit' ':!Docs/plans/launch-battle-plan.md' ':!Docs/design/xoceanus-ui-blessing-session.md' ':!journal' ':!Libs' ':!builds'` returns nothing.
- [ ] Build still passes (`cmake --build build`); the three DSP edits and the manifest helper compile cleanly.
- [ ] Existing `auval -v aumu Xocn XoOx` still passes — no parameter IDs or behavior changed.
- [ ] Manual: open `site/index.html` in a browser and confirm meta description, OG card, and Twitter card all read **86 engines**.

Resolves #1323, #1324, #1327, #1328
Refs #1325, #1326, #1329

---
_Generated by [Claude Code](https://claude.ai/code/session_0182SNZYvs5srVz7qr19MAiN)_