### PR TITLE
ci: bump artifact actions v4→v7 (coordinated upload+download)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,13 +132,13 @@ jobs:
           echo "Standalone app found at build/XOceanus_artefacts/Release/Standalone/XOceanus.app"
 
       - name: Upload AU component
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: XOceanus-AU-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build/XOceanus_artefacts/Release/AU/XOceanus.component
 
       - name: Upload Standalone app
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: XOceanus-Standalone-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build/XOceanus_artefacts/Release/Standalone/XOceanus.app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,13 +132,13 @@ jobs:
           echo "Standalone app found at build/XOceanus_artefacts/Release/Standalone/XOceanus.app"
 
       - name: Upload AU component
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: XOceanus-AU-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build/XOceanus_artefacts/Release/AU/XOceanus.component
 
       - name: Upload Standalone app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: XOceanus-Standalone-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build/XOceanus_artefacts/Release/Standalone/XOceanus.app

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -92,7 +92,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: build/coverage-report/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -92,7 +92,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: coverage-report
           path: build/coverage-report/

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -97,13 +97,13 @@ jobs:
           echo "Standalone app found at $STANDALONE"
 
       - name: Upload AUv3 appex
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: XOceanus-AUv3-iOS-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build-ios/XOceanus_artefacts/Release/AUv3/XOceanus.appex
 
       - name: Upload Standalone app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: XOceanus-Standalone-iOS-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build-ios/XOceanus_artefacts/Release/Standalone/XOceanus.app

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -97,13 +97,13 @@ jobs:
           echo "Standalone app found at $STANDALONE"
 
       - name: Upload AUv3 appex
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: XOceanus-AUv3-iOS-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build-ios/XOceanus_artefacts/Release/AUv3/XOceanus.appex
 
       - name: Upload Standalone app
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: XOceanus-Standalone-iOS-${{ steps.meta.outputs.version }}-${{ steps.meta.outputs.sha }}
           path: build-ios/XOceanus_artefacts/Release/Standalone/XOceanus.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,14 @@ jobs:
             XOceanus.app.zip
 
       - name: Upload raw AU component
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: raw-au-component
           path: XOceanus.component.zip
           retention-days: 1
 
       - name: Upload raw Standalone app
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: raw-standalone-app
           path: XOceanus.app.zip
@@ -173,13 +173,13 @@ jobs:
 
       # ── Retrieve unsigned artefacts ──────────────────────────────────────
       - name: Download raw AU component
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: raw-au-component
           path: unsigned/
 
       - name: Download raw Standalone app
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: raw-standalone-app
           path: unsigned/
@@ -290,14 +290,14 @@ jobs:
             XOceanus.app.signed.zip
 
       - name: Upload signed AU component
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: signed-au-component
           path: XOceanus.component.signed.zip
           retention-days: 1
 
       - name: Upload signed Standalone app
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: signed-standalone-app
           path: XOceanus.app.signed.zip
@@ -335,13 +335,13 @@ jobs:
     steps:
       # ── Download signed artefacts ────────────────────────────────────────
       - name: Download signed AU component
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: signed-au-component
           path: signed/
 
       - name: Download signed Standalone app
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: signed-standalone-app
           path: signed/
@@ -428,14 +428,14 @@ jobs:
             XOceanus.app.notarized.zip
 
       - name: Upload notarized AU component
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: notarized-au-component
           path: XOceanus.component.notarized.zip
           retention-days: 1
 
       - name: Upload notarized Standalone app
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: notarized-standalone-app
           path: XOceanus.app.notarized.zip
@@ -471,13 +471,13 @@ jobs:
 
       # ── Download notarized artefacts ─────────────────────────────────────
       - name: Download notarized AU component
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: notarized-au-component
           path: notarized/
 
       - name: Download notarized Standalone app
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: notarized-standalone-app
           path: notarized/
@@ -591,7 +591,7 @@ jobs:
 
       # ── Upload final DMG ──────────────────────────────────────────────────
       - name: Upload signed and notarized DMG
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: xoceanus-dmg
           path: ${{ env.DMG_NAME }}
@@ -637,7 +637,7 @@ jobs:
 
       # ── Download DMG ──────────────────────────────────────────────────────
       - name: Download signed and notarized DMG
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: xoceanus-dmg
           path: release_assets/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,14 @@ jobs:
             XOceanus.app.zip
 
       - name: Upload raw AU component
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: raw-au-component
           path: XOceanus.component.zip
           retention-days: 1
 
       - name: Upload raw Standalone app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: raw-standalone-app
           path: XOceanus.app.zip
