### PR TITLE
feat(#1378): per-slot PresetData model + APVTS persistence

### DIFF
--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -3256,6 +3256,15 @@ void XOceanusProcessor::getStateInformation(juce::MemoryBlock& destData)
         // always true in subsequent saves and is never reset by the user.
         xml->setAttribute("hasLaunchedBefore", 1);
 
+        // #1378 — Persist per-slot preset names so Starboard and EngineOrbit pill
+        // can display the active preset name after DAW session recall.
+        // Only the preset name (not the full PresetData) is stored — preset parameter
+        // values are already captured by the APVTS state above.
+        // Keys: slot0_presetName … slot3_presetName  (frozen identifiers).
+        for (int i = 0; i < kNumPrimarySlots; ++i)
+            xml->setAttribute("slot" + juce::String(i) + "_presetName",
+                               slotPresets_[static_cast<size_t>(i)].name);
+
         copyXmlToBinary(*xml, destData);
     }
 }
@@ -3461,6 +3470,17 @@ void XOceanusProcessor::setStateInformation(const void* data, int sizeInBytes)
         // Clamp to valid range (0=Gallery, 1=Performance, 2=Coupling).
         if (persistedRegisterCurrent < 0 || persistedRegisterCurrent > 2)
             persistedRegisterCurrent = 0;
+
+        // #1378 — Restore per-slot preset names.
+        // Only the name field is round-tripped; all other PresetData fields remain
+        // at their default-constructed state (empty) until the next preset load.
+        // Sessions saved before #1378 will have empty strings → silent no-op.
+        for (int i = 0; i < kNumPrimarySlots; ++i)
+        {
+            juce::String name = xml->getStringAttribute("slot" + juce::String(i) + "_presetName");
+            if (name.isNotEmpty())
+                slotPresets_[static_cast<size_t>(i)].name = name;
+        }
     }
 }
 
@@ -3889,6 +3909,19 @@ void XOceanusProcessor::applyPreset(const PresetData& preset)
         for (int slot = 0; slot < xoceanus::DNAModulationBus::MaxEngineSlots; ++slot)
             dnaBus_.setBaseDNA(slot, dnaArr);
     }
+}
+
+// ── #1378: Per-slot preset data model ────────────────────────────────────────
+void XOceanusProcessor::setSlotPreset(int slotIdx, const PresetData& preset)
+{
+    jassert(slotIdx >= 0 && slotIdx < kNumPrimarySlots);
+    const int safe = juce::jlimit(0, kNumPrimarySlots - 1, slotIdx);
+    slotPresets_[static_cast<size_t>(safe)] = preset;
+
+    // Notify all registered listeners (message-thread only — no locking needed).
+    for (auto* l : slotPresetListeners_)
+        if (l != nullptr)
+            l->slotPresetChanged(safe, slotPresets_[static_cast<size_t>(safe)]);
 }
 
 } // namespace xoceanus

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -26,9 +26,11 @@
 // Wave 5 A1: Global drag-drop mod routing model (message-thread side).
 // The header lives in Future/ but we reference it in-place per spec.
 #include "Future/UI/ModRouting/DragDropModRouter.h"
+#include <algorithm>
 #include <atomic>
 #include <array>
 #include <memory>
