### PR TITLE
fix(ux): SubmarineHudBar tooltips for 11 controls (F-007)

### DIFF
--- a/Source/UI/Ocean/SubmarineHudBar.h
+++ b/Source/UI/Ocean/SubmarineHudBar.h
@@ -63,7 +63,8 @@ namespace xoceanus
     Floating frosted-glass navigation bar pinned to the top of the Ocean View.
     See file header for full documentation.
 */
-class SubmarineHudBar : public juce::Component
+class SubmarineHudBar : public juce::Component,
+                        public juce::SettableTooltipClient
 {
 public:
     //==========================================================================
@@ -143,6 +144,51 @@ public:
             reactLevel_ = clamped;
             repaint();
         }
+    }
+
+    //==========================================================================
+    // SettableTooltipClient override — hit-test position against control regions
+    // and return a context-appropriate tooltip string.
+
+    juce::String getTooltip() override
+    {
+        // regions_ is populated by buildLayout() which is called on every paint()
+        // and resized(). If the component has been sized but not yet painted, call
+        // buildLayout() ourselves so tooltip queries before first paint still work.
+        if (regions_.empty() && getWidth() > 0)
+            buildLayout();
+
+        // Use the mouse position in local coordinates to find the hovered region.
+        const auto mousePos = getMouseXYRelative();
+        const float mx = static_cast<float>(mousePos.x);
+        const float my = static_cast<float>(mousePos.y);
+
+        for (const auto& reg : regions_)
+        {
+            if (reg.bounds.expanded(2.0f).contains(mx, my))
+            {
+                switch (reg.id)
+                {
+                    case kRegEngines:    return "Browse and add engines (E)";
+                    case kRegUndo:       return "Undo last change (\xe2\x8c\x98Z)";
+                    case kRegRedo:       return "Redo (\xe2\x8c\x98\xe2\x87\xa7Z)";
+                    case kRegPresetPrev: return "Previous preset";
+                    case kRegPresetName: return "Open preset browser";
+                    case kRegPresetNext: return "Next preset";
+                    case kRegFav:        return isFav_ ? "Remove from favourites"
+                                                       : "Add to favourites";
+                    case kRegSave:       return "Save preset (\xe2\x8c\x98S)";
+                    case kRegABCompare:  return "Compare preset A vs B";
+                    case kRegChain:      return "Open coupling / FX chain editor";
+                    case kRegExport:     return "Export preset to file (.xometa)";
+                    case kRegDial:       return "Reactivity \xe2\x80\x94 how strongly the visualizer responds to audio";
+                    case kRegSettings:   return "Settings";
+                    default:             break;
+                }
+            }
+        }
+
+        return {};
     }
 
 private:


### PR DESCRIPTION
## Summary

- `SubmarineHudBar` had zero tooltips on its 11 custom-painted controls — EXPORT, A/B, CHAIN, and the REACT dial were completely undiscoverable on hover.
- Added `juce::SettableTooltipClient` as a second base class and overrode `getTooltip()` to hit-test against the existing `regions_` vector (same `expanded(2.0f)` logic already used by `mouseMove`).
- The existing `juce::TooltipWindow tooltipWindow{this, 400}` in `XOceanusEditor.h` is sufficient — no new infrastructure needed.

## Tooltip strings

| Control | Tooltip |
|---------|---------|
| ENGINES | Browse and add engines (E) |
| Undo | Undo last change (⌘Z) |
| Redo | Redo (⌘⇧Z) |
| ◀ Preset | Previous preset |
| Preset name | Open preset browser |
| ▶ Preset | Next preset |
| ♥ Favourite | Add to favourites / Remove from favourites (dynamic) |
| SAVE | Save preset (⌘S) |
| A/B Compare | Compare preset A vs B |
| CHAIN | Open coupling / FX chain editor |
| EXPORT | Export preset to file (.xometa) |
| REACT dial | Reactivity — how strongly the visualizer responds to audio |

Keyboard shortcuts mirror existing handlers (⌘Z / ⌘⇧Z confirmed in `keyPressed()`). ⌘S is conventional and used as a discoverable hint.

## Test plan

- [ ] Hover each of the 11 controls — tooltip appears after ~400 ms delay
- [ ] Verify ♥ tooltip reads "Remove from favourites" when preset is already favourited
- [ ] AU build: `make XOceanus_AU` — no errors
- [ ] `auval -v aumu Xocn XoOx` — PASS

Phase 5 Wave 1 / F-007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)