### PR TITLE
feat: T5 Velocity mod source — eval-loop infrastructure (Path B Phase 2.1)

### DIFF
--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -2357,6 +2357,17 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                         srcVal = slotSequencers_[static_cast<size_t>(slot)].getLiveGate();
                     }
                 }
+                else if (snap.sourceId == static_cast<int>(ModSourceId::Velocity))
+                {
+                    // T5: Velocity routes use engine-side multiplication (Strategy 2).
+                    // routeModAccum_[ri] stores depth ONLY — not depth * srcVal.
+                    // Engines multiply by voice.velocity at the consumption site to satisfy
+                    // D001 (per-voice latch, not global scalar).  See velocityScaled tag.
+                    if (snap.depth == 0.0f)
+                        continue;
+                    routeModAccum_[static_cast<size_t>(ri)] = snap.depth;
+                    continue; // skip the generic srcVal * depth path below
+                }
                 else
                     continue; // TODO(#mod-source-completion): add remaining sources
 
@@ -3099,6 +3110,10 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
         // orryCutoffParam_ may be nullptr if Orrery is not loaded; guard accordingly.
         snap.isOrryCutoff = (orryCutoffParam_ != nullptr && snap.destParam == orryCutoffParam_);
 
+        // T5: Mark routes whose source is Velocity so engines can apply per-voice
+        // multiplication (D001).  routeModAccum_[ri] will hold depth, not depth*srcVal.
+        snap.velocityScaled = (r.sourceId == static_cast<int>(ModSourceId::Velocity));
+
         ++count;
     }
     // Zero out trailing slots so stale entries are not evaluated.
@@ -3108,6 +3123,7 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
         routesSnapshot_[static_cast<size_t>(i)].destParam       = nullptr;
         routesSnapshot_[static_cast<size_t>(i)].destParamRangeSpan = 0.0f;
         routesSnapshot_[static_cast<size_t>(i)].isOrryCutoff    = false;
+        routesSnapshot_[static_cast<size_t>(i)].velocityScaled  = false;
     }
 
     routesSnapshotCount_.store(count, std::memory_order_relaxed);

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -1043,6 +1043,13 @@ private:
         // This flag is set in flushModRoutesSnapshot by pointer identity (compare resolved
         // destParam against the cached orryCutoffParam_ pointer).
         bool isOrryCutoff{false};
+
+        // T5: True iff this route's source is ModSourceId::Velocity (id 3).
+        // When set, routeModAccum_[ri] holds the raw depth (not depth*srcVal).
+        // The consuming engine multiplies by voice.velocity at render time to satisfy
+        // D001 (per-voice latch).  This tag makes the contract split typesafe — engines
+        // can assert or branch on velocityScaled rather than re-inspecting sourceId.
+        bool velocityScaled{false};
     };
     static constexpr int kMaxGlobalRoutes = ModRoutingModel::MaxRoutes;
     std::array<GlobalModRouteSnapshot, kMaxGlobalRoutes> routesSnapshot_{};


### PR DESCRIPTION
## Summary

- Adds `bool velocityScaled{false}` to `GlobalModRouteSnapshot` — typesafe contract tag that makes it explicit when `routeModAccum_[ri]` holds **depth-only** (not `depth * srcVal`)
- In `flushModRoutesSnapshot()` (message thread): sets `snap.velocityScaled = (r.sourceId == static_cast<int>(ModSourceId::Velocity))` + clears to false in the trailing-slot zeroing loop
- In the eval loop's source dispatch (audio thread): replaces the `else continue;` no-op for `ModSourceId::Velocity` (id 3) with an explicit branch that writes `routeModAccum_[ri] = snap.depth` and continues — bypassing the generic `srcVal * depth` multiply

## Files Changed

| File | +Lines | -Lines |
|------|--------|--------|
| `Source/XOceanusProcessor.h` | +7 | 0 |
| `Source/XOceanusProcessor.cpp` | +16 | 0 |
| **Total** | **+23** | **0** |

## DSP Safety Audit

Audited by `/dsp-safety` skill. All PASS:

- **No allocation**: `velocityScaled` is a POD bool in a pre-allocated `std::array<GlobalModRouteSnapshot, 32>`. Zero heap impact.
- **No blocking I/O / locks / logging**: Plain bool assignment (message thread) and plain float store (audio thread). No new atomics. No mutex.
- **No new atomics**: `routeModAccum_` remains a `std::array<float, 32>` (audio-thread-only plain floats). `velocityScaled` is a plain bool in the POD struct.
- **Fence protocol correct**: `velocityScaled` write in `flushModRoutesSnapshot()` happens before the existing `std::memory_order_release` fence at line 3134. Audio thread's acquire fence at line 2276 ensures visibility before snapshot read. Ordering contract identical to existing `isOrryCutoff` flag.
- **Snapshot POD copy**: Adding a bool to the struct is a trivial size increase (byte-aligned to existing padding). Per-block copy remains a simple struct assignment.

## Architecture

**Strategy 2: engine-side multiplication** (Architect mandate, 2026-04-29 RAC)

The eval loop writes `routeModAccum_[ri] = snap.depth` for Velocity routes. Engines (opt-in via T6 PRs for Onset + Opal) will multiply by `voice.velocity` in their per-voice render loops. This satisfies **D001 (per-voice latch)** without a global scalar.

The `velocityScaled` tag lets engines verify the contract at a glance — they check `snap.velocityScaled` rather than re-inspecting `sourceId`.

## Test Plan

- [x] Build green: `cmake --build /tmp/xoceanus-t5-velocity/build --target XOceanus_AU` — 0 errors, 58 pre-existing warnings (all pre-approved)
- [x] auval green: `auval -v aumu Xocn XoOx` — `AU VALIDATION SUCCEEDED`
- [ ] CI green (auto)
- [ ] T6 Onset opt-in PR depends on this landing
- [ ] T6 Opal opt-in PR depends on this landing

## References

- Architect mandate: 2026-04-29 RAC session (Path B Phase 2, Strategy 2)
- D001 Doctrine: Velocity Must Shape Timbre (per-voice, not global scalar)
- Design study: Strategy 2 (engine-side multiplication) selected over Strategy 1 (eval-loop global scalar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)