### PR TITLE
arch(#1184): Phase 2.5 — OceanLayout design-doc conformance

### DIFF
--- a/Source/UI/Ocean/OceanLayout.h
+++ b/Source/UI/Ocean/OceanLayout.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 XO_OX Designs
 #pragma once
-// OceanLayout.h  —  Phase 2 of the OceanView decomposition (issue #1184).
+// OceanLayout.h  —  Phase 2 + 2.5 of the OceanView decomposition (issue #1184).
 //
 // OceanLayout owns all geometry/layout logic that previously lived directly in
 // OceanView.  It holds references to every component it must position — no
@@ -9,24 +9,26 @@
 //
 // Construction
 // ────────────
-//   OceanLayout layout_{children_, /* LayoutTargets */ {  }};
+//   OceanLayout layout_{children_, /* LayoutTargets */ { ..., selectedSlot_, detailShowing_, firstLaunch_ }};
 //
 //   OceanView::resized() becomes:
-//     layout_.layoutForState(viewState_, getLocalBounds(), selectedSlot_,
-//                            detailShowing_, firstLaunch_);
-//   Phase 3 animation:
-//     layout_.layoutForState(state, bounds, slot, detail, firstLaunch, progress01);
+//     layout_.layoutForState(viewState_, getLocalBounds());
+//
+//   Phase 3 animation (when OceanStateMachine is wired):
+//     layout_.layoutForState(state, bounds, progress01);
 //
 // Constraints (same as OceanChildren):
 //   - No back-reference to OceanView (no OceanView* member).
 //   - LayoutTargets members are plain Component& / Component* references; they
 //     are never used to call back into OceanView — only setBounds/setVisible/
 //     toFront.
+//   - LayoutTargets also holds const-ref bindings to the three layout-input state
+//     members (selectedSlot, detailShowing, firstLaunch) added in Phase 2.5.
 //   - All geometry constants (kDashboardH, kStatusBarH, etc.) duplicated here
 //     for now; Phase 3 should consolidate them into a shared constants header.
 //
 // Phase 3 will extract OceanStateMachine.  At that point the `viewState_`
-// placeholder in applyLayout() will be replaced by a stateMachine_ query.
+// placeholder in layoutForState() will be replaced by a stateMachine_ query.
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "OceanChildren.h"

--- a/Source/UI/Ocean/OceanLayout.h
+++ b/Source/UI/Ocean/OceanLayout.h
@@ -112,6 +112,12 @@ struct LayoutTargets
     SubmarinePlaySurface&           subPlaySurface;
     SubmarineOuijaPanel&            ouijaPanel;
     SurfaceRightPanel&              surfaceRight;
+
+    // Phase 2.5 (#1184): layout-input state — const refs to OceanView members.
+    // Removed from layoutForState() per-call args; now read directly from here.
+    const int&  selectedSlot;    ///< OceanView::selectedSlot_
+    const bool& detailShowing;   ///< OceanView::detailShowing_
+    const bool& firstLaunch;     ///< OceanView::firstLaunch_
 };
 
 //==============================================================================
@@ -164,14 +170,15 @@ public:
     /**
         Apply the full window layout.
 
-        @param viewState     Current state machine state (Orbital / ZoomIn / etc.)
-        @param fullBounds    OceanView's local bounds (from getLocalBounds()).
-        @param selectedSlot  Which slot is enlarged/active (-1 = none).
-        @param detailShowing Whether the detail overlay is currently displayed.
-        @param firstLaunch   Whether the user hasn't loaded any engine yet.
-        @param progress01    Normalised animation progress [0, 1] for in-flight
-                             transitions (default 1.0 = fully settled).  Reserved
-                             for Phase 3 — currently unused (juce::ignoreUnused).
+        The `selectedSlot`, `detailShowing`, and `firstLaunch` state values are
+        now read from `targets_` (const refs to OceanView members) rather than
+        passed per-call.
+
+        @param viewState   Current state machine state (Orbital / ZoomIn / etc.)
+        @param fullBounds  OceanView's local bounds (from getLocalBounds()).
+        @param progress01  Normalised animation progress [0, 1] for in-flight
+                           transitions (default 1.0 = fully settled).  Reserved
+                           for Phase 3 — currently unused (juce::ignoreUnused).
     */
     enum class ViewState
     {
@@ -181,12 +188,9 @@ public:
         BrowserOpen
     };
 
