### PR TITLE
fix(hud): wire 6 HUD bar callbacks (SAVE/A-B/FAV/PREV/NEXT/EXPORT)

### DIFF
--- a/Source/UI/Gallery/ABCompare.h
+++ b/Source/UI/Gallery/ABCompare.h
@@ -72,6 +72,30 @@ public:
 
     bool isActive() const noexcept { return abActive; }
 
+    /** fix(#1354): Enter or exit A/B compare mode from an external caller
+        (e.g. the HUD bar A/B button in OceanView).
+        - enterMode=true  : captures current state into A and arms A/B mode.
+        - enterMode=false : deactivates A/B mode and clears both slots.
+        No-op if already in the requested state.  Must be called on the message thread. */
+    void setABActive(bool enterMode)
+    {
+        if (enterMode == abActive)
+            return;
+
+        if (enterMode)
+        {
+            // Enter A/B mode — same as clicking A when not yet active.
+            handleButtonAction(/*clickedA=*/true, /*clickedB=*/false);
+        }
+        else
+        {
+            // Exit A/B mode — same as clicking the currently-showing slot to deactivate.
+            handleButtonAction(/*clickedA=*/showingA, /*clickedB=*/!showingA);
+        }
+
+        repaint();
+    }
+
     //==========================================================================
     void paint(juce::Graphics& g) override
     {

--- a/Source/UI/Gallery/SidebarPanel.h
+++ b/Source/UI/Gallery/SidebarPanel.h
@@ -199,6 +199,11 @@ public:
             presetBrowser->refresh();
     }
 
+    /** fix(#1354): Returns the lazily-constructed PresetBrowser, or nullptr if
+        setPresetManager() has not yet been called.  Used by the editor to call
+        PresetBrowser::toggleFavorite() when the HUD ♥ button is clicked. */
+    PresetBrowser* getPresetBrowser() noexcept { return presetBrowser.get(); }
+
     // #923: Forward scanning state into the sidebar's full PresetBrowser.
     // Call setPresetBrowserScanning(true) before the async library scan starts
     // and setPresetBrowserScanning(false) in the completion callback.  If the

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -619,6 +619,51 @@ public:
         // and clears any in-progress chain drawing on the substrate.
         hudBar_.onChainToggled = [this]() { applyChainModeVisuals(); };
 
+        // fix(#1354): forward the 6 previously-unwired HUD bar callbacks outward
+        // so the editor can route them to PresetManager / ABCompare / ExportDialog.
+        hudBar_.onSave = [this]()
+        {
+            if (onSavePreset)
+                onSavePreset();
+        };
+
+        hudBar_.onFavChanged = [this](bool newFavState)
+        {
+            if (onFavToggled)
+                onFavToggled(newFavState);
+        };
+
+        hudBar_.onABCompareChanged = [this](bool active)
+        {
+            if (onABCompareToggled)
+                onABCompareToggled(active);
+        };
+
+        hudBar_.onPresetPrev = [this]()
+        {
+            if (onPresetPrev)
+                onPresetPrev();
+        };
+
+        hudBar_.onPresetNext = [this]()
+        {
+            if (onPresetNext)
+                onPresetNext();
+        };
+
+        hudBar_.onExportClicked = [this]()
+        {
+            if (onExportClicked)
+                onExportClicked();
+        };
+
+        // Preset name label click → open preset browser (sidebar Preset tab).
+        hudBar_.onPresetNameClicked = [this]()
+        {
+            if (onPresetNameClicked)
+                onPresetNameClicked();
+        };
+
         // ── Keyboard focus ────────────────────────────────────────────────────
         setWantsKeyboardFocus(true);
 
@@ -1489,6 +1534,40 @@ public:
     // were never assigned.  Forward outward so state changes are observable.
     std::function<void()> onChordBarVisibilityChanged;
     std::function<void(ChordBarComponent::InputMode)> onChordBarInputModeChanged;
