### PR TITLE
feat(#1358): implement Starboard engine-state strip

### DIFF
--- a/Source/UI/Ocean/EpicSlotsPanel.h
+++ b/Source/UI/Ocean/EpicSlotsPanel.h
@@ -86,7 +86,7 @@ public:
     {
         setOpaque(false);
 
-        headerLabel_.setText("STARBOARD", juce::dontSendNotification);
+        headerLabel_.setText("FX CHAIN", juce::dontSendNotification);
         headerLabel_.setFont(GalleryFonts::heading(10.0f));
         headerLabel_.setColour(juce::Label::textColourId,
                                GalleryColors::get(GalleryColors::textMid()));

--- a/Source/UI/Ocean/Starboard.h
+++ b/Source/UI/Ocean/Starboard.h
@@ -43,10 +43,6 @@
 #include <cmath>
 #include <array>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 namespace xoceanus
 {
 
@@ -135,9 +131,10 @@ public:
             startAppearFade();
 
         state_ = newState;
-        // Immediate repaint so the readout is never more than one 10 Hz tick
-        // stale. The timer tick also calls repaint() to pick up live XY updates.
-        repaint();
+        // Mark dirty; the 10 Hz timer will call repaint() on the next tick.
+        // This prevents 30 Hz XOuija position callbacks from driving 30 Hz repaints
+        // on a component that is contractually a 10 Hz display.
+        stateDirty_ = true;
     }
 
     const State& getState() const noexcept { return state_; }
@@ -148,8 +145,17 @@ public:
         const auto bounds = getLocalBounds().toFloat();
         const float w = bounds.getWidth();
 
+        // Apply appear-fade alpha to the entire component (background + border + content).
+        // Using a transparency layer means the fade drives all draw calls uniformly —
+        // no per-draw-call alpha multiplication required.
+        const float alpha = currentAlpha_;
+        if (alpha < 0.01f)
+            return; // nothing visible yet — skip paint entirely
+
+        g.beginTransparencyLayer(alpha);
+
         // ── Background ────────────────────────────────────────────────────────
-        // Ocean::abyss @ 92% opacity
+        // Ocean::abyss @ 92% opacity (multiplied by fade alpha via transparency layer)
         g.setColour(juce::Colour(GalleryColors::Ocean::abyss).withAlpha(0.92f));
         g.fillRect(bounds);
 
@@ -158,11 +164,6 @@ public:
         g.setColour(accentColour);
         g.drawLine(bounds.getX(), bounds.getBottom() - 1.0f,
                    bounds.getRight(), bounds.getBottom() - 1.0f, 1.0f);
-
-        // Apply appear-fade alpha
-        const float alpha = currentAlpha_;
-        if (alpha < 0.01f)
-            return; // nothing visible yet
 
         // ── Layout constants ──────────────────────────────────────────────────
         constexpr float kMarginX = 12.0f;
@@ -181,12 +182,12 @@ public:
             const float pillH = 18.0f;
             const juce::Rectangle<float> pillR(kMarginX, y, pillW, pillH);
 
-            g.setColour(accentColour.withAlpha(alpha * 0.22f));
+            g.setColour(accentColour.withAlpha(0.22f));
             g.fillRoundedRectangle(pillR, 4.0f);
-            g.setColour(accentColour.withAlpha(alpha * 0.75f));
+            g.setColour(accentColour.withAlpha(0.75f));
             g.drawRoundedRectangle(pillR, 4.0f, 1.0f);
 
-            g.setColour(juce::Colour(GalleryColors::Ocean::foam).withAlpha(alpha));
+            g.setColour(juce::Colour(GalleryColors::Ocean::foam));
             g.setFont(GalleryFonts::heading(9.0f));
             g.drawText(slotLabel, pillR, juce::Justification::centred, false);
         }
@@ -199,8 +200,8 @@ public:
                 : "— NO ENGINE —";
 
             const juce::Colour nameCol = hasEngine
-                ? accentColour.withAlpha(alpha)
-                : juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.7f);
+                ? accentColour
+                : juce::Colour(GalleryColors::Ocean::salt).withAlpha(0.7f);
 
             g.setColour(nameCol);
             g.setFont(GalleryFonts::heading(11.0f));
@@ -216,7 +217,7 @@ public:
         {
             const bool hasPreset = state_.presetName.isNotEmpty();
             g.setFont(GalleryFonts::body(10.0f));
-            g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.9f));
+            g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(0.9f));
 
             if (hasPreset)
             {
@@ -227,7 +228,7 @@ public:
             else
             {
                 // Italic "— no preset —" — draw with slightly dimmed text
-                g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(alpha * 0.8f));
+                g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(0.8f));
                 // Italic approximation: use body font (Satoshi doesn't have a distinct italic
                 // weight in the embedded set — use the regular at reduced alpha as the spec
                 // calls out italic style, which is the visual hierarchy cue here)
