### PR TITLE
feat(fx): Pack 1 — Oblate/Oligo scaffold + real Otrium DSP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,8 @@ were renamed to O-prefix convention. **Parameter prefixes are frozen and never c
 | Onda | `oner_` | `oner_boundState` |
 | Ollotron | `ollo_` | `ollo_bank` |
 | Otrium (FX Chain) | `otrm_` | `otrm_pumpDepth` |
+| Oblate (FX Chain) | `obla_` | `obla_threshold` |
+| Oligo (FX Chain) | `olig_` | `olig_lowDepth` |
 
 Legacy engine names (`Snap`, `Morph`, `Dub`, `Drift`, `Bob`, `Fat`, `Bite`)
 are resolved automatically by `resolveEngineAlias()` in `PresetManager.h`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,8 @@ target_sources(XOceanus PRIVATE
     Source/DSP/Effects/OrreryChain.cpp
     # FX Pack 1 — Sidechain Creative (scaffold)
     Source/DSP/Effects/OtriumChain.cpp
+    Source/DSP/Effects/OblateChain.cpp
+    Source/DSP/Effects/OligoChain.cpp
 
     # DSP (shared, pure C++)
     Source/DSP/FastMath.h

--- a/Source/Core/EpicChainSlotController.h
+++ b/Source/Core/EpicChainSlotController.h
@@ -136,6 +136,13 @@ public:
     /// Reset all chain states (called from MasterFXChain::reset()).
     void reset();
 
+    //--------------------------------------------------------------------------
+    /// Inject the DNAModulationBus pointer into every Pack 1 chain instance
+    /// (Otrium, Oblate, Oligo across all 3 slots). Call once on the message
+    /// thread after construction, before audio starts. The pointer is read
+    /// lock-free on the audio thread by the chains' DSP.
+    void setDNABus(const DNAModulationBus* bus) noexcept;
+
 private:
     double sr_         = 0.0;  // Sentinel: must be set by prepare() before use
     int    blockSize_  = 512;
@@ -326,6 +333,16 @@ inline void EpicChainSlotController::reset()
         slot.otrium.reset(); // FX Pack 1 scaffold
         slot.oblate.reset(); // FX Pack 1 scaffold
         slot.oligo.reset();  // FX Pack 1 scaffold
+    }
+}
+
+inline void EpicChainSlotController::setDNABus(const DNAModulationBus* bus) noexcept
+{
+    for (auto& slot : slots_)
+    {
+        slot.otrium.setDNABus(bus);
+        slot.oblate.setDNABus(bus);
+        slot.oligo.setDNABus(bus);
     }
 }
 

--- a/Source/Core/EpicChainSlotController.h
+++ b/Source/Core/EpicChainSlotController.h
@@ -143,6 +143,12 @@ public:
     /// lock-free on the audio thread by the chains' DSP.
     void setDNABus(const DNAModulationBus* bus) noexcept;
 
+    //--------------------------------------------------------------------------
+    /// Inject the PartnerAudioBus pointer into Pack 1 chains that consume
+    /// per-engine-slot mono audio (Otrium triangular ducking). Call once on
+    /// the message thread after construction, before audio starts.
+    void setPartnerAudioBus(const PartnerAudioBus* bus) noexcept;
+
 private:
     double sr_         = 0.0;  // Sentinel: must be set by prepare() before use
     int    blockSize_  = 512;
@@ -344,6 +350,14 @@ inline void EpicChainSlotController::setDNABus(const DNAModulationBus* bus) noex
         slot.oblate.setDNABus(bus);
         slot.oligo.setDNABus(bus);
     }
