### PR TITLE
fix(tooltips): TransportBar timesig + MacroSection prefix

### DIFF
--- a/Source/UI/Gallery/MacroSection.h
+++ b/Source/UI/Gallery/MacroSection.h
@@ -41,7 +41,7 @@ public:
             knobs[i].setSliderStyle(juce::Slider::RotaryVerticalDrag);
             knobs[i].setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
             knobs[i].setColour(juce::Slider::rotarySliderFillColourId, GalleryColors::get(GalleryColors::xoGold));
-            knobs[i].setTooltip(juce::String("Macro ") + juce::String(i + 1) + ": " + tooltipDescs[i]);
+            knobs[i].setTooltip(juce::String(tooltipDescs[i]));
             A11y::setup(knobs[i], juce::String("Macro ") + juce::String(i + 1) + " " + tooltipLabels[i]);
             addAndMakeVisible(knobs[i]);
             attach[i] =

--- a/Source/UI/Ocean/TransportBar.h
+++ b/Source/UI/Ocean/TransportBar.h
@@ -143,9 +143,9 @@ public:
             case kRegTap:
                 return "Tap tempo — tap repeatedly to set BPM";
             case kRegTimeSigN:
-                return "Time signature — click to cycle (4/4, 3/4, 6/8, 7/8, 5/4)";
+                return "Time signature numerator — click to cycle beat count (4, 3, 6, 7, 5)";
             case kRegTimeSigD:
-                return "Time signature — click to cycle (4/4, 3/4, 6/8, 7/8, 5/4)";
+                return "Time signature denominator — click to cycle note value (4, 4, 8, 8, 4)";
             case kRegSyncInt:
                 return "Internal clock — XOceanus drives its own tempo";
             case kRegSyncHost:


### PR DESCRIPTION
## Summary
- TransportBar: numerator/denominator now have distinct tooltips reflecting the actual cycle (4,3,6,7,5 / 4,4,8,8,4)
- MacroSection: drop redundant "Macro N: " prefix from knob tooltip — knob label already shows the macro name (TONE, COLOUR, MOTION, AIR), so the prefix was pure noise. A11y `setup()` call left untouched (screen readers still get "Macro 1 TONE")

Wave 11 polish from /tidesigns + /fab-five audits (TransportBar C2, MacroSection F2 — 2026-04-29).

## Test plan
- [ ] Hover the time-sig numerator/denominator and confirm distinct tooltip text
- [ ] Hover any macro knob and confirm tooltip reads "TONE — timbral character (...)" without "Macro 1: " prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)