-    void layoutForState(ViewState   viewState,
+    void layoutForState(ViewState            viewState,
                         juce::Rectangle<int> fullBounds,
-                        int         selectedSlot,
-                        bool        detailShowing,
-                        bool        firstLaunch,
-                        float       progress01 = 1.0f)
+                        float                progress01 = 1.0f)
     {
         juce::ignoreUnused(progress01);  // Phase 3 will use this for animation interpolation.
 
@@ -194,16 +198,16 @@ public:
         switch (viewState)
         {
             case ViewState::Orbital:
-                layoutOrbital(fullBounds, detailShowing, firstLaunch);
+                layoutOrbital(fullBounds);
                 break;
             case ViewState::ZoomIn:
-                layoutZoomIn(fullBounds, selectedSlot, detailShowing);
+                layoutZoomIn(fullBounds);
                 break;
             case ViewState::SplitTransform:
-                layoutSplitTransform(fullBounds, selectedSlot);
+                layoutSplitTransform(fullBounds);
                 break;
             case ViewState::BrowserOpen:
-                layoutBrowser(fullBounds, detailShowing);
+                layoutBrowser(fullBounds);
                 break;
         }
 
@@ -337,9 +341,7 @@ private:
     // Layout strategies (state-specific)
     //==========================================================================
 
-    void layoutOrbital(juce::Rectangle<int> fullBounds,
-                       bool detailShowing,
-                       bool firstLaunch)
+    void layoutOrbital(juce::Rectangle<int> fullBounds)
     {
         // Step 6: use computeOceanArea() so background/substrate/nexus only fill
         // the ocean viewport above the waterline, not the full window.
@@ -362,7 +364,7 @@ private:
         // FIX 12: Keep OceanBackground informed so it can show/hide ghost outlines.
         targets_.background.setEngineCount(numLoaded);
 
-        // ── Macros: now positioned in the dashboard strip via applyLayout() ──
+        // ── Macros: now positioned in the dashboard strip via layoutForState() ──
         // Fix 4: only show macros when at least one engine is loaded.
         if (auto* m = children_.macros())
             m->setVisible(numLoaded > 0);
@@ -406,20 +408,20 @@ private:
         }
 
         // Step 7: Show the pulsing lifesaver ring on first launch when empty.
-        targets_.lifesaver.setVisible(firstLaunch && numLoaded == 0);
+        targets_.lifesaver.setVisible(targets_.firstLaunch && numLoaded == 0);
         targets_.lifesaver.setBounds(computeOceanArea(fullBounds));
 
         // Hide panels that belong to other states.
-        if (auto* dp = children_.detailPanel(); dp && !detailShowing)
+        if (auto* dp = children_.detailPanel(); dp && !targets_.detailShowing)
             dp->setVisible(false);
         if (auto* sb = children_.sidebar()) sb->setVisible(false);
         targets_.browser.setVisible(false);
     }
 
-    void layoutZoomIn(juce::Rectangle<int> fullBounds,
-                      int selectedSlot,
-                      bool detailShowing)
+    void layoutZoomIn(juce::Rectangle<int> fullBounds)
     {
+        const int  selectedSlot  = targets_.selectedSlot;
+        const bool detailShowing = targets_.detailShowing;
         jassert(selectedSlot >= 0 && selectedSlot < 5);
 
         // Step 6: use computeOceanArea() so background/substrate only fill the
@@ -496,9 +498,9 @@ private:
         targets_.emptyStateLabel.setVisible(false);  // ZoomIn always has an engine selected
     }
 
-    void layoutSplitTransform(juce::Rectangle<int> fullBounds,
-                              int selectedSlot)
+    void layoutSplitTransform(juce::Rectangle<int> fullBounds)
     {
+        const int selectedSlot = targets_.selectedSlot;
         jassert(selectedSlot >= 0 && selectedSlot < 5);
 
         // Step 6: use computeOceanArea() so background/ambient edge stay within the
@@ -559,9 +561,9 @@ private:
         targets_.emptyStateLabel.setVisible(false);  // SplitTransform always has engine selected
     }
 