+}
+
+inline void EpicChainSlotController::setPartnerAudioBus(const PartnerAudioBus* bus) noexcept
+{
+    // Only Otrium consumes partner audio in Pack 1; Oblate/Oligo will
+    // receive their own bus pointers when their real DSP lands.
+    for (auto& slot : slots_)
+        slot.otrium.setPartnerAudioBus(bus);
 }
 
 inline void EpicChainSlotController::processBlock(juce::AudioBuffer<float>& buffer,

--- a/Source/Core/EpicChainSlotController.h
+++ b/Source/Core/EpicChainSlotController.h
@@ -37,6 +37,8 @@
 #include "../DSP/Effects/OrreryChain.h"
 // FX Pack 1 — Sidechain Creative
 #include "../DSP/Effects/OtriumChain.h"
+#include "../DSP/Effects/OblateChain.h"
+#include "../DSP/Effects/OligoChain.h"
 
 namespace xoceanus
 {
@@ -61,8 +63,8 @@ class EpicChainSlotController
 {
 public:
     static constexpr int kNumSlots   = 3;
-    static constexpr int kNumChains  = 31;
-    static constexpr int kMaxChainID = 31;  // == static_cast<int>(Otrium)
+    static constexpr int kNumChains  = 33;
+    static constexpr int kMaxChainID = 33;  // == static_cast<int>(Oligo)
 
     enum ChainID : int
     {
@@ -103,7 +105,9 @@ public:
         Outbreak   = 29,
         Orrery     = 30,
         // FX Pack 1 — Sidechain Creative (scaffold; Pack 1 ships full DSP)
-        Otrium     = 31
+        Otrium     = 31,
+        Oblate     = 32,
+        Oligo      = 33
     };
 
     EpicChainSlotController() = default;
@@ -189,6 +193,8 @@ private:
         OrreryChain     orrery;
         // FX Pack 1 — Sidechain Creative
         OtriumChain     otrium;
+        OblateChain     oblate;
+        OligoChain      oligo;
 
         // Mono scratch buffer for Mono-In chains (19 Wave 2 + Onrush, Obliterate, Obscurity)
         std::vector<float> monoScratch;
@@ -273,6 +279,8 @@ inline void EpicChainSlotController::prepare(double sampleRate, int maxBlockSize
         slot.outbreak.prepare(sampleRate, maxBlockSize);
         slot.orrery.prepare(sampleRate, maxBlockSize);
         slot.otrium.prepare(sampleRate, maxBlockSize); // FX Pack 1 scaffold
+        slot.oblate.prepare(sampleRate, maxBlockSize); // FX Pack 1 scaffold
+        slot.oligo.prepare(sampleRate, maxBlockSize);  // FX Pack 1 scaffold
         // Mono scratch buffer for mono-in epic chains
         slot.monoScratch.assign(maxBlockSize, 0.0f);
     }
@@ -316,6 +324,8 @@ inline void EpicChainSlotController::reset()
         slot.outbreak.reset();
         slot.orrery.reset();
         slot.otrium.reset(); // FX Pack 1 scaffold
+        slot.oblate.reset(); // FX Pack 1 scaffold
+        slot.oligo.reset();  // FX Pack 1 scaffold
     }
 }
 
@@ -345,7 +355,7 @@ inline void EpicChainSlotController::processBlock(juce::AudioBuffer<float>& buff
         // Detect chain change
         ChainID requestedChain = static_cast<ChainID>(static_cast<int>(chainVal + 0.5f));
         requestedChain = static_cast<ChainID>(
-            juce::jlimit(static_cast<int>(Off), static_cast<int>(Orrery),
+            juce::jlimit(static_cast<int>(Off), kMaxChainID,
                          static_cast<int>(requestedChain)));
 
         if (requestedChain != slot.pendingChain && slot.crossfadeProgress >= 1.0f)
@@ -670,6 +680,18 @@ inline void EpicChainSlotController::dispatchChain(FXSlot& slot, ChainID chain,
             break;
         }
 
+        case Oblate:
+        {
+            slot.oblate.processBlock(L, R, numSamples, bpm, ppqPosition);
+            break;
+        }
+
+        case Oligo:
+        {
+            slot.oligo.processBlock(L, R, numSamples, bpm, ppqPosition);
+            break;
+        }
+
         default: break;
     }
 }
@@ -747,6 +769,8 @@ inline void EpicChainSlotController::addParameters(
     OutbreakChain::addParameters(layout);
     OrreryChain::addParameters(layout);
     OtriumChain::addParameters(layout); // FX Pack 1 scaffold
+    OblateChain::addParameters(layout); // FX Pack 1 scaffold
+    OligoChain::addParameters(layout);  // FX Pack 1 scaffold
 }
 
 inline void EpicChainSlotController::cacheParameterPointers(
@@ -794,6 +818,8 @@ inline void EpicChainSlotController::cacheParameterPointers(
         slots_[n].outbreak.cacheParameterPointers(apvts);
         slots_[n].orrery.cacheParameterPointers(apvts);
         slots_[n].otrium.cacheParameterPointers(apvts); // FX Pack 1 scaffold
+        slots_[n].oblate.cacheParameterPointers(apvts); // FX Pack 1 scaffold
+        slots_[n].oligo.cacheParameterPointers(apvts);  // FX Pack 1 scaffold
     }
 }
 

--- a/Source/Core/PartnerAudioBus.h
+++ b/Source/Core/PartnerAudioBus.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+
+#include <array>
+#include <vector>
+#include <algorithm>
+
+namespace xoceanus
+{
+
+//==============================================================================
+// PartnerAudioBus — per-engine-slot mono audio bus for FX chains.
+//
+// Phase 0 wildcard infrastructure (FX gap analysis, 2026-04-27 Pack 1).
+//
+// Allows FX chains (e.g. OtriumChain) to read each engine slot's most-recent
+// mono mix per block without breaching the matrix-mediates-coupling boundary.
+// The bus is published by XOceanusProcessor after each engine's renderBlock()
+// and consumed by Pack 1 FX chains during their own processBlock().
+//
+// Lifecycle per audio block:
+//   1. processBlock() top → clearForBlock()  (zeroes per-slot sample counts)
+//   2. for each engine slot i (0..3):
+//        engine[i]->renderBlock(buf[i], midi[i], n)
+//        bus.publish(i, buf[i].L, buf[i].R, n)        ← engines write
+//   3. epicSlots.processBlock(...)                    ← FX chains read
+//        chain.getMono(slot) for slot in {A,B,C}
+//
+// Threading: single-threaded on the audio thread. Engine writes and chain
+// reads are sequential within the same processBlock() call. No locks, no
+// atomics — kept simple because the read/write order is deterministic.
+//==============================================================================
+class PartnerAudioBus
+{
+public:
+    static constexpr int kNumSlots = 4; // matches XOceanus' 4-slot engine fleet
+
+    void prepare(int maxBlockSize)
+    {
+        maxBlock_ = maxBlockSize;
+        for (auto& buf : monoBuffers_)
+            buf.assign(static_cast<size_t>(maxBlockSize), 0.0f);
+        for (auto& n : slotSamples_) n = 0;
+    }
+
+    // Call at the top of each audio block, before any engine renders.
+    // Resets all slot sample counts so unpublished slots return nullptr.
+    void clearForBlock() noexcept
+    {
+        for (auto& n : slotSamples_) n = 0;
+    }
+
+    // Audio thread: called once per engine slot after its renderBlock().
+    // Stores mono mix (0.5 * (L + R)) into the slot's buffer.
+    void publish(int slot, const float* L, const float* R, int numSamples) noexcept
+    {
+        if (slot < 0 || slot >= kNumSlots || numSamples <= 0 || maxBlock_ <= 0)
+            return;
+        const int n = std::min(numSamples, maxBlock_);
+        auto& buf = monoBuffers_[static_cast<size_t>(slot)];
+        for (int i = 0; i < n; ++i)
+            buf[static_cast<size_t>(i)] = (L[i] + R[i]) * 0.5f;
+        slotSamples_[static_cast<size_t>(slot)] = n;
+    }
+
+    // Audio thread: read mono buffer for a slot. Pointer is valid until the
+    // next clearForBlock() or publish() to the same slot. Returns nullptr if
+    // the slot was not published this block (e.g. silence-gated engine).
+    const float* getMono(int slot) const noexcept
+    {
+        if (slot < 0 || slot >= kNumSlots
+            || slotSamples_[static_cast<size_t>(slot)] <= 0)
+            return nullptr;
+        return monoBuffers_[static_cast<size_t>(slot)].data();
+    }
+
+    int getNumSamples(int slot) const noexcept
+    {
+        return (slot < 0 || slot >= kNumSlots)
+                   ? 0
+                   : slotSamples_[static_cast<size_t>(slot)];
+    }
+
+private:
+    std::array<std::vector<float>, kNumSlots> monoBuffers_;
+    std::array<int, kNumSlots> slotSamples_{};
+    int maxBlock_ = 0;
+};
+
+} // namespace xoceanus

--- a/Source/DSP/Effects/OblateChain.cpp
+++ b/Source/DSP/Effects/OblateChain.cpp
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#include "OblateChain.h"

--- a/Source/DSP/Effects/OblateChain.h
+++ b/Source/DSP/Effects/OblateChain.h
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+
+#include "../../Core/DNAModulationBus.h"
+#include "../ParameterSmoother.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <atomic>
+
+namespace xoceanus
+{
+
+//==============================================================================
+// OblateChain — Spectral Gate (FX Pack 1, Sidechain Creative)
+//
+// Wildcard: STFT gate where each FFT bin is gated by the partner engine's
+// spectrum, with partner brightness DNA tilting the threshold curve.
+// Sidechain key driven by partner *spectrum*, not just amplitude.
+//
+// Parameter prefix: obla_  (12 params: 11 base + obla_hqMode per spec §10 A2)
+//
+// Routing: Stereo In → Stereo Out (per-channel STFT analysis)
+// Latency: PDC declared per active FFT size (default 1024 ≈ 23 ms)
+//
+// Phase 0 status: SCAFFOLD ONLY.
+//   - Class structure, parameters, DNA bus consumption hook are complete.
+//   - DSP is a placeholder pass-through with threshold-modulated gain.
+//   - Real STFT/ISTFT pipeline + per-bin gating lands in Pack 1 implementation.
+//
+// See: Docs/specs/2026-04-27-fx-pack-1-sidechain-creative.md §3, §10 (A2)
+//==============================================================================
+class OblateChain
+{
+public:
+    OblateChain() = default;
+
+    void prepare(double sampleRate, int /*maxBlockSize*/)
+    {
+        sr_ = sampleRate;
+        thresholdSmoothed_.reset(sampleRate, 0.02);
+        mixSmoothed_.reset(sampleRate, 0.02);
+    }
+
+    void reset()
+    {
+        thresholdSmoothed_.setCurrentAndTargetValue(-20.0f);
+        mixSmoothed_.setCurrentAndTargetValue(1.0f);
+    }
+
+    // Inject DNA bus pointer (set once on message thread before audio starts).
+    // Pack 1 implementation wires this into the dnaCoupling parameter — partner
+    // brightness DNA scales the per-bin threshold tilt.
+    void setDNABus(const DNAModulationBus* bus) noexcept { dnaBus_ = bus; }
+
+    // Stereo in, stereo out. Pack 1 will replace this with STFT/ISTFT
+    // resynthesis driven by the sidechain key extractor; for now applies a
+    // simple threshold-modulated mute to demonstrate parameter wiring.
+    void processBlock(float* L, float* R, int numSamples,
+                      double /*bpm*/ = 0.0, double /*ppqPosition*/ = -1.0)
+    {
+        if (! pThreshold_ || ! pMix_) return;
+
+        thresholdSmoothed_.setTargetValue(pThreshold_->load(std::memory_order_relaxed));
+        mixSmoothed_.setTargetValue(pMix_->load(std::memory_order_relaxed));
+
+        for (int i = 0; i < numSamples; ++i)
+        {
+            const float thresholdDb = thresholdSmoothed_.getNextValue();
+            const float mix         = mixSmoothed_.getNextValue();
+            const float thresholdLin = juce::Decibels::decibelsToGain(thresholdDb);
+            const float dryL = L[i];
+            const float dryR = R[i];
+            const float gateL = std::abs(dryL) > thresholdLin ? dryL : 0.0f;
+            const float gateR = std::abs(dryR) > thresholdLin ? dryR : 0.0f;
+            L[i] = dryL * (1.0f - mix) + gateL * mix;
+            R[i] = dryR * (1.0f - mix) + gateR * mix;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // APVTS integration — 12 parameters per Pack 1 spec §3 + A2 (hqMode).
+    static void addParameters(juce::AudioProcessorValueTreeState::ParameterLayout& layout,
+                              const juce::String& slotPrefix = "")
+    {
+        const juce::String p = slotPrefix + "obla_";
+
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "threshold", 1), "OBLA Threshold",
+            juce::NormalisableRange<float>(-60.0f, 0.0f), -20.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "ratio", 1), "OBLA Ratio",
+            juce::NormalisableRange<float>(1.0f, 100.0f, 0.0f, 0.3f), 4.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "attack", 1), "OBLA Attack",
+            juce::NormalisableRange<float>(0.1f, 50.0f, 0.0f, 0.5f), 2.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "release", 1), "OBLA Release",
+            juce::NormalisableRange<float>(5.0f, 500.0f, 0.0f, 0.5f), 100.0f));
+        layout.add(std::make_unique<juce::AudioParameterInt>(
+            juce::ParameterID(p + "keyEngine", 1), "OBLA Key Engine", 0, 3, 0));
+        // A2 (locked 2026-04-27): default 1024, 2048 only when hqMode is on.
+        layout.add(std::make_unique<juce::AudioParameterChoice>(
+            juce::ParameterID(p + "fftSize", 1), "OBLA FFT Size",
+            juce::StringArray{"256", "512", "1024", "2048"}, 2));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "tilt", 1), "OBLA Tilt",
+            juce::NormalisableRange<float>(-1.0f, 1.0f), 0.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "dnaCoupling", 1), "OBLA DNA Coupling",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "smoothing", 1), "OBLA Smoothing",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+        // D005 floor: 0.001 Hz.
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "breathRate", 1), "OBLA Breath Rate",
+            juce::NormalisableRange<float>(0.001f, 2.0f, 0.0f, 0.3f), 0.1f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "mix", 1), "OBLA Mix",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 1.0f));
+        // A2 (locked 2026-04-27): HQ Mode toggle gates the 2048 FFT option.
+        layout.add(std::make_unique<juce::AudioParameterBool>(
+            juce::ParameterID(p + "hqMode", 1), "OBLA HQ Mode", false));
+    }
+
+    void cacheParameterPointers(juce::AudioProcessorValueTreeState& apvts,
+                                const juce::String& slotPrefix = "")
+    {
+        const juce::String p = slotPrefix + "obla_";
+        pThreshold_ = apvts.getRawParameterValue(p + "threshold");
+        pMix_       = apvts.getRawParameterValue(p + "mix");
+        // Remaining param pointers cached during Pack 1 implementation when
+        // their consuming DSP stages are added.
+    }
+
+private:
+    double sr_ = 0.0;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> thresholdSmoothed_;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> mixSmoothed_;
+
+    std::atomic<float>* pThreshold_ = nullptr;
+    std::atomic<float>* pMix_       = nullptr;
+
+    // Set once via setDNABus() on message thread before audio starts;
+    // read on audio thread without synchronisation (single-writer, single-reader,
+    // before-after pattern). Pack 1 implementation will read DNA per block.
+    const DNAModulationBus* dnaBus_ = nullptr;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OblateChain)
+};
+
+} // namespace xoceanus

