### PR TITLE
fix(ci): swap auto-update-prs.yml GITHUB_TOKEN → PAT to break merge deadlock

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Update open PR branches
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}
           script: |
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,


### PR DESCRIPTION
## Problem

`auto-update-prs.yml` used `${{ secrets.GITHUB_TOKEN }}` to push branch-update commits onto open PRs. GitHub's token scoping means `GITHUB_TOKEN`-triggered pushes do **not** fan out to other workflows — so required status checks on those PRs never re-run, deadlocking merges (closes #1349).

## Fix

Swapped `github-token` to `${{ secrets.PAT }}` — a user/org PAT whose pushes are treated as a real actor and correctly trigger downstream check workflows.

## Action Required

**`secrets.PAT` does not yet exist in this repo.** Go to **Settings → Secrets and variables → Actions → New repository secret** and add a PAT with `repo` + `workflow` scopes under the name `PAT`. Until then the workflow will fail on the token lookup, but merges will no longer deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)