### PR TITLE
wire: final mount PR — W9c walkthrough + W6.5 collision + W8 XY params + F03 PAD/DRUM fix

### DIFF
--- a/Source/UI/FirstHourWalkthrough.h
+++ b/Source/UI/FirstHourWalkthrough.h
@@ -640,50 +640,15 @@ private:
 
 
 //==============================================================================
-// TODO W9c mount — XOceanusEditor.h
-// (After Wave 7: move steps 4-6 into OceanStateMachine::onGreetingComplete.)
+// Wave 9c mount COMPLETE — XOceanusEditor.h (applied 2026-04-26, PR #mount-final)
 //
-// 1. Declare as member (after tooltipWindow):
-//      xoceanus::FirstHourWalkthrough walkthrough_;
-//
-// 2. Wire bound accessors (in constructor or initOceanView, BEFORE addChildComponent):
-//      walkthrough_.getPlaySurfaceBounds = [this]() { return playSurface_.getBounds(); };
-//      walkthrough_.getEngineSlotBounds  = [this]() {
-//          return tiles[0] != nullptr ? tiles[0]->getBounds() : juce::Rectangle<int>{};
-//      };
-//      walkthrough_.getMacroBounds       = [this]() { return macros.getBounds(); };
-//      walkthrough_.getDnaBrowserBounds  = [this]() {
-//          // TODO W9c: expose DnaMapBrowser or PresetBrowserStrip bounds
-//          return juce::Rectangle<int>{};
-//      };
-//      walkthrough_.getCoupleOrbitBounds = [this]() {
-//          // TODO W9c: expose EngineOrbit buoy 1 bounds from OceanView
-//          return juce::Rectangle<int>{};
-//      };
-//      walkthrough_.getCmToggleBounds    = [this]() { return cmToggleBtn.getBounds(); };
-//      walkthrough_.getFavBtnBounds      = [this]() {
-//          // TODO W9c: expose PresetBrowserStrip favBtn bounds
-//          return juce::Rectangle<int>{};
-//      };
-//      walkthrough_.getXouijaBounds      = [this]() {
-//          // TODO W9c: expose SubmarineOuijaPanel or XOuija button bounds
-//          return juce::Rectangle<int>{};
-//      };
-//
-// 3. Add as topmost child (must paint over all other children):
-//      addAndMakeVisible(walkthrough_);
-//
-// 4. In resized():
-//      walkthrough_.setBounds(getLocalBounds());
-//
-// 5. Trigger after greeting — interim pre-Wave7 path (timerCallback or greeting callback):
-//      if (!greetingIsActive && !walkthroughTriggeredThisSession_) {
-//          walkthroughTriggeredThisSession_ = true;
-//          walkthrough_.promptIfEligible(settingsFile_.get());
-//      }
-//
-// 6. Wire Settings > Experience "Restart Walkthrough" in SettingsPanel::Experience section:
-//      restartWalkthroughBtn.onClick = [this] {
-//          // editor must expose a restartWalkthrough() method or direct access
-//          walkthrough_.restartWalkthrough(settingsFile_.get());
-//      };
+// All 6 mount points wired:
+//   1. Member: walkthrough_  (before toastOverlay_ in declaration order)
+//   2. Bound accessors wired in initOceanView() — steps 0/2/5 fully resolved;
+//      steps 3/4/6/7 return {} until DnaMapBrowser/EngineOrbit/favBtn/XOuija
+//      are accessible directly from the editor (post-Wave 7 decomp).
+//   3. addAndMakeVisible(walkthrough_) in initOceanView() before toastOverlay_.
+//   4. setBounds in resized() OceanView branch.
+//   5. promptIfEligible() fired on first timerCallback tick via walkthroughTriggeredThisSession_ guard.
+//   6. Settings "Restart Walkthrough" — TODO: wire restartWalkthrough() in SettingsPanel
+//      when Settings > Experience section is built (issue #1303 follow-up).

--- a/Source/UI/FirstHourWalkthrough.h
+++ b/Source/UI/FirstHourWalkthrough.h
@@ -196,7 +196,7 @@ public:
         g.setColour (juce::Colour (0xFFCCCCCC));
         g.setFont   (juce::Font ("Inter", 11.5f, juce::Font::plain));
         juce::AttributedString bodyAS;