--- a/Source/DSP/Effects/OblateChain.h
+++ b/Source/DSP/Effects/OblateChain.h
@@ -99,10 +99,14 @@ public:
             juce::NormalisableRange<float>(5.0f, 500.0f, 0.0f, 0.5f), 100.0f));
         layout.add(std::make_unique<juce::AudioParameterInt>(
             juce::ParameterID(p + "keyEngine", 1), "OBLA Key Engine", 0, 3, 0));
-        // A2 (locked 2026-04-27): default 1024, 2048 only when hqMode is on.
+        // A2 (locked 2026-04-27): default 1024. The 2048 option is gated
+        // behind obla_hqMode and re-introduced together with the gating
+        // logic in the Pack 1 implementation PR. Omitted here to prevent
+        // invalid (fftSize=2048, hqMode=false) combinations from being
+        // saved/automated against the scaffold.
         layout.add(std::make_unique<juce::AudioParameterChoice>(
             juce::ParameterID(p + "fftSize", 1), "OBLA FFT Size",
-            juce::StringArray{"256", "512", "1024", "2048"}, 2));
+            juce::StringArray{"256", "512", "1024"}, 2));
         layout.add(std::make_unique<juce::AudioParameterFloat>(
             juce::ParameterID(p + "tilt", 1), "OBLA Tilt",
             juce::NormalisableRange<float>(-1.0f, 1.0f), 0.0f));