+
+    // fix(#1354): HUD bar preset/save/export callbacks — forwarded outward so the
+    // editor can route to PresetManager / ABCompare / ExportDialog.
+
+    /** Fired when the user clicks SAVE in the HUD bar.
+        Editor should prompt for a name (or overwrite current preset) and write the
+        .xometa file via PresetManager::savePresetToFile(). */
+    std::function<void()> onSavePreset;
+
+    /** Fired when the user clicks ♥ in the HUD bar.
+        @param newFavState   true = preset is now a favourite; false = removed.
+        Editor should call PresetBrowser::toggleFavorite() on the current preset. */
+    std::function<void(bool newFavState)> onFavToggled;
+
+    /** Fired when the user clicks A/B in the HUD bar.
+        @param active   true = A/B mode is now on; false = off.
+        Editor should drive the ABCompare component (enter/exit compare mode). */
+    std::function<void(bool active)> onABCompareToggled;
+
+    /** Fired when the user clicks ◀ in the HUD bar.
+        Editor should call PresetManager::previousPreset() then applyPreset(). */
+    std::function<void()> onPresetPrev;
+
+    /** Fired when the user clicks ▶ in the HUD bar.
+        Editor should call PresetManager::nextPreset() then applyPreset(). */
+    std::function<void()> onPresetNext;
+
+    /** Fired when the user clicks EXPORT in the HUD bar.
+        Editor should open the ExportDialog via juce::CallOutBox. */
+    std::function<void()> onExportClicked;
+
+    /** Fired when the user clicks the preset name label in the HUD bar.
+        Editor should open the preset browser (e.g. sidebar Preset tab). */
+    std::function<void()> onPresetNameClicked;
 
     //==========================================================================
     // State queries

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -925,6 +925,147 @@ public:
             }
         };
 