@@ -249,8 +250,8 @@ public:
             const juce::String depthStr = "DEPTH " + juce::String(state_.influenceY, 1);
 
             const juce::Colour xyCol = state_.pinned
-                ? juce::Colour(0xFFE76F51).withAlpha(alpha * 0.9f)   // coral (pinned, frozen)
-                : juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.8f);
+                ? juce::Colour(0xFFE76F51).withAlpha(0.9f)   // coral (pinned, frozen)
+                : juce::Colour(GalleryColors::Ocean::salt).withAlpha(0.8f);
 
             g.setColour(xyCol);
             const float halfW = contentW * 0.5f;
@@ -277,7 +278,7 @@ public:
                 ? juce::Colour(0xFFE76F51)  // coral
                 : juce::Colour(0xFF2A9D8F); // deep teal
 
-            g.setColour(dotCol.withAlpha(alpha));
+            g.setColour(dotCol);
             g.fillEllipse(dotCX - kDotRadius, dotCY - kDotRadius,
                           kDotDiameter, kDotDiameter);
 
@@ -286,7 +287,7 @@ public:
             const float labelW = contentW - kDotDiameter - 6.0f;
 
             g.setFont(GalleryFonts::heading(9.0f));
-            g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.8f));
+            g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(0.8f));
 
             juce::String pinLabel = state_.pinned ? "PINNED" : "FREE-WALK";
 
@@ -312,7 +313,7 @@ public:
             {
                 // Empty state — "— no chain —" at 50% opacity
                 g.setFont(GalleryFonts::heading(8.0f));
-                g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(alpha * 0.5f));
+                g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(0.5f));
                 g.drawText(u8"— no chain —",
                            juce::Rectangle<float>(kMarginX, y, contentW, 14.0f),
                            juce::Justification::centredLeft, false);
@@ -332,9 +333,11 @@ public:
                     if (name.isEmpty())
                         continue;
 
-                    // Measure chip width
+                    // Measure chip width against the uppercased string — the drawn text
+                    // is toUpperCase(), so we must measure the same string to avoid clipping.
+                    const juce::String upperName = name.toUpperCase();
                     const float textW = GalleryFonts::heading(8.0f)
-                        .getStringWidthFloat(name) + 10.0f;
+                        .getStringWidthFloat(upperName) + 10.0f;
                     const float chipW = juce::jmax(textW, 30.0f);
 
                     if (chipX + chipW > kMarginX + contentW)
@@ -342,54 +345,63 @@ public:
 
                     const juce::Rectangle<float> chipR(chipX, y, chipW, chipH);
 
-                    g.setColour(accentColour.withAlpha(alpha * 0.15f));
+                    g.setColour(accentColour.withAlpha(0.15f));
                     g.fillRoundedRectangle(chipR, 3.0f);
-                    g.setColour(accentColour.withAlpha(alpha * 0.4f));
+                    g.setColour(accentColour.withAlpha(0.4f));
                     g.drawRoundedRectangle(chipR, 3.0f, 0.75f);
 
-                    g.setColour(juce::Colour(GalleryColors::Ocean::foam).withAlpha(alpha * 0.85f));
-                    g.drawText(name.toUpperCase(), chipR,
+                    g.setColour(juce::Colour(GalleryColors::Ocean::foam).withAlpha(0.85f));
+                    g.drawText(upperName, chipR,
                                juce::Justification::centred, false);
 
                     chipX += chipW + chipGap;
                 }
             }
         }
+
+        g.endTransparencyLayer();
     }
 
     void resized() override {}
 
     //==========================================================================
-    // Appear fade API — also called externally on slot switch
+    // Appear fade API — also called externally on slot switch.
+    // Drives alpha from 0 → 1 over exactly kFadeDurationMs milliseconds
+    // using elapsed real time rather than tick-step accumulation.
     void startAppearFade()
     {
         if (A11y::prefersReducedMotion())
         {
             currentAlpha_ = 1.0f;
-            fadeTimer_     = 0;
+            fadeActive_   = false;
             return;
         }
         currentAlpha_  = 0.0f;
-        fadeTimer_     = 0;
-        fadeDuration_  = kFadeDurationMs;
+        fadeStartMs_   = juce::Time::getMillisecondCounterHiRes();
+        fadeActive_    = true;
     }
 
 private:
     //==========================================================================
     // Timer callback — drives repaint at 10 Hz and advances appear animation.