-        bodyAS.append (bodyText_, g.getCurrentFont(), g.getCurrentColour());
+        bodyAS.append (bodyText_, g.getCurrentFont(), juce::Colour (0xFFCCCCCC));
         bodyAS.setWordWrap (juce::AttributedString::byWord);
         juce::TextLayout tl;
         tl.createLayout (bodyAS, static_cast<float> (getWidth() - kPad * 2));
@@ -519,14 +519,14 @@ private:
 
         switch (step)
         {
-            case 0: return (getPlaySurfaceBounds  && getPlaySurfaceBounds())  ? getPlaySurfaceBounds()  : fallback();
-            case 1: return (getEngineSlotBounds   && getEngineSlotBounds())   ? getEngineSlotBounds()   : fallback();
-            case 2: return (getMacroBounds        && getMacroBounds())        ? getMacroBounds()        : fallback();
-            case 3: return (getDnaBrowserBounds   && getDnaBrowserBounds())   ? getDnaBrowserBounds()   : fallback();
-            case 4: return (getCoupleOrbitBounds  && getCoupleOrbitBounds())  ? getCoupleOrbitBounds()  : fallback();
-            case 5: return (getCmToggleBounds     && getCmToggleBounds())     ? getCmToggleBounds()     : fallback();
-            case 6: return (getFavBtnBounds       && getFavBtnBounds())       ? getFavBtnBounds()       : fallback();
-            case 7: return (getXouijaBounds       && getXouijaBounds())       ? getXouijaBounds()       : fallback();
+            case 0: return (getPlaySurfaceBounds  && !getPlaySurfaceBounds().isEmpty())  ? getPlaySurfaceBounds()  : fallback();
+            case 1: return (getEngineSlotBounds   && !getEngineSlotBounds().isEmpty())   ? getEngineSlotBounds()   : fallback();
+            case 2: return (getMacroBounds        && !getMacroBounds().isEmpty())        ? getMacroBounds()        : fallback();
+            case 3: return (getDnaBrowserBounds   && !getDnaBrowserBounds().isEmpty())   ? getDnaBrowserBounds()   : fallback();
+            case 4: return (getCoupleOrbitBounds  && !getCoupleOrbitBounds().isEmpty())  ? getCoupleOrbitBounds()  : fallback();
+            case 5: return (getCmToggleBounds     && !getCmToggleBounds().isEmpty())     ? getCmToggleBounds()     : fallback();
+            case 6: return (getFavBtnBounds       && !getFavBtnBounds().isEmpty())       ? getFavBtnBounds()       : fallback();
+            case 7: return (getXouijaBounds       && !getXouijaBounds().isEmpty())       ? getXouijaBounds()       : fallback();
             default: return fallback();
         }
     }

--- a/Source/UI/Ocean/Wave65SurfaceWiring.h
+++ b/Source/UI/Ocean/Wave65SurfaceWiring.h
@@ -92,7 +92,7 @@ inline bool isPercussionEngine (const juce::String& engineId)
 */
 inline void pollLayoutModeParams (juce::AudioProcessorValueTreeState& apvts,
                                   std::array<int, 4>& cache,
-                                  PlaySurface& playSurface)
+                                  xoceanus::PlaySurface& playSurface)
 {
     for (int s = 0; s < 4; ++s)
     {

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -52,6 +52,10 @@
 // No explicit re-include needed here — pragma once guards prevent duplication.
 // Wave 5 A3: ModMatrixBreakout (strip + slide-up panel).
 #include "Future/UI/ModRouting/ModMatrixBreakout.h"
+// Wave 6.5 (#1306): Pad/Drum collision wiring + layout-mode polling.
+#include "Ocean/Wave65SurfaceWiring.h"
+// Wave 9c (#1303): First-hour onboarding walkthrough overlay.
+#include "FirstHourWalkthrough.h"
 
 namespace xoceanus
 {
@@ -637,14 +641,12 @@ public:
                             modMatrixStrip_->loadEngine(
                                 GalleryColors::prefixForEngine(eng->getEngineId()));
                     }
-                    // TODO Wave6.5 mount A (#1306): auto-switch PlaySurface to PADS+drum
+                    // Wave6.5 mount A (#1306): auto-switch PlaySurface to PADS+drum
                     // sub-mode when a percussion engine (Onset / Offering) loads.
-                    // Include "Ocean/Wave65SurfaceWiring.h" and add layoutModeCache_ member,
-                    // then replace these comments with the live call:
-                    //   if (slot >= 0 && slot < kNumPrimarySlots)
-                    //       if (auto* eng = processor.getEngine(slot))
-                    //           oceanView_.getPlaySurface().setSurfaceDefault(
-                    //               Wave65::isPercussionEngine(eng->getEngineId()));
+                    if (slot >= 0 && slot < kNumPrimarySlots)
+                        if (auto* eng = processor.getEngine(slot))
+                            oceanView_.getPlaySurface().setSurfaceDefault(
+                                Wave65::isPercussionEngine(eng->getEngineId()));
                 });
         };
     }