+        // fix(#1354): Wire the 6 previously-unwired HUD bar callbacks.
+        //
+        // onPresetPrev / onPresetNext — same pattern as the legacy header prev/next buttons.
+        oceanView_.onPresetPrev = [this]()
+        {
+            auto& pm = processor.getPresetManager();
+            pm.previousPreset();
+            try
+            {
+                const auto& preset = pm.getCurrentPreset();
+                processor.getUndoManager().beginNewTransaction("Load preset: " + preset.name);
+                processor.applyPreset(preset);
+            }
+            catch (const std::exception& e)
+            {
+                ToastOverlay::show("Failed to load preset: " + juce::String(e.what()),
+                                   Toast::Level::Warn);
+                processor.killDelayTails();
+            }
+        };
+
+        oceanView_.onPresetNext = [this]()
+        {
+            auto& pm = processor.getPresetManager();
+            pm.nextPreset();
+            try
+            {
+                const auto& preset = pm.getCurrentPreset();
+                processor.getUndoManager().beginNewTransaction("Load preset: " + preset.name);
+                processor.applyPreset(preset);
+            }
+            catch (const std::exception& e)
+            {
+                ToastOverlay::show("Failed to load preset: " + juce::String(e.what()),
+                                   Toast::Level::Warn);
+                processor.killDelayTails();
+            }
+        };
+
+        // onSavePreset — prompt for a name via juce::AlertWindow, then write the
+        // .xometa file via PresetManager::savePresetToFile().
+        // TODO(#1354): A richer "Save As" dialog (overwrite-check, mood selector)
+        // is a follow-up task.  For now, a modal input box is sufficient.
+        oceanView_.onSavePreset = [this]()
+        {
+            auto& pm = processor.getPresetManager();
+            const juce::String currentName = pm.getCurrentPreset().name;
+            const juce::String suggestion  = currentName.isEmpty() ? "My Preset" : currentName;
+
+            // takeOwnership=true: JUCE manages lifetime — do NOT delete dialog inside callback.
+            auto* dialog = new juce::AlertWindow(
+                "Save Preset",
+                "Enter a name for this preset:",
+                juce::MessageBoxIconType::NoIcon,
+                this);
+            dialog->addTextEditor("name", suggestion, "Preset name:");
+            dialog->addButton("Save",   1);
+            dialog->addButton("Cancel", 0);
+
+            dialog->enterModalState(
+                true,
+                juce::ModalCallbackFunction::create(
+                    [safeThis = juce::Component::SafePointer<XOceanusEditor>(this), dialog](int result)
+                    {
+                        if (result != 1 || safeThis == nullptr)
+                            return;
+
+                        const juce::String newName = dialog->getTextEditorContents("name").trim();
+                        if (newName.isEmpty())
+                            return;
+
+                        auto& pm2  = safeThis->processor.getPresetManager();
+                        auto  data = pm2.getCurrentPreset();
+                        data.name  = newName;
+
+                        const auto presetDir =
+                            juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+                                .getChildFile("Application Support/XO_OX/XOceanus/Presets");
+                        presetDir.createDirectory();
+                        const auto file = presetDir.getChildFile(data.name + ".xometa");
+
+                        if (pm2.savePresetToFile(file, data))
+                        {
+                            pm2.setCurrentPreset(data);
+                            ToastOverlay::show("Preset saved: " + data.name, Toast::Level::Info);
+                            // Rescan so the new preset appears in the browser immediately.
+                            if (auto* sb = safeThis->oceanView_.getSidebar())
+                                sb->refreshPresetBrowser();
+                        }
+                        else
+                        {
+                            ToastOverlay::show(
+                                "Failed to save preset — check disk space or permissions.",
+                                Toast::Level::Warn);
+                        }
+                    }),
+                true /* deleteWhenDismissed */);
+        };
+
+        // onFavToggled — toggle favourite status on the current preset and persist.
+        // Routes to PresetBrowser::toggleFavorite() which handles settings-file I/O.
+        oceanView_.onFavToggled = [this](bool /*newFavState*/)
+        {
+            auto& pm = processor.getPresetManager();
+            const auto& current = pm.getCurrentPreset();
+            if (current.name.isEmpty())
+                return;
+
+            // Reach the PresetBrowser via the OceanView sidebar (always present).
+            if (auto* sb = oceanView_.getSidebar())
+                if (auto* pb = sb->getPresetBrowser())
+                    pb->toggleFavorite(current);
+        };
+
+        // onABCompareToggled — delegate to the (hidden) ABCompare Gallery component.
+        // When active=true: enter A/B mode (captures A snapshot).
+        // When active=false: deactivate (clears A/B slots, no state restore).
+        oceanView_.onABCompareToggled = [this](bool active)
+        {
+            abCompare.setABActive(active);
+        };
+
+        // onExportClicked — open the ExportDialog in a CallOutBox anchored to the
+        // HUD bar (same as the legacy exportBtn in the Gallery header).
+        oceanView_.onExportClicked = [this]()
+        {
+            juce::CallOutBox::launchAsynchronously(
+                std::make_unique<ExportDialog>(processor.getPresetManager(),
+                                               &processor.getAPVTS(),
+                                               &processor.getCouplingMatrix()),
+                oceanView_.getScreenBounds(), getTopLevelComponent());
+        };
+
+        // onPresetNameClicked — clicking the preset name label opens the Preset tab
+        // in the OceanView sidebar so the user can browse and select a preset.
+        oceanView_.onPresetNameClicked = [this]()
+        {
+            if (auto* sb = oceanView_.getSidebar())
+                sb->selectTab(SidebarPanel::Preset);
+        };
+
         // Wire MIDI + PlaySurface inside OceanView
         {
             auto& ps = oceanView_.getPlaySurface();


### PR DESCRIPTION
## Summary
**Re-open of #1368** with clean cherry-pick onto fresh main. The previous branch accumulated commits from parallel agents (genomes, Settings, TimeSig) and CI-failed on a private/public visibility issue introduced by an out-of-scope inherited commit.

This PR has only the HUD work: 4 files, 249 insertions, no inherited cruft.

## What was fixed
`SubmarineHudBar` defines six callback fields that were never assigned in `OceanView::initHudBar()`. Result: clicking SAVE, A/B compare, ♥ FAV, ◀/▶ PREV/NEXT, and EXPORT all silently did nothing.

## Files changed
- `Source/UI/Gallery/ABCompare.h` — new `setABActive(bool)` public API (calls existing private `handleButtonAction`)
- `Source/UI/Gallery/SidebarPanel.h` — new `getPresetBrowser()` accessor
- `Source/UI/Ocean/OceanView.h` — 7 new `std::function` callbacks + HUD wiring
- `Source/UI/XOceanusEditor.h` — wires all 7 callbacks in `initOceanView()`

## Wiring map
| Callback | Wired to |
|---|---|
| PREV | `pm.previousPreset()` + `applyPreset()` + undo + toast |
| NEXT | `pm.nextPreset()` + `applyPreset()` + undo + toast |
| SAVE | `AlertWindow` input → `pm.savePresetToFile()` + toast + refresh |
| FAV | `PresetBrowser::toggleFavorite(currentPreset)` via sidebar |
| A/B | `abCompare.setABActive(bool)` |
| EXPORT | `CallOutBox(ExportDialog)` anchored to oceanView bounds |
| NAME-CLICK | sidebar tab switch to Preset |

## Test plan
- [ ] SAVE: name a preset, confirm it persists to disk
- [ ] PREV/NEXT: cycle through bank, confirm preset loads + undo entry
- [ ] FAV: toggle ♥, confirm star icon updates + persists
- [ ] A/B: toggle, swap, compare
- [ ] EXPORT: dialog opens, exports MPC file

🤖 Generated with [Claude Code](https://claude.com/claude-code)