+#include <vector>
 
 namespace xoceanus
 {
@@ -190,6 +192,44 @@ public:
     // Preset management (UI thread only)
     PresetManager& getPresetManager() { return presetManager; }
     void applyPreset(const PresetData& preset);
+
+    // ── Per-slot preset data model (#1378) ───────────────────────────────────
+    // Stores which preset is currently loaded in each primary slot (0–3).
+    // Written on the message thread only; read by UI components (Starboard,
+    // EngineOrbit pill) via getSlotPreset() and notified via SlotPresetListener.
+    //
+    // Listener interface — register via addSlotPresetListener / removeSlotPresetListener.
+    // Called on the message thread whenever setSlotPreset() is invoked.
+    struct SlotPresetListener
+    {
+        virtual ~SlotPresetListener() = default;
+        virtual void slotPresetChanged(int slotIdx, const PresetData& preset) = 0;
+    };
+
+    // Bounds-checked accessor: jassert in debug, clamp to slot 0 in release.
+    // Returns a const reference — valid for the lifetime of the processor.
+    const PresetData& getSlotPreset(int slotIdx) const noexcept
+    {
+        jassert(slotIdx >= 0 && slotIdx < kNumPrimarySlots);
+        const int safe = juce::jlimit(0, kNumPrimarySlots - 1, slotIdx);
+        return slotPresets_[static_cast<size_t>(safe)];
+    }
+
+    // Stores the preset for the given slot and notifies all registered listeners.
+    // Message thread only.
+    void setSlotPreset(int slotIdx, const PresetData& preset);
+
+    void addSlotPresetListener(SlotPresetListener* l)
+    {
+        if (l != nullptr)
+            slotPresetListeners_.push_back(l);
+    }
+    void removeSlotPresetListener(SlotPresetListener* l)
+    {
+        slotPresetListeners_.erase(
+            std::remove(slotPresetListeners_.begin(), slotPresetListeners_.end(), l),
+            slotPresetListeners_.end());
+    }
 
     // Engine slot management (message thread only)
     // Slot 4 (0-indexed) is the Ghost Slot — see EngineRegistry::detectCollection().
@@ -936,12 +976,19 @@ private:
     bool persistedRegisterLocked = false; // D4: register lock toggle
     int  persistedRegisterCurrent = 0;   // D4: current register index (0=Gallery, 1=Performance, 2=Coupling)
 
-    // ── #1179: TideWaterline deferred step-sequence state ────────────────────
+    // ── #1178: TideWaterline deferred step-sequence state ────────────────────
     // Holds the "TideWaterlineSteps" tree from setStateInformation() when the
     // editor was not yet open at restore time.  OceanView picks it up in
     // initWaterline() via getPersistedTideWaterlineState().
     // Message-thread only — no atomic needed.
     juce::ValueTree persistedTideWaterlineState_;
+
+    // ── #1378: Per-slot preset data model ────────────────────────────────────
+    // Tracks which preset is loaded in each primary slot (0–3).
+    // Initialised to default-constructed PresetData (empty name, no engines).
+    // Written/read on the message thread only — no atomic needed.
+    std::array<PresetData, kNumPrimarySlots> slotPresets_;
+    std::vector<SlotPresetListener*> slotPresetListeners_;
 
     // ── External MIDI Clock state — audio thread only (closes #359) ──────────
     // Used to derive BPM from incoming 0xF8 pulses.


### PR DESCRIPTION
## Summary

- Adds `std::array<PresetData, 4> slotPresets_` to `XOceanusProcessor` as the single source of truth for which preset is loaded in each primary slot (0–3).
- Exposes `getSlotPreset(int) const` (bounds-checked, returns const ref) and `setSlotPreset(int, const PresetData&)` (notifies listeners).
- Adds `SlotPresetListener` interface (`slotPresetChanged(int, const PresetData&)`) with `addSlotPresetListener` / `removeSlotPresetListener`.
- Slot preset names round-trip through DAW state via XML attributes `slot0_presetName` … `slot3_presetName`, following the established `slotXEngine` / `slotMuted` side-tree pattern in `getStateInformation` / `setStateInformation`.

## Before / After API surface

**Before:** No per-slot preset tracking existed; UI had no processor-level source of truth for which preset is in a given slot.

**After:**
```cpp
// Accessor (const, bounds-checked, jassert in debug / clamp in release)
const PresetData& getSlotPreset(int slotIdx) const noexcept;

// Mutator (message thread only; notifies SlotPresetListener chain)
void setSlotPreset(int slotIdx, const PresetData& preset);

// Listener (register once from Starboard / EngineOrbit pill)
struct SlotPresetListener {
    virtual void slotPresetChanged(int slotIdx, const PresetData& preset) = 0;
};
void addSlotPresetListener(SlotPresetListener*);
void removeSlotPresetListener(SlotPresetListener*);
```

## Persistence approach

Used the **XML attribute side-tree pattern** — the same approach as `slotXEngine`, `slotMuted`, `playScaleIndex`, and `editorSelectedSlot`. Attributes are appended to the XML element in `getStateInformation()` and read back in `setStateInformation()`. Only the preset `name` field is stored (parameter values are already captured by the APVTS tree). Sessions predating #1378 have no `slotN_presetName` attributes → name fields remain empty on restore, which is the correct silent-no-op default.

No new float audio parameters were registered. The `PresetData` type is already fully defined in `Source/Core/PresetManager.h` (transitively included via the existing `#include "Core/PresetManager.h"` in `XOceanusProcessor.h`).

## PresetManager.h changes

None. The existing `PresetData` struct at line 337 is used as-is.

## APVTS round-trip path

1. `setSlotPreset(slot, preset)` — stores full `PresetData` in `slotPresets_[slot]`.
2. `getStateInformation()` — serialises `slotPresets_[i].name` as `slot{i}_presetName` XML attribute.
3. `setStateInformation()` — reads `slot{i}_presetName` and restores only the `name` field; remaining `PresetData` fields repopulate on next preset load.

## Acceptance checklist

- [x] `slotPresets_` member added with `std::array<PresetData, 4>` typing.
- [x] `getSlotPreset(int) const` accessor returns const ref, bounds-checked (`jassert` + `jlimit` clamp).
- [x] `setSlotPreset(int, const PresetData&)` mutator notifies `slotPresetListeners_`.
- [x] APVTS state save/load round-trips slot preset names (XML attribute side-tree, `slot0_presetName`…`slot3_presetName`).
- [x] `cmake --build build --target XOceanus_AU` succeeds (0 errors, pre-existing warnings only).
- [x] `auval -v aumu Xocn XoOx` → **AU VALIDATION SUCCEEDED**.
- [x] No new compiler warnings in touched files.

Closes #1378