@@ -923,6 +925,26 @@ public:
             };
         }
 
+        // F03 fix (#1322): Wire SurfaceRightPanel note callbacks to MidiCollector.
+        // Without this, clicks on PAD/DRUM pads fired onNoteOn/onNoteOff but the
+        // lambdas were null — the pad grid was completely silent.
+        // Wiring pattern mirrors SubmarinePlaySurface (lines above).
+        {
+            auto& srp = oceanView_.getSurfaceRight();
+            srp.onNoteOn = [this](int note, float velocity)
+            {
+                auto msg = juce::MidiMessage::noteOn(1, note, velocity);
+                msg.setTimeStamp(juce::Time::getMillisecondCounterHiRes() * 0.001);
+                processor.getMidiCollector().addMessageToQueue(msg);
+            };
+            srp.onNoteOff = [this](int note)
+            {
+                auto msg = juce::MidiMessage::noteOff(1, note);
+                msg.setTimeStamp(juce::Time::getMillisecondCounterHiRes() * 0.001);
+                processor.getMidiCollector().addMessageToQueue(msg);
+            };
+        }
+
         // #1304 wiring: surfaceRight_.onOuijaCCOutput → processor.pushCCOutput().
         // Fires at ~30 Hz while HARMONIC tab is active; cc 85 = planchette X,
         // cc 86 = planchette radius/depth (SurfaceRightPanel::kOuijaCCCircleX/Y).
@@ -1164,6 +1186,38 @@ public:
             proc.getAPVTS(), proc.getModRoutingModel(), *modRouter_);
         addAndMakeVisible(*modMatrixStrip_);
         modMatrixStrip_->addPanelToParent(*this);
+
+        // ── Wave 9c (#1303): First-hour walkthrough overlay ──────────────────
+        // Wire bound accessors so the walkthrough bubbles point at the correct
+        // components.  Components that are not yet directly addressable from the
+        // editor return empty rectangles; the bubble falls back to the safe
+        // centred-area position and the tour still functions.
+        walkthrough_.getPlaySurfaceBounds  = [this]() { return oceanView_.getPlaySurface().getBounds(); };
+        walkthrough_.getEngineSlotBounds   = [this]() {
+            return tiles[0] != nullptr ? tiles[0]->getBounds() : juce::Rectangle<int>{};
+        };
+        walkthrough_.getMacroBounds        = [this]() { return macros.getBounds(); };
+        walkthrough_.getDnaBrowserBounds   = [this]() {
+            // TODO: expose DnaMapBrowser bounds when component is accessible from editor
+            return juce::Rectangle<int>{};
+        };
+        walkthrough_.getCoupleOrbitBounds  = [this]() {
+            // TODO: expose EngineOrbit buoy 1 bounds when component is accessible from editor
+            return juce::Rectangle<int>{};
+        };
+        walkthrough_.getCmToggleBounds     = [this]() { return cmToggleBtn.getBounds(); };
+        walkthrough_.getFavBtnBounds       = [this]() {
+            // TODO: expose PresetBrowserStrip favBtn bounds when accessible from editor
+            return juce::Rectangle<int>{};
+        };
+        walkthrough_.getXouijaBounds       = [this]() {
+            // TODO: expose SubmarineOuijaPanel or XOuija button bounds when accessible from editor
+            return juce::Rectangle<int>{};
+        };
+
+        // Mount as topmost child before toastOverlay_ — paints above all panels
+        // but below toasts so notifications are never obscured.
+        addAndMakeVisible(walkthrough_);
 
         // ── ToastOverlay — MUST be the last addAndMakeVisible call ────────────
         // JUCE paints children in insertion order; last child paints on top.