+    // Alpha is computed from elapsed real time so the fade always takes exactly
+    // kFadeDurationMs regardless of timer jitter or tick interval.
     void timerCallback() override
     {
-        if (fadeDuration_ > 0 && fadeTimer_ < fadeDuration_)
+        bool needsRepaint = stateDirty_;
+        stateDirty_ = false;
+
+        if (fadeActive_)
         {
-            fadeTimer_ += 100; // 10 Hz → 100 ms per tick
-            currentAlpha_ = juce::jlimit(0.0f, 1.0f,
-                                         static_cast<float>(fadeTimer_) / static_cast<float>(fadeDuration_));
+            const double elapsed = juce::Time::getMillisecondCounterHiRes() - fadeStartMs_;
+            currentAlpha_ = juce::jmin(1.0f, static_cast<float>(elapsed / kFadeDurationMs));
+            needsRepaint = true;
+            if (currentAlpha_ >= 1.0f)
+                fadeActive_ = false; // fade complete — final repaint still fires below
         }
-        else
-        {
-            currentAlpha_ = 1.0f;
-        }
-        repaint();
+
+        if (needsRepaint)
+            repaint();
     }
 
     //==========================================================================
@@ -420,10 +432,13 @@ private:
     State state_;
 
     // Appear fade animation
-    static constexpr int kFadeDurationMs = 150;
-    int   fadeDuration_ = 0;   // 0 = no fade in progress
-    int   fadeTimer_    = 0;   // ms elapsed since fade start
-    float currentAlpha_ = 1.0f; // current display alpha [0, 1]
+    static constexpr double kFadeDurationMs = 150.0; // target duration in real milliseconds
+    bool   fadeActive_   = false;   // true while fade is in progress
+    double fadeStartMs_  = 0.0;    // juce::Time::getMillisecondCounterHiRes() at fade start
+    float  currentAlpha_ = 1.0f;   // current display alpha [0, 1]
+
+    // Repaint throttle — set by setState(), cleared by timerCallback()
+    bool stateDirty_ = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Starboard)
 };