-    void layoutBrowser(juce::Rectangle<int> fullBounds,
-                       bool detailShowing)
+    void layoutBrowser(juce::Rectangle<int> fullBounds)
     {
+        const bool detailShowing = targets_.detailShowing;
         // Step 6: browser covers the ocean viewport above the waterline only.
         const auto area = computeOceanArea(fullBounds);
 

--- a/Source/UI/Ocean/OceanLayout.h
+++ b/Source/UI/Ocean/OceanLayout.h
@@ -12,8 +12,8 @@
 //   OceanLayout layout_{children_, /* LayoutTargets */ {  }};
 //
 //   OceanView::resized() becomes:
-//     layout_.applyLayout(viewState_, getLocalBounds(), selectedSlot_,
-//                         detailShowing_, firstLaunch_);
+//     layout_.layoutForState(viewState_, getLocalBounds(), selectedSlot_,
+//                            detailShowing_, firstLaunch_);
 //
 // Constraints (same as OceanChildren):
 //   - No back-reference to OceanView (no OceanView* member).
@@ -119,7 +119,7 @@ struct LayoutTargets
     Encapsulates all geometry/layout strategies extracted from OceanView.
 
     Responsibilities:
-      - `applyLayout()` — called from OceanView::resized(); dispatches to the
+      - `layoutForState()` — called from OceanView::resized(); dispatches to the
         correct per-state layout strategy and also runs the dashboard/overlay
         layout that is state-independent.
       - `reorderZStack()` — static Z-order enforcement; called once per setup
@@ -176,11 +176,11 @@ public:
         BrowserOpen
     };
 
-    void applyLayout(ViewState   viewState,
-                     juce::Rectangle<int> fullBounds,
-                     int         selectedSlot,
-                     bool        detailShowing,
-                     bool        firstLaunch)
+    void layoutForState(ViewState   viewState,
+                        juce::Rectangle<int> fullBounds,
+                        int         selectedSlot,
+                        bool        detailShowing,
+                        bool        firstLaunch)
     {
         // ── Ocean-area strategy (state-dependent) ────────────────────────────
         switch (viewState)

--- a/Source/UI/Ocean/OceanLayout.h
+++ b/Source/UI/Ocean/OceanLayout.h
@@ -14,6 +14,8 @@
 //   OceanView::resized() becomes:
 //     layout_.layoutForState(viewState_, getLocalBounds(), selectedSlot_,
 //                            detailShowing_, firstLaunch_);
+//   Phase 3 animation:
+//     layout_.layoutForState(state, bounds, slot, detail, firstLaunch, progress01);
 //
 // Constraints (same as OceanChildren):
 //   - No back-reference to OceanView (no OceanView* member).
@@ -167,6 +169,9 @@ public:
         @param selectedSlot  Which slot is enlarged/active (-1 = none).
         @param detailShowing Whether the detail overlay is currently displayed.
         @param firstLaunch   Whether the user hasn't loaded any engine yet.
+        @param progress01    Normalised animation progress [0, 1] for in-flight
+                             transitions (default 1.0 = fully settled).  Reserved
+                             for Phase 3 — currently unused (juce::ignoreUnused).
     */
     enum class ViewState
     {
@@ -180,8 +185,11 @@ public:
                         juce::Rectangle<int> fullBounds,
                         int         selectedSlot,
                         bool        detailShowing,
-                        bool        firstLaunch)
+                        bool        firstLaunch,
+                        float       progress01 = 1.0f)
     {
+        juce::ignoreUnused(progress01);  // Phase 3 will use this for animation interpolation.
+
         // ── Ocean-area strategy (state-dependent) ────────────────────────────
         switch (viewState)
         {

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -653,6 +653,10 @@ public:
                 subPlaySurface_,
                 ouijaPanel_,
                 surfaceRight_,
+                // Phase 2.5 (#1184): layout-input state bindings (const-ref).
+                selectedSlot_,
+                detailShowing_,
+                firstLaunch_,
             });
     }
 
@@ -841,10 +845,7 @@ public:
         jassert(layout_ != nullptr);
         layout_->layoutForState(
             static_cast<OceanLayout::ViewState>(viewState_),
-            getLocalBounds(),
-            selectedSlot_,
-            detailShowing_,
-            firstLaunch_);
+            getLocalBounds());
     }
 
     bool keyPressed(const juce::KeyPress& key) override