@@ -1447,6 +1501,9 @@ public:
             aboutModal_.setBounds(getLocalBounds());
 
             toastOverlay_.setBounds(getLocalBounds());
+
+            // Wave 9c: walkthrough overlay always tracks full editor bounds.
+            walkthrough_.setBounds(getLocalBounds());
 
             return;
         }
@@ -1805,6 +1862,18 @@ private:
         }
         checkCollectionUnlock();
 
+        // ── Wave 9c (#1303): prompt for walkthrough after first timer tick ────
+        // Fires once per session — one tick of latency ensures the editor is
+        // fully constructed and bounds are settled before the overlay appears.
+        // Pre-Wave7 interim path: no explicit greeting flag, so we use the
+        // session-guard bool.  Post-Wave 7: move this into
+        // OceanStateMachine::onGreetingComplete().
+        if (!walkthroughTriggeredThisSession_)
+        {
+            walkthroughTriggeredThisSession_ = true;
+            walkthrough_.promptIfEligible(settingsFile_.get());
+        }
+
         // ── Refresh Export tab panel with current preset/kit info ────────────
         if (!oceanView_.isVisible())
             sidebar.refreshExportPanel();
@@ -2018,13 +2087,11 @@ private:
             playSurface_.setAccentColour(accent);
         }
 
-        // TODO Wave6.5 mount B (#1306): poll slot[N]_layout_mode APVTS params and
+        // Wave6.5 mount B (#1306): poll slot[N]_layout_mode APVTS params and
         // forward changes to PlaySurface::setLayoutMode() for DAW session recall.
-        // Include "Ocean/Wave65SurfaceWiring.h" and add layoutModeCache_ member
-        // (mount C), then replace these comments with the live call:
-        //   Wave65::pollLayoutModeParams(processor.getAPVTS(),
-        //                                layoutModeCache_,
-        //                                oceanView_.getPlaySurface());
+        Wave65::pollLayoutModeParams(processor.getAPVTS(),
+                                     layoutModeCache_,
+                                     oceanView_.getPlaySurface());
 
         // ── D4: Register Manager update ───────────────────────────────────────
         // Compute elapsed time (ms) since last timer tick for smooth transitions.
@@ -2449,9 +2516,8 @@ private:
     // Cache the last preset name to detect changes without polling every frame.
     juce::String lastHeaderHexPreset_;
 
-    // TODO Wave6.5 mount C (#1306): per-slot layout mode cache for APVTS polling.
-    // Include "Ocean/Wave65SurfaceWiring.h" then uncomment this member:
-    //   std::array<int, 4> layoutModeCache_ { -1, -1, -1, -1 };
+    // Wave6.5 mount C (#1306): per-slot layout mode cache for APVTS polling.
+    std::array<int, 4> layoutModeCache_ { -1, -1, -1, -1 };
 
     // Last MIDI note number seen (for interval computation in session DNA drift).
     // -1 = no note played yet this session.
@@ -2540,6 +2606,15 @@ private:
     // unique_ptr: constructed in initOceanView() after the processor is ready
     // (ModRoutingModel lives in the processor, pointer stable for plugin lifetime).
     std::unique_ptr<DragDropModRouter> modRouter_;
+
+    // ── Wave 9c (#1303): First-hour walkthrough overlay ──────────────────────
+    // Transparent overlay that paints the gold highlight ring and floating bubbles.
+    // Mounted as topmost child (above obadge_/aboutModal_, below toastOverlay_).
+    // setBounds: always getLocalBounds() (set in resized()).
+    FirstHourWalkthrough walkthrough_;
+    // True once promptIfEligible() has been fired this session — prevents re-firing
+    // on every timerCallback tick after the greeting flag clears.
+    bool walkthroughTriggeredThisSession_ = false;
 
     // ── ToastOverlay — non-blocking notification layer ────────────────────────
     // Declared last so it is destroyed first (child components destroyed in

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -1197,20 +1197,20 @@ public:
             return tiles[0] != nullptr ? tiles[0]->getBounds() : juce::Rectangle<int>{};
         };
         walkthrough_.getMacroBounds        = [this]() { return macros.getBounds(); };
