### PR TITLE
fix(ci): extend lcov capture to ignore inconsistent JUCE metadata errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,7 +72,7 @@ jobs:
           # Capture coverage data
           lcov --capture --directory build \
             --output-file build/coverage.info \
-            --ignore-errors mismatch
+            --ignore-errors mismatch,inconsistent
 
           # Remove external code (JUCE, Catch2, system headers)
           lcov --remove build/coverage.info \


### PR DESCRIPTION
## Summary

- `lcov --capture` fails on `juce_PushNotifications.h` destructor line-range metadata, producing an `inconsistent` error that terminates the Test Coverage workflow even though all tests pass cleanly.
- PR #1361 fixed the same class of error on the `lcov --summary` call; this PR applies the same treatment to the `lcov --capture` call one step earlier in the pipeline.
- One-character change: `--ignore-errors mismatch` → `--ignore-errors mismatch,inconsistent`

## Root cause

lcov 2.4 processes JUCE's `juce_PushNotifications.h` which has a destructor where the end-line number (58) is less than the start-line number (63) in DWARF metadata. This is a JUCE-internal artefact; it cannot be filtered via `--remove` because it fails before filtering even starts.

## Test plan

- [ ] Test Coverage workflow passes on main after merge (watch run at https://github.com/BertCalm/XO_OX-XOmnibus/actions)
- [ ] No other CI workflows affected (change is coverage.yml only)

**Unblocks:** v0.1.0 release tag — all actual tests pass, only report generation was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)