--- a/Source/DSP/Effects/OligoChain.cpp
+++ b/Source/DSP/Effects/OligoChain.cpp
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#include "OligoChain.h"

--- a/Source/DSP/Effects/OligoChain.h
+++ b/Source/DSP/Effects/OligoChain.h
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+
+#include "../../Core/DNAModulationBus.h"
+#include "../ParameterSmoother.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <atomic>
+
+namespace xoceanus
+{
+
+//==============================================================================
+// OligoChain — Frequency-Selective Ducker (FX Pack 1, Sidechain Creative)
+//
+// Wildcard: 4-band Linkwitz-Riley split with per-band ducking. Partner DNA
+// shapes per-band release time — brightness → high band, density → lo-mid,
+// aggression → low band.
+//
+// Parameter prefix: olig_  (13 params per Pack 1 spec §4)
+//
+// Routing: Stereo In → Stereo Out (4-band split applied per channel)
+//
+// Phase 0 status: SCAFFOLD ONLY.
+//   - Class structure, parameters, DNA bus consumption hook are complete.
+//   - DSP is a placeholder pass-through with summed-depth-modulated gain.
+//   - Real LR4 split + per-band VCAs + DNA-aware release scaling lands in
+//     Pack 1 implementation.
+//
+// See: Docs/specs/2026-04-27-fx-pack-1-sidechain-creative.md §4
+//==============================================================================
+class OligoChain
+{
+public:
+    OligoChain() = default;
+
+    void prepare(double sampleRate, int /*maxBlockSize*/)
+    {
+        sr_ = sampleRate;
+        depthSumSmoothed_.reset(sampleRate, 0.02);
+        mixSmoothed_.reset(sampleRate, 0.02);
+    }
+
+    void reset()
+    {
+        depthSumSmoothed_.setCurrentAndTargetValue(0.0f);
+        mixSmoothed_.setCurrentAndTargetValue(1.0f);
+    }
+
+    // Inject DNA bus pointer (set once on message thread before audio starts).
+    // Pack 1 implementation wires this into the dnaScale parameter — partner
+    // DNA scales per-band release time (brightness/density/aggression axes).
+    void setDNABus(const DNAModulationBus* bus) noexcept { dnaBus_ = bus; }
+
+    // Stereo in, stereo out. Pack 1 will replace this with a 4-band LR4
+    // split, per-band envelope followers, and DNA-aware release-scaled VCAs.
+    // For now applies a single-band gain reduction proportional to the sum
+    // of the 4 depth params, demonstrating parameter wiring.
+    void processBlock(float* L, float* R, int numSamples,
+                      double /*bpm*/ = 0.0, double /*ppqPosition*/ = -1.0)
+    {
+        if (! pLowDepth_ || ! pLoMidDepth_ || ! pHiMidDepth_ || ! pHighDepth_ || ! pMix_)
+            return;
+
+        const float depthSum = pLowDepth_->load(std::memory_order_relaxed)
+                             + pLoMidDepth_->load(std::memory_order_relaxed)
+                             + pHiMidDepth_->load(std::memory_order_relaxed)
+                             + pHighDepth_->load(std::memory_order_relaxed);
+        depthSumSmoothed_.setTargetValue(depthSum * 0.25f); // average across 4 bands
+        mixSmoothed_.setTargetValue(pMix_->load(std::memory_order_relaxed));
+
+        for (int i = 0; i < numSamples; ++i)
+        {
+            const float depth = depthSumSmoothed_.getNextValue();
+            const float mix   = mixSmoothed_.getNextValue();
+            const float gain  = 1.0f - depth * 0.5f; // placeholder ducking
+            const float dryL  = L[i];
+            const float dryR  = R[i];
+            L[i] = dryL * (1.0f - mix) + dryL * gain * mix;
+            R[i] = dryR * (1.0f - mix) + dryR * gain * mix;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // APVTS integration — 13 parameters per Pack 1 spec §4.
+    static void addParameters(juce::AudioProcessorValueTreeState::ParameterLayout& layout,
+                              const juce::String& slotPrefix = "")
+    {
+        const juce::String p = slotPrefix + "olig_";
+
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "lowDepth", 1), "OLIG Low Depth",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "loMidDepth", 1), "OLIG Lo-Mid Depth",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.3f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "hiMidDepth", 1), "OLIG Hi-Mid Depth",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.3f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "highDepth", 1), "OLIG High Depth",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "attack", 1), "OLIG Attack",
+            juce::NormalisableRange<float>(0.1f, 50.0f, 0.0f, 0.5f), 5.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "release", 1), "OLIG Release",
+            juce::NormalisableRange<float>(10.0f, 1000.0f, 0.0f, 0.5f), 200.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "dnaScale", 1), "OLIG DNA Scale",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "lowSplit", 1), "OLIG Low Split",
+            juce::NormalisableRange<float>(40.0f, 200.0f, 0.0f, 0.5f), 100.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "midSplit", 1), "OLIG Mid Split",
+            juce::NormalisableRange<float>(200.0f, 2000.0f, 0.0f, 0.5f), 800.0f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "highSplit", 1), "OLIG High Split",
+            juce::NormalisableRange<float>(2000.0f, 10000.0f, 0.0f, 0.5f), 4000.0f));
+        layout.add(std::make_unique<juce::AudioParameterInt>(
+            juce::ParameterID(p + "keyEngine", 1), "OLIG Key Engine", 0, 3, 0));
+        // D005 floor: 0.001 Hz, drift on crossovers.
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "breathRate", 1), "OLIG Breath Rate",
+            juce::NormalisableRange<float>(0.001f, 2.0f, 0.0f, 0.3f), 0.1f));
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID(p + "mix", 1), "OLIG Mix",
+            juce::NormalisableRange<float>(0.0f, 1.0f), 1.0f));
+    }
+
+    void cacheParameterPointers(juce::AudioProcessorValueTreeState& apvts,
+                                const juce::String& slotPrefix = "")
+    {
+        const juce::String p = slotPrefix + "olig_";
+        pLowDepth_   = apvts.getRawParameterValue(p + "lowDepth");
+        pLoMidDepth_ = apvts.getRawParameterValue(p + "loMidDepth");
+        pHiMidDepth_ = apvts.getRawParameterValue(p + "hiMidDepth");
+        pHighDepth_  = apvts.getRawParameterValue(p + "highDepth");
+        pMix_        = apvts.getRawParameterValue(p + "mix");
+        // Remaining param pointers cached during Pack 1 implementation when
+        // their consuming DSP stages are added.
+    }
+
+private:
+    double sr_ = 0.0;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> depthSumSmoothed_;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> mixSmoothed_;
+
+    std::atomic<float>* pLowDepth_   = nullptr;
+    std::atomic<float>* pLoMidDepth_ = nullptr;
+    std::atomic<float>* pHiMidDepth_ = nullptr;
+    std::atomic<float>* pHighDepth_  = nullptr;
+    std::atomic<float>* pMix_        = nullptr;
+
+    // Set once via setDNABus() on message thread before audio starts;
+    // read on audio thread without synchronisation (single-writer, single-reader,
+    // before-after pattern). Pack 1 implementation will read DNA per block.
+    const DNAModulationBus* dnaBus_ = nullptr;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OligoChain)
+};
+
+} // namespace xoceanus