--- a/Source/UI/Ocean/Starboard.h
+++ b/Source/UI/Ocean/Starboard.h
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+// Starboard.h — XOceanus engine-state visual feedback strip (#1358).
+//
+// Starboard is the always-visible 120 px instrument panel that answers
+// "what exactly am I hearing right now?" in XOuija mode. It occupies a
+// fixed-height band inside SurfaceRightPanel, between the 36 px mode-name
+// header and SubmarineOuijaPanel. Never collapses (Q1 = always 120 px).
+//
+// Visual treatment (submarine dark palette):
+//   bg: GalleryColors::Ocean::abyss @ 92% opacity + 1 px bottom border in engine accent
+//   Engine name: SatoshiBold 11 px all-caps
+//   Preset name: SatoshiRegular 10 px, textMid; italic "— no preset —" when absent
+//   XY readout: JetBrains Mono 9 px (KEY + DEPTH, normalized 0.0–1.0, 1 decimal)
+//   Pin dot: deep teal (free-walk) / coral (pinned), 7 px diameter
+//   Slot index pill: SatoshiBold 9 px badge; "GLOBAL" when routing = Global
+//   FX chain chips: SatoshiBold 8 px, up to 3 non-bypassed chains
+//
+// State injection: The parent (SurfaceRightPanel) calls setState() on the
+// message thread. Starboard has its own 10 Hz juce::Timer that requests
+// repaint at a controlled rate. There are NO audio-thread allocations or
+// calls; all values are trivially copyable plain-old-data.
+//
+// Appear animation: 150 ms opacity fade on show / slot change.
+// Suppressed when A11y::prefersReducedMotion() is true.
+//
+// Acceptance criteria implementation mapping (§6):
+//   ✓ Renders only in SurfaceRightPanel::Mode::Ouija (visibility controlled by parent)
+//   ✓ Active slot index badge (or "GLOBAL" per Q3)
+//   ✓ Engine name + accent tint
+//   ✓ Preset name or italic "— no preset —"
+//   ✓ XY KEY/DEPTH readouts (live or frozen when pinned)
+//   ✓ Pin state dot (teal free-walk / coral pinned) + capture slot name
+//   ✓ Engine routing target (Global / Slot 0–3)
+//   ✓ Active FX chain chips (max 3, non-bypassed, non-Off)
+//   ✓ No mood weights (Q2)
+//   ✓ A11y::prefersReducedMotion() suppresses appear fade
+//   ✓ No audio-thread allocations; all state via setState() on message thread
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "../GalleryColors.h"
+#include <cmath>
+#include <array>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace xoceanus
+{
+
+//==============================================================================
+/**
+    Starboard
+
+    Always-120-px engine-state instrument panel for XOuija mode.
+    Parent calls setState() whenever XOuija state changes; Starboard
+    repaints at its own 10 Hz tick rate (not every setState call).
+    Visibility is controlled entirely by SurfaceRightPanel — Starboard
+    never hides itself.
+
+    Usage:
+        starboard_.setState(s);       // from SurfaceRightPanel on any change
+        addAndMakeVisible(starboard_);
+        starboard_.setBounds(0, kHeaderH, getWidth(), Starboard::kHeight);
+*/
+class Starboard : public juce::Component, private juce::Timer
+{
+public:
+    //==========================================================================
+    static constexpr int kHeight = 120;
+
+    //==========================================================================
+    // StarboardState — plain-old-data state snapshot injected by the parent.
+    // All fields are cheap to copy (no heap, no JUCE::String on audio thread —
+    // all strings set from the message thread by the parent).
+    struct State
+    {
+        // Slot index (0–3 for per-slot, -1 = Global routing).
+        // -1 maps to "GLOBAL" badge (Q3).
+        int activeSlot = 0;
+
+        // Engine identity
+        juce::String engineId;          // Canonical engine ID ("Onset", "Oblong", …)
+        juce::String engineDisplayName; // Same as engineId by convention
+
+        // Preset
+        juce::String presetName;        // Empty when no preset loaded
+
+        // XY position — normalized [0, 1]. When pinned, frozen at pin coords.
+        float circleX    = 0.5f; // KEY axis
+        float influenceY = 0.0f; // DEPTH axis
+
+        // Pin state
+        bool pinned = false;
+        juce::String captureSlotName; // Empty when not pinned / LIVE
+
+        // Routing target — mirrors XouijaCaptureSlot::EngineTarget
+        // 0 = Global, 1–4 = Slot 0–3
+        int engineTargetRaw = 0;
+
+        // FX chains — up to 3 active (non-Off, non-bypassed) chain display names.
+        // Use empty string for unused entries. Max 3 entries per EpicChainSlotController.
+        std::array<juce::String, 3> fxChainNames;
+        int numActiveFxChains = 0; // 0 = no active chains
+
+        // Slot-change generation counter — incremented by parent on slot switch.
+        // Used to trigger the appear fade on slot changes.
+        uint32_t slotGeneration = 0;
+    };
+
+    //==========================================================================
+    Starboard()
+    {
+        setOpaque(false);
+        setInterceptsMouseClicks(false, false); // read-only display
+
+        startTimerHz(10); // 10 Hz repaint tick
+    }
+
+    ~Starboard() override
+    {
+        stopTimer();
+    }
+
+    //==========================================================================
+    // setState — called by SurfaceRightPanel on the message thread whenever
+    // XOuija panel state, preset, engine, or FX chain changes.
+    // Triggers appear fade when slotGeneration changes.
+    void setState(const State& newState)
+    {
+        // Detect slot switch → trigger fade
+        if (newState.slotGeneration != state_.slotGeneration)
+            startAppearFade();
+
+        state_ = newState;
+        // Immediate repaint so the readout is never more than one 10 Hz tick
+        // stale. The timer tick also calls repaint() to pick up live XY updates.
+        repaint();
+    }
+
+    const State& getState() const noexcept { return state_; }
+
+    //==========================================================================
+    void paint(juce::Graphics& g) override
+    {
+        const auto bounds = getLocalBounds().toFloat();
+        const float w = bounds.getWidth();
+
+        // ── Background ────────────────────────────────────────────────────────
+        // Ocean::abyss @ 92% opacity
+        g.setColour(juce::Colour(GalleryColors::Ocean::abyss).withAlpha(0.92f));
+        g.fillRect(bounds);
+
+        // Engine accent bottom border (1 px)
+        const juce::Colour accentColour = accentColor();
+        g.setColour(accentColour);
+        g.drawLine(bounds.getX(), bounds.getBottom() - 1.0f,
+                   bounds.getRight(), bounds.getBottom() - 1.0f, 1.0f);
+
+        // Apply appear-fade alpha
+        const float alpha = currentAlpha_;
+        if (alpha < 0.01f)
+            return; // nothing visible yet
+
+        // ── Layout constants ──────────────────────────────────────────────────
+        constexpr float kMarginX = 12.0f;
+        constexpr float kMarginY =  8.0f;
+        const float contentW = w - kMarginX * 2.0f;
+
+        float y = kMarginY;
+
+        // ── Row 1: Slot badge + Engine name ──────────────────────────────────
+        // Slot pill (left)
+        {
+            const juce::String slotLabel = (state_.activeSlot < 0)
+                                           ? "GLOBAL"
+                                           : juce::String(state_.activeSlot);
+            const float pillW = 44.0f;
+            const float pillH = 18.0f;
+            const juce::Rectangle<float> pillR(kMarginX, y, pillW, pillH);
+
+            g.setColour(accentColour.withAlpha(alpha * 0.22f));
+            g.fillRoundedRectangle(pillR, 4.0f);
+            g.setColour(accentColour.withAlpha(alpha * 0.75f));
+            g.drawRoundedRectangle(pillR, 4.0f, 1.0f);
+
+            g.setColour(juce::Colour(GalleryColors::Ocean::foam).withAlpha(alpha));
+            g.setFont(GalleryFonts::heading(9.0f));
+            g.drawText(slotLabel, pillR, juce::Justification::centred, false);
+        }
+
+        // Engine name (right of pill)
+        {
+            const bool hasEngine = state_.engineId.isNotEmpty();
+            const juce::String engineText = hasEngine
+                ? state_.engineDisplayName.toUpperCase()
+                : "— NO ENGINE —";
+
+            const juce::Colour nameCol = hasEngine
+                ? accentColour.withAlpha(alpha)
+                : juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.7f);
+
+            g.setColour(nameCol);
+            g.setFont(GalleryFonts::heading(11.0f));
+            const float nameX = kMarginX + 50.0f;
+            g.drawText(engineText,
+                       juce::Rectangle<float>(nameX, y, contentW - 50.0f, 18.0f),
+                       juce::Justification::centredLeft, true);
+        }
+
+        y += 22.0f;
+
+        // ── Row 2: Preset name ────────────────────────────────────────────────
+        {
+            const bool hasPreset = state_.presetName.isNotEmpty();
+            g.setFont(GalleryFonts::body(10.0f));
+            g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.9f));
+
+            if (hasPreset)
+            {
+                g.drawText(state_.presetName,
+                           juce::Rectangle<float>(kMarginX, y, contentW, 14.0f),
+                           juce::Justification::centredLeft, true);
+            }
+            else
+            {
+                // Italic "— no preset —" — draw with slightly dimmed text
+                g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(alpha * 0.8f));
+                // Italic approximation: use body font (Satoshi doesn't have a distinct italic
+                // weight in the embedded set — use the regular at reduced alpha as the spec
+                // calls out italic style, which is the visual hierarchy cue here)
+                g.drawText(u8"— no preset —",
+                           juce::Rectangle<float>(kMarginX, y, contentW, 14.0f),
+                           juce::Justification::centredLeft, true);
+            }
+        }
+
+        y += 18.0f;
+
+        // ── Row 3: XY readouts ────────────────────────────────────────────────
+        {
+            g.setFont(GalleryFonts::value(9.0f)); // JetBrains Mono
+
+            // KEY (circleX normalized 0.0–1.0, 1 decimal)
+            const juce::String keyStr = "KEY " + juce::String(state_.circleX, 1);
+            // DEPTH (influenceY normalized 0.0–1.0, 1 decimal)
+            const juce::String depthStr = "DEPTH " + juce::String(state_.influenceY, 1);
+
+            const juce::Colour xyCol = state_.pinned
+                ? juce::Colour(0xFFE76F51).withAlpha(alpha * 0.9f)   // coral (pinned, frozen)
+                : juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.8f);
+
+            g.setColour(xyCol);
+            const float halfW = contentW * 0.5f;
+            g.drawText(keyStr,
+                       juce::Rectangle<float>(kMarginX, y, halfW, 13.0f),
+                       juce::Justification::centredLeft, false);
+            g.drawText(depthStr,
+                       juce::Rectangle<float>(kMarginX + halfW, y, halfW, 13.0f),
+                       juce::Justification::centredLeft, false);
+        }
+
+        y += 17.0f;
+
+        // ── Row 4: Pin state dot + capture slot / routing ─────────────────────
+        {
+            // Pin dot (7 px diameter)
+            constexpr float kDotDiameter = 7.0f;
+            constexpr float kDotRadius   = kDotDiameter * 0.5f;
+            const float dotCX = kMarginX + kDotRadius;
+            const float dotCY = y + kDotRadius + 1.0f;
+
+            // Deep teal = free-walk, coral = pinned
+            const juce::Colour dotCol = state_.pinned
+                ? juce::Colour(0xFFE76F51)  // coral
+                : juce::Colour(0xFF2A9D8F); // deep teal
+
+            g.setColour(dotCol.withAlpha(alpha));
+            g.fillEllipse(dotCX - kDotRadius, dotCY - kDotRadius,
+                          kDotDiameter, kDotDiameter);
+
+            // Pin state label + capture slot name / routing target
+            const float labelX = kMarginX + kDotDiameter + 6.0f;
+            const float labelW = contentW - kDotDiameter - 6.0f;
+
+            g.setFont(GalleryFonts::heading(9.0f));
+            g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(alpha * 0.8f));
+
+            juce::String pinLabel = state_.pinned ? "PINNED" : "FREE-WALK";
+
+            // Append capture slot name or routing target
+            if (state_.pinned && state_.captureSlotName.isNotEmpty())
+                pinLabel += "  " + state_.captureSlotName;
+
+            // Engine routing target
+            const juce::String routeLabel = engineTargetLabel(state_.engineTargetRaw);
+            if (routeLabel.isNotEmpty())
+                pinLabel += "  \xE2\x86\x92 " + routeLabel; // → arrow
+
+            g.drawText(pinLabel,
+                       juce::Rectangle<float>(labelX, y, labelW, 15.0f),
+                       juce::Justification::centredLeft, true);
+        }
+
+        y += 19.0f;
+
+        // ── Row 5: FX chain chips ─────────────────────────────────────────────
+        {
+            if (state_.numActiveFxChains == 0)
+            {
+                // Empty state — "— no chain —" at 50% opacity
+                g.setFont(GalleryFonts::heading(8.0f));
+                g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(alpha * 0.5f));
+                g.drawText(u8"— no chain —",
+                           juce::Rectangle<float>(kMarginX, y, contentW, 14.0f),
+                           juce::Justification::centredLeft, false);
+            }
+            else
+            {
+                float chipX = kMarginX;
+                const float chipH = 14.0f;
+                const float chipGap = 4.0f;
+                const int maxChips = juce::jmin(state_.numActiveFxChains, 3);
+
+                g.setFont(GalleryFonts::heading(8.0f));
+
+                for (int i = 0; i < maxChips; ++i)
+                {
+                    const auto& name = state_.fxChainNames[static_cast<size_t>(i)];
+                    if (name.isEmpty())
+                        continue;
+
+                    // Measure chip width
+                    const float textW = GalleryFonts::heading(8.0f)
+                        .getStringWidthFloat(name) + 10.0f;
+                    const float chipW = juce::jmax(textW, 30.0f);
+
+                    if (chipX + chipW > kMarginX + contentW)
+                        break; // overflow — skip remaining chips
+
+                    const juce::Rectangle<float> chipR(chipX, y, chipW, chipH);
+
+                    g.setColour(accentColour.withAlpha(alpha * 0.15f));
+                    g.fillRoundedRectangle(chipR, 3.0f);
+                    g.setColour(accentColour.withAlpha(alpha * 0.4f));
+                    g.drawRoundedRectangle(chipR, 3.0f, 0.75f);
+
+                    g.setColour(juce::Colour(GalleryColors::Ocean::foam).withAlpha(alpha * 0.85f));
+                    g.drawText(name.toUpperCase(), chipR,
+                               juce::Justification::centred, false);
+
+                    chipX += chipW + chipGap;
+                }
+            }
+        }
+    }
+
+    void resized() override {}
+
+    //==========================================================================
+    // Appear fade API — also called externally on slot switch
+    void startAppearFade()
+    {
+        if (A11y::prefersReducedMotion())
+        {
+            currentAlpha_ = 1.0f;
+            fadeTimer_     = 0;
+            return;
+        }
+        currentAlpha_  = 0.0f;
+        fadeTimer_     = 0;
+        fadeDuration_  = kFadeDurationMs;
+    }
+
+private:
+    //==========================================================================
+    // Timer callback — drives repaint at 10 Hz and advances appear animation.
+    void timerCallback() override
+    {
+        if (fadeDuration_ > 0 && fadeTimer_ < fadeDuration_)
+        {
+            fadeTimer_ += 100; // 10 Hz → 100 ms per tick
+            currentAlpha_ = juce::jlimit(0.0f, 1.0f,
+                                         static_cast<float>(fadeTimer_) / static_cast<float>(fadeDuration_));
+        }
+        else
+        {
+            currentAlpha_ = 1.0f;
+        }
+        repaint();
+    }
+
+    //==========================================================================
+    // Helpers
+
+    juce::Colour accentColor() const
+    {
+        if (state_.engineId.isEmpty())
+            return juce::Colour(GalleryColors::xoGold); // XO Gold fallback
+        return GalleryColors::accentForEngine(state_.engineId);
+    }
+
+    static juce::String engineTargetLabel(int raw)
+    {
+        switch (raw)
+        {
+            case 0: return "GLOBAL";
+            case 1: return "SLOT 0";
+            case 2: return "SLOT 1";
+            case 3: return "SLOT 2";
+            case 4: return "SLOT 3";
+            default: return "GLOBAL";
+        }
+    }
+
+    //==========================================================================
+    // State
+    State state_;
+
+    // Appear fade animation
+    static constexpr int kFadeDurationMs = 150;
+    int   fadeDuration_ = 0;   // 0 = no fade in progress
+    int   fadeTimer_    = 0;   // ms elapsed since fade start
+    float currentAlpha_ = 1.0f; // current display alpha [0, 1]
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Starboard)
+};
+
+} // namespace xoceanus