@@ -2088,10 +2089,12 @@ private:
     // layoutFloatingControls() have all been moved to OceanLayout.
     //
     // They are no longer declared here.  OceanView::resized() now calls:
-    //   layout_->layoutForState(state, bounds, selectedSlot_, detailShowing_, firstLaunch_)
+    //   layout_->layoutForState(state, bounds)
     //
     // OceanLayout::layoutForState() dispatches to the per-state layout strategies
-    // and also runs the state-independent dashboard layout.
+    // and also runs the state-independent dashboard layout.  The selectedSlot,
+    // detailShowing, and firstLaunch state values are now const-ref bindings in
+    // LayoutTargets (Phase 2.5, #1184) rather than per-call arguments.
     //==========================================================================
 
     //==========================================================================

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -839,7 +839,7 @@ public:
         static_assert(static_cast<int>(ViewState::BrowserOpen)    == static_cast<int>(OceanLayout::ViewState::BrowserOpen));
 
         jassert(layout_ != nullptr);
-        layout_->applyLayout(
+        layout_->layoutForState(
             static_cast<OceanLayout::ViewState>(viewState_),
             getLocalBounds(),
             selectedSlot_,
@@ -2088,9 +2088,9 @@ private:
     // layoutFloatingControls() have all been moved to OceanLayout.
     //
     // They are no longer declared here.  OceanView::resized() now calls:
-    //   layout_->applyLayout(state, bounds, selectedSlot_, detailShowing_, firstLaunch_)
+    //   layout_->layoutForState(state, bounds, selectedSlot_, detailShowing_, firstLaunch_)
     //
-    // OceanLayout::applyLayout() dispatches to the per-state layout strategies
+    // OceanLayout::layoutForState() dispatches to the per-state layout strategies
     // and also runs the state-independent dashboard layout.
     //==========================================================================
 


### PR DESCRIPTION
## Summary

- Renames `OceanLayout::applyLayout` → `layoutForState` to match the locked design doc API (issue #1184, `oceanview-decomposition-design-2026-04-26.md`).
- Adds `float progress01 = 1.0f` trailing parameter (with `juce::ignoreUnused`) reserved for Phase 3 animation interpolation.
- Folds the three per-call state args (`int selectedSlot`, `bool detailShowing`, `bool firstLaunch`) into `LayoutTargets` as `const&` bindings to the corresponding `OceanView` members, so `layoutForState`'s final signature is exactly `void layoutForState(ViewState, juce::Rectangle<int>, float = 1.0f)` — matching the design doc.

**Parent:** PR #1343 (Phase 2 — OceanLayout extraction).
**Unblocks:** Phase 3 (OceanStateMachine extraction) — StateMachine can now wire `onAnimationFrame` → `layout_.layoutForState(state, bounds, progress01)` without any further API changes.

## What changed

- `Source/UI/Ocean/OceanLayout.h`: rename, new param, 3 new const-ref fields in `LayoutTargets`, all 4 per-state private helpers (`layoutOrbital`, `layoutZoomIn`, `layoutSplitTransform`, `layoutBrowser`) updated to drop their state args and read from `targets_`.
- `Source/UI/Ocean/OceanView.h`: updated call site, `LayoutTargets` construction wires `selectedSlot_`, `detailShowing_`, `firstLaunch_`, updated doc comments.

## Test plan

- [x] `cmake --build build --target XOceanus_AU -j4` — 0 errors after each of the 3 commits.
- [x] Pure refactor — no behavior change (same data flow, same values, just plumbed via const-ref instead of per-call arg).
- [ ] Manual smoke test in DAW (AU) — load engine, cycle through all 4 view states, verify layout behaves identically to pre-patch.

## Commits

1. `arch(#1184): Phase 2.5 step 1 — rename applyLayout → layoutForState`
2. `arch(#1184): Phase 2.5 step 2 — add progress01 animation param to layoutForState`
3. `arch(#1184): Phase 2.5 step 3 — fold layout-input state into LayoutTargets`

Closes part of #1184 (Phase 2.5 conformance patch; Phase 3 remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)