### PR TITLE
chore(wave65): cleanup stale mount TODOs

### DIFF
--- a/Source/UI/Ocean/Wave65SurfaceWiring.h
+++ b/Source/UI/Ocean/Wave65SurfaceWiring.h
@@ -17,30 +17,12 @@
 //      forward them to PlaySurface::setLayoutMode(). The cache array avoids
 //      calling setLayoutMode() on every tick (would spam resized()).
 //
-// Mount instructions for XOceanusEditor.h:
+// Mount sites in XOceanusEditor.h:
 // ─────────────────────────────────────────
-//
-//   A. After Wave 5 A3 modMatrixStrip block inside proc.onEngineChanged
-//      (inside the MessageManager::callAsync lambda, slot 0..3 only):
-//
-//        // TODO Wave6.5 mount — A: auto-switch surface to PADS on percussion engines
-//        if (slot >= 0 && slot < kNumPrimarySlots)
-//        {
-//            if (auto* eng = processor.getEngine(slot))
-//                oceanView_.getPlaySurface().setSurfaceDefault(
-//                    Wave65::isPercussionEngine(eng->getEngineId()));
-//        }
-//
-//   B. After the PlaySurface accent colour block in timerCallback()
-//      (approx. after `playSurface_.setAccentColour(accent);`):
-//
-//        // TODO Wave6.5 mount — B: forward slot[N]_layout_mode changes to PlaySurface
-//        Wave65::pollLayoutModeParams(processor.getAPVTS(),
-//                                     layoutModeCache_,
-//                                     oceanView_.getPlaySurface());
-//
-//   C. Add `std::array<int, 4> layoutModeCache_ { -1, -1, -1, -1 };` to the
-//      private members of XOceanusEditor (near lastLayoutMode_ comment block).
+//   A. isPercussionEngine() — onEngineChanged callAsync lambda, line ~649
+//      (auto-switches PlaySurface to PADS+drum sub-mode on Onset/Offering load)
+//   B. pollLayoutModeParams() — timerCallback(), line ~2220
+//      (forwards slot[N]_layout_mode APVTS changes to PlaySurface::setLayoutMode)
 //
 // Collision handling (item 1 from issue):
 // ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `Wave65SurfaceWiring.h` contained two `// TODO Wave6.5 mount` instruction blocks (mount A and mount B) that were written as future work but have since been implemented in `XOceanusEditor.h`.
- Mount A (`isPercussionEngine`) is called at **XOceanusEditor.h line ~649** inside the `onEngineChanged` `callAsync` lambda, auto-switching the PlaySurface to PADS+drum mode for Onset/Offering engines.
- Mount B (`pollLayoutModeParams`) is called at **XOceanusEditor.h line ~2220** inside `timerCallback()`, forwarding `slot[N]_layout_mode` APVTS changes to `PlaySurface::setLayoutMode()`.

Replaces the stale instruction/code-snippet blocks with two-line "mount sites" references pointing to the actual call sites. All function docstrings, collision-handling notes, and DSP logic are preserved unchanged.

## Test plan

- [ ] Verify `Wave65SurfaceWiring.h` compiles cleanly as part of the normal build (comment-only edit, no functional changes)
- [ ] Confirm mount A fires: load Onset or Offering into any slot → PlaySurface auto-switches to PADS+drum mode
- [ ] Confirm mount B fires: change `slot0_layout_mode` in an APVTS-connected DAW → `setLayoutMode` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)