-        walkthrough_.getDnaBrowserBounds   = [this]() {
+        walkthrough_.getDnaBrowserBounds   = []() {
             // TODO: expose DnaMapBrowser bounds when component is accessible from editor
             return juce::Rectangle<int>{};
         };
-        walkthrough_.getCoupleOrbitBounds  = [this]() {
+        walkthrough_.getCoupleOrbitBounds  = []() {
             // TODO: expose EngineOrbit buoy 1 bounds when component is accessible from editor
             return juce::Rectangle<int>{};
         };
         walkthrough_.getCmToggleBounds     = [this]() { return cmToggleBtn.getBounds(); };
-        walkthrough_.getFavBtnBounds       = [this]() {
+        walkthrough_.getFavBtnBounds       = []() {
             // TODO: expose PresetBrowserStrip favBtn bounds when accessible from editor
             return juce::Rectangle<int>{};
         };
-        walkthrough_.getXouijaBounds       = [this]() {
+        walkthrough_.getXouijaBounds       = []() {
             // TODO: expose SubmarineOuijaPanel or XOuija button bounds when accessible from editor
             return juce::Rectangle<int>{};
         };

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1259,6 +1259,51 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
             0 /* default = PlaySurface */));
     }
 
+    // Wave 8 (#1302): XY Surface parameters (8 params × 4 slots = 32 params).
+    // See Source/UI/PlaySurface/XYSurface.h "APVTS Parameter Registration" section.
+    {
+        const juce::StringArray kXYPatterns {"None","PULSE","DRIFT","TIDE","RIPPLE","CHAOS"};
+        const juce::StringArray kXYSync     {"Free","1bar/4","1bar/2","1bar","2bar","4bar"};
+        const juce::StringArray kXYAssign   {
+            "None","Filter Cutoff","Filter Res","LFO Rate","LFO Depth",
+            "Env Attack","Env Release","Drive",
+            "Macro1","Macro2","Macro3","Macro4",
+            "FX1 Wet","FX2 Wet","FX3 Wet"
+        };
+        for (int s = 0; s < 4; ++s)
+        {
+            const juce::String sfx = "_slot" + juce::String(s);
+            layout.add(std::make_unique<juce::AudioParameterChoice>(
+                juce::ParameterID("xy_pattern" + sfx, 1),
+                "XY Pattern Slot " + juce::String(s + 1), kXYPatterns, 0));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(
+                juce::ParameterID("xy_speed"   + sfx, 1),
+                "XY Speed Slot "   + juce::String(s + 1),
+                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(
+                juce::ParameterID("xy_depth"   + sfx, 1),
+                "XY Depth Slot "   + juce::String(s + 1),
+                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+            layout.add(std::make_unique<juce::AudioParameterChoice>(
+                juce::ParameterID("xy_sync"    + sfx, 1),
+                "XY Sync Slot "    + juce::String(s + 1), kXYSync, 3)); // default: 1bar
+            layout.add(std::make_unique<juce::AudioParameterChoice>(
+                juce::ParameterID("xy_assignX" + sfx, 1),
+                "XY Assign X Slot "+ juce::String(s + 1), kXYAssign, 0));
+            layout.add(std::make_unique<juce::AudioParameterChoice>(
+                juce::ParameterID("xy_assignY" + sfx, 1),
+                "XY Assign Y Slot "+ juce::String(s + 1), kXYAssign, 0));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(
+                juce::ParameterID("xy_pos_x"   + sfx, 1),
+                "XY Pos X Slot "   + juce::String(s + 1),
+                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(
+                juce::ParameterID("xy_pos_y"   + sfx, 1),
+                "XY Pos Y Slot "   + juce::String(s + 1),
+                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+        }
+    }
+
     return layout;
 }
 


### PR DESCRIPTION
## Summary

Absorbs all editor TODO mount points from three recent PRs and fixes one HIGH-severity bug from the W11 verification audit.

### Sections applied

**W9c — FirstHourWalkthrough mount** (source `FirstHourWalkthrough.h` confirmed on main)
- `#include "FirstHourWalkthrough.h"` added to editor includes
- `walkthrough_` member declared before `toastOverlay_` (correct paint order)
- `walkthroughTriggeredThisSession_` session guard added
- 8 bound-accessor lambdas wired in `initOceanView()`: steps 0 (PlaySurface), 1 (tile[0]), 2 (macros), 5 (cmToggleBtn) fully resolved; steps 3/4/6/7 return `{}` with inline TODO comments pending Wave 7 OceanView decomp exposing DnaMapBrowser/EngineOrbit/favBtn/XOuija
- `addAndMakeVisible(walkthrough_)` before `toastOverlay_`
- `walkthrough_.setBounds(getLocalBounds())` in `resized()` OceanView branch
- `promptIfEligible(settingsFile_.get())` triggered on first `timerCallback()` tick
- TODO W9c block removed from `FirstHourWalkthrough.h`, replaced with completion note
- Settings "Restart Walkthrough" wiring deferred — no Settings > Experience section exists yet (issue #1303 follow-up)

**W6.5 — Pad/Drum collision wiring** (source `Wave65SurfaceWiring.h` confirmed on main)
- `#include "Ocean/Wave65SurfaceWiring.h"` added
- Mount A: `setSurfaceDefault(Wave65::isPercussionEngine(...))` activated in `onEngineChanged` lambda (auto-switches to PADS+drum mode when Onset/Offering loads)
- Mount B: `Wave65::pollLayoutModeParams(...)` activated in `timerCallback()` for DAW session recall
- Mount C: `std::array<int, 4> layoutModeCache_ { -1, -1, -1, -1 }` member added

**W8 — XY Surface APVTS params** (both `XYSurface.h` + `XYPatternGenerator.h` confirmed on main)
- 32 APVTS parameters registered in `XOceanusProcessor::createParameterLayout()` before `return layout`: `xy_pattern_slot{n}`, `xy_speed_slot{n}`, `xy_depth_slot{n}`, `xy_sync_slot{n}`, `xy_assignX_slot{n}`, `xy_assignY_slot{n}`, `xy_pos_x_slot{n}`, `xy_pos_y_slot{n}` for slots 0–3
- Copied verbatim from the "APVTS Parameter Registration" comment block in `XYSurface.h`
- Note: `handleXYOutput`, `resolveXYParamId`, and `onXYChanged` wiring in OceanView are separate W8 TODOs (marked in XYSurface.h header) — not included here per "mount work only" constraint

**F03 — SurfaceRightPanel PAD/DRUM callbacks** (HIGH bug from audit #1322)
- `oceanView_.getSurfaceRight().onNoteOn` and `.onNoteOff` wired to `processor.getMidiCollector()` in `initOceanView()`
- PAD/DRUM pad clicks were completely silent — lambdas fired but were null (never assigned)
- Wiring mirrors the SubmarinePlaySurface block immediately above it (same 3-line MidiMessage pattern)
- Location: `Source/UI/XOceanusEditor.h`, just before the existing `#1304 onOuijaCCOutput` block

## Files changed

| File | Changes |
|------|---------|
| `Source/UI/XOceanusEditor.h` | +107 / -6 — all 4 sections |
| `Source/UI/FirstHourWalkthrough.h` | +14 / -56 — TODO block replaced with completion note |
| `Source/XOceanusProcessor.cpp` | +45 / 0 — W8 APVTS params |

## Test plan

- [ ] PAD mode: click a pad → audio sounds (F03 fix verified)
- [ ] DRUM mode: click a pad → audio sounds (F03 fix verified)  
- [ ] Load Onset engine into any slot → PlaySurface auto-switches to PADS+drum sub-mode (W6.5 A)
- [ ] Load Offering engine → same auto-switch (W6.5 A)
- [ ] Load non-percussion engine → no auto-switch (W6.5 A)
- [ ] First launch (clear `onboardingWalkthroughStep` from settings): tour prompt appears after ~1 timer tick (W9c)
- [ ] "Skip" on prompt → no tour, `onboardingDisabled=true` persisted (W9c)
- [ ] Second launch after Skip → no prompt (W9c)
- [ ] XY params appear in APVTS: `xy_pattern_slot0` etc. queryable via `processor.getAPVTS().getRawParameterValue(...)` (W8)
- [ ] Build passes (cmake release) with no new errors

Closes #1322
Refs #1303 #1306 #1302 #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)