--- a/Source/DSP/Effects/OtriumChain.h
+++ b/Source/DSP/Effects/OtriumChain.h
@@ -3,11 +3,13 @@
 #pragma once
 
 #include "../../Core/DNAModulationBus.h"
+#include "../../Core/PartnerAudioBus.h"
 #include "../ParameterSmoother.h"
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <array>
 #include <atomic>
+#include <cmath>
 
 namespace xoceanus
 {
@@ -24,11 +26,18 @@ namespace xoceanus
 // Routing: Stereo In → Stereo Out (no expansion stage)
 // Accent: TBD — Pack 1 color table review
 //
-// Phase 0 status: SCAFFOLD ONLY.
-//   - Class structure, parameters, DNA bus consumption hook are complete.
-//   - DSP is a placeholder pass-through with pumpDepth-modulated gain.
-//   - Real triangular ducking via TriangularCoupling routes lands in Pack 1
-//     implementation (per §9 build sequence).
+// DSP: 3 partner engines duck each other in a phase-staggered loop.
+//   1. Triangular Input Router — partnerX_idx params select 3 engine slots;
+//      partner mono audio is read from PartnerAudioBus per block.
+//   2. Phase-Stagger Envelope Followers — one-pole attack/release per partner,
+//      modulated by sine LFO at pumpRate with phaseSkew° offset between followers.
+//   3. Cross-Triangle Mixer — A-env ducks the B-path, B-env ducks the C-path,
+//      C-env ducks the A-path (the "phase-staggered loop" wildcard).
+//   4. VCA Bank — per-path gain = 1 - depth × cross-routed envelope.
+//   5. Output Mixer — averages the 3 paths, blends to dry via otrm_mix.
+//
+// couplingDepth blends autonomous LFO ducking ↔ partner-driven envelope ducking.
+// dnaTilt scales depth by partner aggression DNA (read via DNAModulationBus).
 //
 // See: Docs/specs/2026-04-27-fx-pack-1-sidechain-creative.md §2
 //==============================================================================
@@ -48,33 +57,102 @@ public:
     {
         pumpDepthSmoothed_.setCurrentAndTargetValue(0.5f);
         mixSmoothed_.setCurrentAndTargetValue(1.0f);
+        envA_ = envB_ = envC_ = 0.0f;
+        lfoPhase_ = 0.0f;
     }
 
     // Inject DNA bus pointer (set once on message thread before audio starts).
-    // Not yet read by the placeholder DSP; Pack 1 implementation wires this
-    // into the dnaTilt parameter (see Pack 1 spec §2 wildcard).
+    // Read lock-free per block to apply dnaTilt scaling to ducking depth.
     void setDNABus(const DNAModulationBus* bus) noexcept { dnaBus_ = bus; }
 
-    // Stereo in, stereo out. Pack 1 will overload to accept partner-engine
-    // envelope state via TriangularCoupling routes; for now, applies a static
-    // pumpDepth-modulated gain to demonstrate parameter wiring.
+    // Inject partner audio bus pointer (set once on message thread before
+    // audio starts). Read lock-free per block to pull partner mono mix for
+    // each of the 3 envelope followers.
+    void setPartnerAudioBus(const PartnerAudioBus* bus) noexcept { partnerBus_ = bus; }
+
+    // Real DSP — 3-partner phase-staggered cross-ducking.
     void processBlock(float* L, float* R, int numSamples,
                       double /*bpm*/ = 0.0, double /*ppqPosition*/ = -1.0)
     {
         if (! pPumpDepth_ || ! pMix_) return;
 
+        // ---- Block-rate parameter loads ----
         pumpDepthSmoothed_.setTargetValue(pPumpDepth_->load(std::memory_order_relaxed));
         mixSmoothed_.setTargetValue(pMix_->load(std::memory_order_relaxed));
 
+        const float pumpRate     = pPumpRate_      ? pPumpRate_->load(std::memory_order_relaxed)      : 1.0f;
+        const float atkMs        = pAttack_        ? pAttack_->load(std::memory_order_relaxed)        : 5.0f;
+        const float relMs        = pRelease_       ? pRelease_->load(std::memory_order_relaxed)       : 200.0f;
+        const float phaseSkewDeg = pPhaseSkew_     ? pPhaseSkew_->load(std::memory_order_relaxed)     : 120.0f;
+        const float couplingAmt  = pCouplingDepth_ ? pCouplingDepth_->load(std::memory_order_relaxed) : 0.5f;
+        const float dnaTilt      = pDnaTilt_       ? pDnaTilt_->load(std::memory_order_relaxed)       : 0.0f;
+        const int   idxA         = pPartnerA_      ? clampSlot(pPartnerA_->load(std::memory_order_relaxed)) : 0;
+        const int   idxB         = pPartnerB_      ? clampSlot(pPartnerB_->load(std::memory_order_relaxed)) : 1;
+        const int   idxC         = pPartnerC_      ? clampSlot(pPartnerC_->load(std::memory_order_relaxed)) : 2;
+
+        // ---- Resolve partner audio (nullptr when slot silent / no bus) ----
+        const float* pA = partnerBus_ ? partnerBus_->getMono(idxA) : nullptr;
+        const float* pB = partnerBus_ ? partnerBus_->getMono(idxB) : nullptr;
+        const float* pC = partnerBus_ ? partnerBus_->getMono(idxC) : nullptr;
+
+        // ---- Envelope-follower coefficients (one-pole, exact ms → coef) ----
+        const float atkCoef = (sr_ > 0.0 && atkMs > 0.0f)
+                                  ? std::exp(-1.0f / (atkMs * 0.001f * static_cast<float>(sr_)))
+                                  : 0.0f;
+        const float relCoef = (sr_ > 0.0 && relMs > 0.0f)
+                                  ? std::exp(-1.0f / (relMs * 0.001f * static_cast<float>(sr_)))
+                                  : 0.0f;
+
+        // ---- LFO step (radians per sample, with D005 0.001 Hz floor) ----
+        const float twoPi   = juce::MathConstants<float>::twoPi;
+        const float lfoInc  = (sr_ > 0.0)
+                                  ? twoPi * pumpRate / static_cast<float>(sr_)
+                                  : 0.0f;
+        const float skewRad = juce::degreesToRadians(phaseSkewDeg);
+
+        // ---- DNA tilt: scale depth by partner aggression on slot 0 ----
+        // Partner DNA (per spec) modulates duck spectrum; scaffold uses depth.
+        // Real implementation may route this into a tilt EQ on the duck path.
+        float aggression = 0.5f;
+        if (dnaBus_)
+            aggression = dnaBus_->get(0, DNAModulationBus::Axis::Aggression);
+        const float dnaScale = 1.0f + dnaTilt * (aggression - 0.5f) * 2.0f;
+
         for (int i = 0; i < numSamples; ++i)
         {
-            const float depth = pumpDepthSmoothed_.getNextValue();
+            const float depth = pumpDepthSmoothed_.getNextValue() * dnaScale;
             const float mix   = mixSmoothed_.getNextValue();
-            const float gain  = 1.0f - depth * 0.5f; // placeholder ducking
-            const float dryL  = L[i];
-            const float dryR  = R[i];
-            L[i] = dryL * (1.0f - mix) + dryL * gain * mix;
-            R[i] = dryR * (1.0f - mix) + dryR * gain * mix;
+
+            // Envelope followers (silent when partner slot null)
+            const float aIn = pA ? std::abs(pA[i]) : 0.0f;
+            const float bIn = pB ? std::abs(pB[i]) : 0.0f;
+            const float cIn = pC ? std::abs(pC[i]) : 0.0f;
+            envA_ = (aIn > envA_) ? atkCoef * envA_ + (1.0f - atkCoef) * aIn : relCoef * envA_;
+            envB_ = (bIn > envB_) ? atkCoef * envB_ + (1.0f - atkCoef) * bIn : relCoef * envB_;
+            envC_ = (cIn > envC_) ? atkCoef * envC_ + (1.0f - atkCoef) * cIn : relCoef * envC_;
+
+            // 3 LFO outputs at 0°, +skew, +2*skew (unipolar 0..1)
+            const float lfoA = 0.5f + 0.5f * std::sin(lfoPhase_);
+            const float lfoB = 0.5f + 0.5f * std::sin(lfoPhase_ + skewRad);
+            const float lfoC = 0.5f + 0.5f * std::sin(lfoPhase_ + 2.0f * skewRad);
+            lfoPhase_ += lfoInc;
+            if (lfoPhase_ > twoPi) lfoPhase_ -= twoPi;
+
+            // Cross-rotate: A-path ducked by env C, B by env A, C by env B.
+            // couplingAmt blends autonomous LFO (0) ↔ partner envelope (1).
+            const float duckA = depth * (couplingAmt * envC_ * lfoC + (1.0f - couplingAmt) * lfoC);
+            const float duckB = depth * (couplingAmt * envA_ * lfoA + (1.0f - couplingAmt) * lfoA);
+            const float duckC = depth * (couplingAmt * envB_ * lfoB + (1.0f - couplingAmt) * lfoB);
+
+            const float gainA = std::max(0.0f, 1.0f - duckA);
+            const float gainB = std::max(0.0f, 1.0f - duckB);
+            const float gainC = std::max(0.0f, 1.0f - duckC);
+            const float avgGain = (gainA + gainB + gainC) * (1.0f / 3.0f);
+
+            const float dryL = L[i];
+            const float dryR = R[i];
+            L[i] = dryL * (1.0f - mix) + dryL * avgGain * mix;
+            R[i] = dryR * (1.0f - mix) + dryR * avgGain * mix;
         }
     }
 
@@ -128,25 +206,54 @@ public:
                                 const juce::String& slotPrefix = "")
     {
         const juce::String p = slotPrefix + "otrm_";
-        pPumpDepth_ = apvts.getRawParameterValue(p + "pumpDepth");
-        pMix_       = apvts.getRawParameterValue(p + "mix");
-        // Remaining param pointers cached during Pack 1 implementation when
-        // their consuming DSP stages are added.
+        pPumpDepth_     = apvts.getRawParameterValue(p + "pumpDepth");
+        pPumpRate_      = apvts.getRawParameterValue(p + "pumpRate");
+        pAttack_        = apvts.getRawParameterValue(p + "attack");
+        pRelease_       = apvts.getRawParameterValue(p + "release");
+        pPhaseSkew_     = apvts.getRawParameterValue(p + "phaseSkew");
+        pPartnerA_      = apvts.getRawParameterValue(p + "partnerA_idx");
+        pPartnerB_      = apvts.getRawParameterValue(p + "partnerB_idx");
+        pPartnerC_      = apvts.getRawParameterValue(p + "partnerC_idx");
+        pCouplingDepth_ = apvts.getRawParameterValue(p + "couplingDepth");
+        pDnaTilt_       = apvts.getRawParameterValue(p + "dnaTilt");
+        pMix_           = apvts.getRawParameterValue(p + "mix");
+        // otrm_topology + otrm_syncMode reserved for follow-up DSP work
+        // (Cyclical/Chaotic topology variants + tempo-sync rate division).
     }
 
 private:
+    static int clampSlot(float v) noexcept
+    {
+        const int n = static_cast<int>(v + 0.5f);
+        return n < 0 ? 0 : (n > 3 ? 3 : n);
+    }
+
     double sr_ = 0.0;
 
     juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> pumpDepthSmoothed_;
     juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> mixSmoothed_;
 
-    std::atomic<float>* pPumpDepth_ = nullptr;
-    std::atomic<float>* pMix_       = nullptr;
+    // Envelope-follower state per partner (one-pole, mono).
+    float envA_ = 0.0f, envB_ = 0.0f, envC_ = 0.0f;
+    // Master LFO phase shared across A/B/C; per-partner phase = phase + k*skew.
+    float lfoPhase_ = 0.0f;
 
-    // Set once via setDNABus() on message thread before audio starts;
-    // read on audio thread without synchronisation (single-writer, single-reader,
-    // before-after pattern). Pack 1 implementation will read DNA per block.
-    const DNAModulationBus* dnaBus_ = nullptr;
+    std::atomic<float>* pPumpDepth_     = nullptr;
+    std::atomic<float>* pPumpRate_      = nullptr;
+    std::atomic<float>* pAttack_        = nullptr;
+    std::atomic<float>* pRelease_       = nullptr;
+    std::atomic<float>* pPhaseSkew_     = nullptr;
+    std::atomic<float>* pPartnerA_      = nullptr;
+    std::atomic<float>* pPartnerB_      = nullptr;
+    std::atomic<float>* pPartnerC_      = nullptr;
+    std::atomic<float>* pCouplingDepth_ = nullptr;
+    std::atomic<float>* pDnaTilt_       = nullptr;
+    std::atomic<float>* pMix_           = nullptr;
+
+    // Set once on message thread before audio starts; read lock-free on the
+    // audio thread (single-writer / single-reader before-after pattern).
+    const DNAModulationBus*  dnaBus_     = nullptr;
+    const PartnerAudioBus*   partnerBus_ = nullptr;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OtriumChain)
 };

