### PR TITLE
fix(lore): correct OFFERING citation + OWARE drift timescale

### DIFF
--- a/Source/UI/AboutModal.h
+++ b/Source/UI/AboutModal.h
@@ -518,7 +518,7 @@ private:
             drawLine(bodyFont, Colour(200, 204, 216).withAlpha(0.55f),
                      "The Mantis Shrimp strikes. Eight drum slots, eight distinct synthesis", 12.0f);
             drawLine(bodyFont, Colour(200, 204, 216).withAlpha(0.55f),
-                     "topologies: TR-808 metallic networks, Karplus-Strong comb, Chaigne", 12.0f);
+                     "topologies: TR-808 metallic networks, Karplus-Strong comb, acoustic", 12.0f);
             drawLine(bodyFont, Colour(200, 204, 216).withAlpha(0.55f),
                      "contact physics, city-specific compressor chains. Detroit always runs late.", 12.0f);
             y += 4.0f;
@@ -529,9 +529,9 @@ private:
             drawLine(bodyFont, Colour(200, 204, 216).withAlpha(0.55f),
                      "Modal ratio tables from Rossing (2000). Material alpha decay exponents", 12.0f);
             drawLine(bodyFont, Colour(200, 204, 216).withAlpha(0.55f),
-                     "from beam dispersion theory. Per-voice tuning drift on a 100-second time", 12.0f);
+                     "from beam dispersion theory. Per-voice thermal drift approaches a new", 12.0f);
             drawLine(bodyFont, Colour(200, 204, 216).withAlpha(0.55f),
-                     "constant. Each bar of the instrument has its own stable character.", 12.0f);
+                     "tuning target every ~4 seconds. Each bar has its own stable character.", 12.0f);
             y += 4.0f;
 
             // OGIVE


### PR DESCRIPTION
## Summary

- **OFFERING excerpt:** Removed misattributed "Chaigne" citation. Chaigne's beam-dispersion / contact physics work is cited in OWARE's seance, not OFFERING's. Replaced with "acoustic contact physics" — accurate and citation-neutral.
- **OWARE excerpt:** Removed unsupported "100-second time constant" figure. Seance documents record a thermal drift approach coefficient corrected to 0.0001 (targeting ~4-second convergence); OWARE's LFO1 floor is 0.005 Hz (200-second period). Neither supports "100 seconds." Replaced with "Per-voice thermal drift approaches a new tuning target every ~4 seconds."

## Source

Both corrections are grounded in the OWARE seance document (thermal drift target interval analysis, approach coefficient 0.0001 → ~4-second settling) and the OFFERING seance (no Chaigne reference present).

## Test plan

- [ ] Build and open the About modal → Lore tab
- [ ] Confirm OFFERING body reads "…Karplus-Strong comb, acoustic contact physics…"
- [ ] Confirm OWARE body reads "…Per-voice thermal drift approaches a new tuning target every ~4 seconds…"
- [ ] No other Lore tab content changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)