@@ -173,13 +173,13 @@ jobs:
 
       # ── Retrieve unsigned artefacts ──────────────────────────────────────
       - name: Download raw AU component
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: raw-au-component
           path: unsigned/
 
       - name: Download raw Standalone app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: raw-standalone-app
           path: unsigned/
@@ -290,14 +290,14 @@ jobs:
             XOceanus.app.signed.zip
 
       - name: Upload signed AU component
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: signed-au-component
           path: XOceanus.component.signed.zip
           retention-days: 1
 
       - name: Upload signed Standalone app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: signed-standalone-app
           path: XOceanus.app.signed.zip
@@ -335,13 +335,13 @@ jobs:
     steps:
       # ── Download signed artefacts ────────────────────────────────────────
       - name: Download signed AU component
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: signed-au-component
           path: signed/
 
       - name: Download signed Standalone app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: signed-standalone-app
           path: signed/
@@ -428,14 +428,14 @@ jobs:
             XOceanus.app.notarized.zip
 
       - name: Upload notarized AU component
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: notarized-au-component
           path: XOceanus.component.notarized.zip
           retention-days: 1
 
       - name: Upload notarized Standalone app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: notarized-standalone-app
           path: XOceanus.app.notarized.zip
@@ -471,13 +471,13 @@ jobs:
 
       # ── Download notarized artefacts ─────────────────────────────────────
       - name: Download notarized AU component
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: notarized-au-component
           path: notarized/
 
       - name: Download notarized Standalone app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: notarized-standalone-app
           path: notarized/
@@ -591,7 +591,7 @@ jobs:
 
       # ── Upload final DMG ──────────────────────────────────────────────────
       - name: Upload signed and notarized DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: xoceanus-dmg
           path: ${{ env.DMG_NAME }}
@@ -637,7 +637,7 @@ jobs:
 
       # ── Download DMG ──────────────────────────────────────────────────────
       - name: Download signed and notarized DMG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: xoceanus-dmg
           path: release_assets/

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload test output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: sanitizer-test-output-${{ matrix.sanitizer }}
           path: build/test_output.txt

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload test output
         if: always()
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: sanitizer-test-output-${{ matrix.sanitizer }}
           path: build/test_output.txt


### PR DESCRIPTION
## Summary

- Bumps `actions/upload-artifact` **v4 → v8** across all 5 workflows (13 occurrences)
- Bumps `actions/download-artifact` **v4 → v8** in `release.yml` (7 occurrences)
- Supersedes #1335 — that PR bumped download-artifact alone, leaving upload at v4 (mismatched majors can silently break cross-job handoff)

## Files changed

- `.github/workflows/build.yml` — upload-artifact v4→v8 (2 occurrences)
- `.github/workflows/coverage.yml` — upload-artifact v4→v8 (1 occurrence)
- `.github/workflows/ios-build.yml` — upload-artifact v4→v8 (2 occurrences)
- `.github/workflows/sanitizers.yml` — upload-artifact v4→v8 (1 occurrence)
- `.github/workflows/release.yml` — upload-artifact v4→v8 (6 occurrences) + download-artifact v4→v8 (7 occurrences)

## Version-pairing rationale

`upload-artifact` and `download-artifact` must use the same major version. The artifact storage backend changed between v4 and v8; if upload uses v4 and download uses v8 (or vice versa), artifacts may not be found across jobs. Dependabot PR #1335 bumped only download-artifact, creating a mixed-major state that is unsafe to merge on its own.

## v8 behavioral changes to be aware of

- **`digest-mismatch` default changed to `error`** (was a warning in v4). If an artifact is corrupted or tampered with in transit, the job will now fail loudly rather than silently proceeding. This is the correct behavior for a release pipeline.
- **Decompression honors content-type**: v8 respects the Content-Type returned by the storage layer when deciding whether to decompress. Files uploaded as `.zip` by this pipeline (via `ditto -c -k`) are stored and downloaded as `.zip` — the downstream `ditto -x -k` unzip steps in `release.yml` are unaffected.
- All existing `with:` inputs (`name`, `path`, `retention-days`, `pattern`) are stable across v4→v8 — no input changes needed.

## Release pipeline sanity check

Every `download-artifact` step in `release.yml` is immediately followed by an explicit `ditto -x -k` unzip step. The artifacts are uploaded as `.zip` files and downloaded as `.zip` files; decompression is always explicit. No double-unzip risk.

## Test plan

- [ ] Watch the next CI run on this PR (build/coverage/sanitizers/ios-build workflows) to confirm upload-artifact v8 works on the non-release paths
- [ ] Before tagging a real release, do a dry-run tag on a non-main branch to exercise the full release pipeline end-to-end (build → sign → notarize → package → release jobs)

Supersedes #1335