--- a/Source/UI/Ocean/EpicSlotsPanel.h
+++ b/Source/UI/Ocean/EpicSlotsPanel.h
@@ -52,8 +52,8 @@ public:
 
     //==========================================================================
     // Chain name table — MUST match EpicChainSlotController::ChainID enum ordering.
-    // Index = ChainID integer value (0 = Off … 30 = Orrery).
-    static constexpr std::array<const char*, 31> kChainNames = {
+    // Index = ChainID integer value (0 = Off … 33 = Oligo).
+    static constexpr std::array<const char*, 34> kChainNames = {
         "Off",
         "Aquatic", "Math", "Boutique",                     // Suites
         "Onslaught", "Obscura", "Oratory",                 // Singularity
@@ -62,12 +62,13 @@ public:
         "Outage", "Override", "Occlusion", "Obdurate",     // Wave 2 — Sunken Treasure
         "Orison", "Overshoot", "Obverse", "Oxymoron",      // Wave 2 — Anomalous
         "Ornate", "Oration", "Offcut", "Omen",             // Wave 2 — AHA
-        "Opus", "Outlaw", "Outbreak", "Orrery"             // Wave 2 — Alt Universe
+        "Opus", "Outlaw", "Outbreak", "Orrery",            // Wave 2 — Alt Universe
+        "Otrium", "Oblate", "Oligo"                        // FX Pack 1 — Sidechain Creative
     };
 
     // Group headers inserted into the ComboBox menu before the chain IDs that
     // start each family. { firstChainId, headerText }.
-    static constexpr std::array<std::pair<int, const char*>, 8> kChainGroups = {{
+    static constexpr std::array<std::pair<int, const char*>, 9> kChainGroups = {{
         { 1,  "— SUITES —" },
         { 4,  "— SINGULARITY —" },
         { 7,  "— EPIC —" },
@@ -76,6 +77,7 @@ public:
         { 19, "— WAVE 2: ANOMALOUS —" },
         { 23, "— WAVE 2: AHA —" },
         { 27, "— WAVE 2: ALT UNIVERSE —" },
+        { 31, "— FX PACK 1: SIDECHAIN CREATIVE —" },
     }};
 
     //==========================================================================

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1414,6 +1414,10 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
     // a user selects a chain for a slot.
     epicSlots.prepare(sampleRate, samplesPerBlock);
     epicSlots.cacheParameterPointers(apvts);
+    // Wire the DNA bus into every Pack 1 chain (Otrium / Oblate / Oligo).
+    // Pointer is stable for the lifetime of the processor; chains read it
+    // lock-free on the audio thread.
+    epicSlots.setDNABus(&dnaBus_);
 
     // #1257: Reset MPE channel expression state to match the new sample rate / block size.
     // MPEManager::prepare() calls resetAllChannels() — clears stale per-channel pitch bend

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1418,6 +1418,11 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
     // Pointer is stable for the lifetime of the processor; chains read it
     // lock-free on the audio thread.
     epicSlots.setDNABus(&dnaBus_);
+    // Allocate per-slot mono buffers once; the partner audio bus is published
+    // after each engine renderBlock() in processBlock() and consumed by Pack 1
+    // FX chains (Otrium triangular ducking) later in the same block.
+    partnerAudioBus_.prepare(samplesPerBlock);
+    epicSlots.setPartnerAudioBus(&partnerAudioBus_);
 
     // #1257: Reset MPE channel expression state to match the new sample rate / block size.
     // MPEManager::prepare() calls resetAllChannels() — clears stale per-channel pitch bend
@@ -2159,6 +2164,10 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         }
     }
 
+    // Reset partner audio bus for this block — slots that don't render
+    // (silence-gated or empty) will return nullptr to FX chain consumers.
+    partnerAudioBus_.clearForBlock();
+
     // Render each active engine into its own buffer using slot-specific MIDI
     for (int i = 0; i < MaxSlots; ++i)
     {
@@ -2208,6 +2217,14 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         // Waveform FIFO push — capture raw engine output (pre-coupling, pre-master FX)
         // for the UI oscilloscope.  No allocation; O(n) copy is fine at 512 samples.
         waveformFifos[i].push(engineBuffers[i].getReadPointer(0), static_cast<size_t>(numSamples));
+
+        // Publish mono mix to the partner audio bus for Pack 1 FX chains
+        // (Otrium triangular ducking). Done here so consumers see this slot's
+        // most recent renderBlock() output for the current block.
+        partnerAudioBus_.publish(i,
+                                 engineBuffers[i].getReadPointer(0),
+                                 engineBuffers[i].getReadPointer(1),
+                                 numSamples);
     }
 
     // ── Wave 5 A1: Evaluate global mod routes ────────────────────────────────

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -16,6 +16,7 @@
 #include "Core/CouplingPresetManager.h"
 #include "Core/MacroSystem.h"
 #include "Core/DNAModulationBus.h"
+#include "Core/PartnerAudioBus.h"
 #include "Core/BrothCoordinator.h"
 #include "Core/SharedTransport.h"
 #include "DSP/EngineProfiler.h"
@@ -474,6 +475,10 @@ private:
     // Per-engine DNA bus updated at preset load + each block from M1 CHARACTER macro.
     // Consumed by FX chains via get(slot, axis). See Source/Core/DNAModulationBus.h.
     xoceanus::DNAModulationBus dnaBus_;
+    // Per-engine-slot mono audio bus published after each renderBlock(),
+    // consumed by Pack 1 FX chains (Otrium triangular ducking).
+    // See Source/Core/PartnerAudioBus.h for lifecycle.
+    xoceanus::PartnerAudioBus partnerAudioBus_;
     MegaCouplingMatrix couplingMatrix;
     CouplingCrossfader couplingCrossfader;
 


### PR DESCRIPTION
## Summary

Pack 1 (Sidechain Creative) scaffold + real Otrium DSP. Continues the FX gap-analysis work from spec PR #1337.

**4 commits:**
| SHA | Layer |
|---|---|
| `aadf4581` | Oblate + Oligo scaffolds; `obla_` / `olig_` prefixes locked; `EpicChainSlotController` clamp bug fix (Otrium=31 was unreachable since #1337) |
| `b3b5e514` | `setDNABus` wiring — processor → all 3 Pack 1 chain instances across all 3 slots |
| `c6db2ceb` | Copilot review fixes — UI ComboBox `kChainNames` extended to 34 (was clamping 31–33 silently); Oblate `fftSize=2048` dropped until HQ gating ships |
| `5488f842` | **`PartnerAudioBus` (new)** + real Otrium DSP — 3-partner phase-staggered cross-ducking per spec §2 |

## Architecture decision — Path A (locked this PR)

The `TriangularCoupling` matrix primitive can't carry source identity to its destination, so 3-partner routing via the matrix isn't viable without a matrix change (would contradict spec §5.4). Instead:

- Partner identity stays in Otrium's own `otrm_partnerA/B/C_idx` params (already on the spec)
- A new `PartnerAudioBus` injects per-engine-slot mono audio into the FX layer, mirroring the `DNAModulationBus` injection pattern that already shipped in #1337
- Otrium remains an FX chain (no `OtriumEngine.h` SynthEngine adapter needed)
- Matrix stays untouched

Trade-off: Otrium's "Triangular Input Router" wildcard now means *Otrium pulls partner audio*, not *the matrix pushes partner state*. The audible result matches spec §2's "phase-staggered loop"; the implementation is just simpler.

## Otrium DSP — 5 stages per spec §2

1. **Triangular Input Router** — `partnerX_idx` → `bus.getMono(slot)`
2. **Phase-Stagger Envelope Followers** — one-pole attack/release per partner; sine LFO at `pumpRate` with `phaseSkew°` between A/B/C
3. **Cross-Triangle Mixer** — A-env ducks B-path, B-env ducks C-path, C-env ducks A-path
4. **VCA Bank** — per-path gain = 1 − depth × cross-routed envelope
5. **Output Mixer** — averages 3 paths; `otrm_mix` blends to dry

`couplingDepth` blends autonomous LFO ↔ partner-driven ducking. `dnaTilt` × partner aggression DNA scales depth.

## Doctrine compliance

- **D004** — 11 of 13 `otrm_*` params now drive audio; `topology` + `syncMode` reserved for follow-up DSP work (Cyclical/Chaotic variants + tempo-sync). Both `obla_*` (12) and `olig_*` (13) intentionally stay scaffold-only — params route through `addParameters` but real DSP arrives in their own implementation PRs.
- **D005** — `pumpRate`, `obla_breathRate`, `olig_breathRate` all carry the 0.001 Hz floor.
- **D006** — `dnaTilt` × DNA aggression axis active; aftertouch routable via host MIDI to any `otrm_*` param.

## Test plan

- [ ] macOS build green: `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug && cmake --build build`
- [ ] iOS build green
- [ ] AU validation: `auval -v aumu Xocn XoOx`
- [ ] **`/synth-seance` on Otrium per D2** (gate decision, locked) — should run *after* this PR but *before* presets that depend on it
- [ ] UI ComboBox: verify Otrium / Oblate / Oligo are all selectable and round-trip correctly through `slotN_chain` automation (was broken pre-`c6db2ceb`)
- [ ] Otrium audible behaviour: load 3 distinct engine slots, route through Otrium, sweep `pumpDepth` and verify cross-rotated ducking with phase stagger
- [ ] DNA tilt: verify `dnaTilt` scales depth based on partner aggression DNA
- [ ] Phase 0 tests still green (`Tests/DSPTests/DNAModulationBusTests.cpp`)

## What's deferred

- Real Oblate DSP (STFT/ISTFT) — own PR, ~1-2 days
- Real Oligo DSP (4-band LR4 split) — own PR, ~3-4 hr
- Otrium `topology` + `syncMode` DSP — small follow-up
- Otrium demo presets — `Presets/XOceanus/Coupling/`, ~5 `.xometa` files per spec §8
- `setDNABus` / `setPartnerAudioBus` consumption hooks for Oblate / Oligo — wired through controller already, but the chains' DSP stays placeholder until their implementation PRs

Refs: `Docs/specs/2026-04-27-fx-pack-1-sidechain-creative.md` §2, §5, §8, §10

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code)_