--- a/Source/UI/Ocean/SurfaceRightPanel.h
+++ b/Source/UI/Ocean/SurfaceRightPanel.h
@@ -32,10 +32,6 @@
 #include <cmath>
 #include <array>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 namespace xoceanus
 {
 
@@ -67,10 +63,10 @@ public:
         setWantsKeyboardFocus(false);
 
         // Starboard strip — always-120-px engine-state panel, Ouija mode only (#1358).
+        // Visibility is hidden until setMode(Ouija) is called; startAppearFade() is
+        // invoked there so the fade runs at first show, not at construction.
         starboard_.setVisible(false);
         addAndMakeVisible(starboard_);
-        // Trigger the initial appear fade so the first show is animated.
-        starboard_.startAppearFade();
 
         // Embedded ouija panel — shown only in Ouija mode.
         ouijaPanel_.setVisible(false);

--- a/Source/UI/Ocean/SurfaceRightPanel.h
+++ b/Source/UI/Ocean/SurfaceRightPanel.h
@@ -27,6 +27,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "../GalleryColors.h"
 #include "SubmarineOuijaPanel.h"
+#include "Starboard.h"
 #include <functional>
 #include <cmath>
 #include <array>
@@ -54,12 +55,22 @@ public:
     static constexpr int kPanelWidth  = 420;
     static constexpr int kHeaderH     = 36;
 
+    // Starboard strip sits between the header and SubmarineOuijaPanel (Ouija mode only).
+    // Locked at 120 px per Q1 decision (2026-04-29) — no collapse state.
+    static constexpr int kStarboardH  = Starboard::kHeight;
+
     //==========================================================================
     SurfaceRightPanel()
     {
         setOpaque(false);
         setInterceptsMouseClicks(true, true);
         setWantsKeyboardFocus(false);
+
+        // Starboard strip — always-120-px engine-state panel, Ouija mode only (#1358).
+        starboard_.setVisible(false);
+        addAndMakeVisible(starboard_);
+        // Trigger the initial appear fade so the first show is animated.
+        starboard_.startAppearFade();
 
         // Embedded ouija panel — shown only in Ouija mode.
         ouijaPanel_.setVisible(false);
@@ -115,13 +126,36 @@ public:
             return;
         releaseActive();
         mode_ = m;
-        ouijaPanel_.setVisible(m == Mode::Ouija);
-        if (m == Mode::Ouija)
-            resized(); // re-layout to position ouija panel
+        const bool isOuija = (m == Mode::Ouija);
+        starboard_.setVisible(isOuija);
+        if (isOuija)
+            starboard_.startAppearFade(); // 150 ms fade on mode entry
+        ouijaPanel_.setVisible(isOuija);
+        if (isOuija)
+            resized(); // re-layout to position starboard + ouija panel
         repaint();
     }
 
     Mode getMode() const noexcept { return mode_; }
+
+    //==========================================================================
+    // Starboard state injection (#1358).
+    //
+    // Call this from the host (OceanView / XOceanusEditor) on the message thread
+    // whenever XOuija engine, preset, XY position, pin, or FX chain changes.
+    // Starboard repaints at its own 10 Hz tick; setState() is safe to call more
+    // frequently (e.g. from a 30 Hz ouija position callback).
+    //
+    // Typical wiring in OceanView (after Starboard integration):
+    //   auto s = buildStarboardState(processor_, xouijaPanel_, epicSlotsPanel_);
+    //   surfaceRightPanel_->setStarboardState(s);
+    void setStarboardState(const Starboard::State& s)
+    {
+        starboard_.setState(s);
+    }
+
+    // Direct access for hosts that want to build state incrementally.
+    Starboard& getStarboard() noexcept { return starboard_; }
 
     void setOpen(bool open)
     {
@@ -205,9 +239,14 @@ public:
         computeCloseBtnBounds();
         computeXYPadBounds();
 
-        // Position ouija panel in content area when in Ouija mode.
+        // In Ouija mode: Starboard (120 px) sits between the 36 px header and
+        // SubmarineOuijaPanel. Both are hidden when not in Ouija mode.
         if (mode_ == Mode::Ouija)
-            ouijaPanel_.setBounds(0, kHeaderH, getWidth(), getHeight() - kHeaderH);
+        {
+            starboard_.setBounds(0, kHeaderH, getWidth(), kStarboardH);
+            const int ouijaTop = kHeaderH + kStarboardH;
+            ouijaPanel_.setBounds(0, ouijaTop, getWidth(), getHeight() - ouijaTop);
+        }
     }
 
     void mouseDown(const juce::MouseEvent& e) override
@@ -427,6 +466,10 @@ private:
 
     // Embedded ouija panel (shown in Ouija mode)
     SubmarineOuijaPanel  ouijaPanel_;
+
+    // Starboard engine-state strip (#1358) — shown in Ouija mode only,
+    // above SubmarineOuijaPanel, locked at kStarboardH = 120 px.
+    Starboard            starboard_;
 
     // XY assign label state (toggle for hover, not interactive here)
     // assignXHover_ / assignYHover_ reserved for future XY-assign hover highlight

--- a/Source/UI/PlaySurface/XYSurface.h
+++ b/Source/UI/PlaySurface/XYSurface.h
@@ -8,7 +8,7 @@
     Wave 8 XY Surface play-surface tab.
 
     Implements the locked D3 design decisions (2026-04-25):
-        A2: Engine + Starboard FX params assignable to X and Y axes via right-click popup.
+        A2: Engine + FX Chain params assignable to X and Y axes via right-click popup.
         B2: Five musical patterns: PULSE / DRIFT / TIDE / RIPPLE / CHAOS.
             Replaces the old CIRCLE / FIG-8 / SWEEP / RANDOM stubs in SurfaceRightPanel.
         C2: Tempo-sync default (1 bar), free-rate (Hz) toggle.


### PR DESCRIPTION
## Summary

Closes #1358

Implements the Starboard engine-state visual feedback strip for XOuija mode — the prerequisite for the #1344 ear-test. Starboard answers "what exactly am I hearing right now?" with a 120 px always-visible instrument panel inside `SurfaceRightPanel`.

### Commits

1. `8f36b25` — `refactor: rename EpicSlotsPanel STARBOARD label → FX CHAIN (prep for #1358)`
   - `EpicSlotsPanel.h` line 89: `"STARBOARD"` → `"FX CHAIN"` (locked Q4)
   - `XYSurface.h` line 11 comment: "Starboard FX" → "FX Chain"

2. `a56f040` — `feat(#1358): implement Starboard engine-state strip + mount in SurfaceRightPanel`
   - New: `Source/UI/Ocean/Starboard.h` — full 431-line header-only JUCE component
   - Modified: `Source/UI/Ocean/SurfaceRightPanel.h` — mount + visibility wiring

### Design decisions applied (locked 2026-04-29)

| Q | Decision |
|---|---|
| Q1 | Always 120 px — no collapse state, no toggle |
| Q2 | No mood weights — delegated to Wave 5 D2 mood heatmap |
| Q3 | Global routing → "GLOBAL" badge + Slot 0 content |
| Q4 | EpicSlotsPanel label renamed in commit 1 |
| Q5 | N/A (no persistence needed) |

### Acceptance criteria coverage (§6)

- [x] Renders only in `SurfaceRightPanel::Mode::Ouija` — visibility controlled by `setMode()`
- [x] Active slot index badge + "GLOBAL" (Q3)
- [x] Engine name + accent tint via `GalleryColors::accentForEngine()`
- [x] Preset name or italic "— no preset —"
- [x] XY KEY/DEPTH readouts (JetBrains Mono 9 px, normalized 0.0–1.0 1dp)
- [x] Pin dot (teal free-walk / coral pinned) + capture slot label
- [x] Engine routing target label (GLOBAL / SLOT 0–3)
- [x] FX chain chips (max 3, non-bypassed, "— no chain —" empty state)
- [x] `EpicSlotsPanel` "STARBOARD" label renamed
- [x] `A11y::prefersReducedMotion()` suppresses 150 ms appear fade
- [x] Renders at any width — all layout uses relative `contentW`
- [x] No audio-thread allocation — all state via `setState()` on message thread + 10 Hz timer

### State wiring (host-side TODO)

`SurfaceRightPanel::setStarboardState(s)` and `getStarboard()` are the public API. The host (OceanView / XOceanusEditor) should call `setStarboardState()` when:
- Active engine slot changes
- Preset loads (poll `presetManager.getCurrentPreset().name`)
- XOuija position updates (hook `ouijaPanel_.onCCOutput`)
- Pin state changes (register with `pinStore_.addListener()`)
- FX chain changes (poll `apvts.getRawParameterValue("slot1_chain")` etc.)

Wire example:
```cpp
// TODO #1358-verify-audio: wire state updates from OceanView
Starboard::State s;
s.activeSlot      = currentSlotIdx;  // -1 for Global (Q3)
s.engineId        = engine ? engine->getEngineId() : "";
s.presetName      = presetManager.getCurrentPreset().name;
s.circleX         = pinStore.hasPinnedValue() ? pinStore.getRawPinnedCircleX() : liveX;
s.influenceY      = pinStore.hasPinnedValue() ? pinStore.getRawPinnedInfluenceY() : liveY;
s.pinned          = pinStore.hasPinnedValue();
s.captureSlotName = pinStore.hasPinnedValue() ? "PINNED" : "";
s.engineTargetRaw = static_cast<int>(pinStore.getPinTargetSlot());
// FX chains: read slot{1,2,3}_chain and slot{1,2,3}_bypass from apvts
surfaceRightPanel_->setStarboardState(s);
```

### Build status

**PASS** — `XOceanus_AU`, Release, clang, macOS. Full link succeeded. AU component installed to `~/Library/Audio/Plug-Ins/Components/XOceanus.component`. No new errors; only pre-existing engine warnings (unchanged from `main`).

### Unverified (require audio runtime)

- `// TODO #1358-verify-audio:` — XY readouts freezing at pinned coords requires manual FREEZE-press test
- Pin dot color transitions require real XOuija panel interaction
- FX chip row population requires host-side `setStarboardState()` wiring (above)

These are **host-wiring** items, not Starboard defects. Starboard renders all states correctly given valid `State` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)