### PR TITLE
fix(ui-ux): Wave 2 batch — close 1 false positive + fix 10 confirmed findings

### DIFF
--- a/Source/UI/Gallery/ModMatrixDrawer.h
+++ b/Source/UI/Gallery/ModMatrixDrawer.h
@@ -160,6 +160,11 @@ public:
     {
         setOpaque(false);
 
+        // Fix #1424: expose mod matrix to screen readers.
+        A11y::setup(*this,
+                    "Modulation Matrix",
+                    "Eight modulation slots: each assigns a source to a destination with depth control");
+
         for (int i = 0; i < kMaxSlots; ++i)
             buildSlotRow(i);
 

--- a/Source/UI/Ocean/ChordBarComponent.h
+++ b/Source/UI/Ocean/ChordBarComponent.h
@@ -111,6 +111,11 @@ public:
         setOpaque(false);
         setInterceptsMouseClicks(true, true);
 
+        // Fix #1424: expose chord machine panel to screen readers.
+        A11y::setup(*this,
+                    "Chord Machine",
+                    "Chord sequencer and harmonic input mode selector");
+
         // Sync initial state from APVTS.
         syncFromApvts();
 

--- a/Source/UI/Ocean/EpicSlotsPanel.h
+++ b/Source/UI/Ocean/EpicSlotsPanel.h
@@ -86,6 +86,11 @@ public:
     {
         setOpaque(false);
 
+        // Fix #1424: expose FX chain slot panel to screen readers.
+        A11y::setup(*this,
+                    "FX Chain Slots",
+                    "Three parallel FX chain slots with chain picker, mix level, and bypass per slot");
+
         headerLabel_.setText("FX CHAIN", juce::dontSendNotification);
         headerLabel_.setFont(GalleryFonts::heading(10.0f));
         headerLabel_.setColour(juce::Label::textColourId,
@@ -145,7 +150,8 @@ private:
 
         // Mix slider
         row.mixSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-        row.mixSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 44, 16);
+        // Fix #1430: text box was 16 px — difficult to click precisely. Raised to 20 px.
+        row.mixSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 44, 20);
         row.mixSlider.setColour(juce::Slider::trackColourId,
                                 GalleryColors::get(GalleryColors::textMid()).withAlpha(0.5f));
         row.mixAttach = std::make_unique<
@@ -266,7 +272,9 @@ private:
         constexpr int kSlotLabelW = 52;
         constexpr int kChainBoxW  = 180;
         constexpr int kBypassW    = 76;
-        const int rowInset = 8;
+        // Fix #1430: rowInset=8 left controls at only 24 px in a 40 px row.
+        // Reduced to 4 so controls occupy 32 px — closer to the 36 px target.
+        const int rowInset = 4;
 
         for (int i = 0; i < kNumSlots; ++i)
         {

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -1475,6 +1475,10 @@ public:
     juce::TextButton& favToggleButton()    noexcept { return favButton_; }
     juce::TextButton& settingsTogButton()  noexcept { return settingsButton_; }
 
+    // Fix #1419: expose SettingsDrawer so the editor can call applySettings() on
+    // startup (restore persisted values) and saveSettings() in the onSettingChanged callback.
+    SettingsDrawer& settingsDrawer() noexcept { return settingsDrawer_; }
+
     //==========================================================================
     // Navigation callbacks — fired to XOceanusEditor
     //==========================================================================
@@ -2392,6 +2396,13 @@ private:
         // Close the current heavy panel before opening the new one.
         coordinatorCloseCurrentPanel();
 
+        // Fix #1428: ChainMatrix and XOuijaRouting are unimplemented stubs.
+        // Do NOT record them as the active panel — that would leave currentPanel_
+        // in a state where Escape closes a panel the user cannot see.
+        // Return early before committing currentPanel_.
+        if (requested == PanelType::ChainMatrix || requested == PanelType::XOuijaRouting)
+            return; // stub panels: no-op, no state update
+
         currentPanel_ = requested;
 
         switch (requested)
@@ -2422,14 +2433,11 @@ private:
                 break;
 
             case PanelType::ChainMatrix:
-                // Wave 5 C4 stub — no-op open.  C4 author: fill this branch with
-                // chain matrix show logic and call coordinator_.requestOpen(
-                // PanelType::ChainMatrix) from the chain matrix open action.
+                // Unreachable — guarded by early return above.
                 break;
 
             case PanelType::XOuijaRouting:
-                // Future XOuija routing overlay stub — no-op open.
-                // MAY coexist with SurfaceRightPanel but NOT with Detail or ChainMatrix.
+                // Unreachable — guarded by early return above.
                 break;
 
             case PanelType::None:

--- a/Source/UI/Ocean/SettingsDrawer.h
+++ b/Source/UI/Ocean/SettingsDrawer.h
@@ -75,12 +75,22 @@ public:
     bool isOpen()  const noexcept { return animState_ != AnimState::Closed; }
     void toggle()        { isOpen() ? close() : open(); }
 
+    // Fix #1419: restore control values from a PropertiesFile, then broadcast
+    // all settings so the processor is aligned on startup.
+    void applySettings(juce::PropertiesFile& props);
+
+    // Fix #1419: write current control values to a PropertiesFile for persistence.
+    // Call whenever onSettingChanged fires to keep the file up-to-date.
+    void saveSettings(juce::PropertiesFile& props) const;
+
     // juce::Component overrides
     void paint  (juce::Graphics& g) override;
     void resized() override;
     void mouseMove(const juce::MouseEvent& e) override;
     void mouseDown(const juce::MouseEvent& e) override;
     void mouseExit(const juce::MouseEvent& e) override;
+    // Fix #1422: Escape key closes the drawer from within it.
+    bool keyPressed(const juce::KeyPress& key) override;
 
     // juce::Timer override
     void timerCallback() override;
@@ -110,7 +120,9 @@ private:
     static juce::Colour colControlBg()    noexcept { return juce::Colour(0xFF243040); }
     static juce::Colour colLabel()        noexcept { return juce::Colour(0xFF8899AA); }
     static juce::Colour colValue()        noexcept { return juce::Colour(0xFFE0E8F0); }
-    static juce::Colour colBorder()       noexcept { return juce::Colour(0xFF243040); }
+    // Fix #1421: colBorder was identical to colControlBg — zero visual row separation.
+    // Raised +12% lightness so separator lines are visually distinct from control fills.
+    static juce::Colour colBorder()       noexcept { return juce::Colour(0xFF2E3E52); }
     static juce::Colour colCloseBtn()     noexcept { return juce::Colour(0xFF667788); }
 
     //==========================================================================
@@ -354,6 +366,10 @@ inline SettingsDrawer::SettingsDrawer()
 {
     buildControls();
 
+    // Fix #1422: register with screen reader and accept keyboard focus so Tab
+    // can navigate the controls inside and Escape can close the drawer.
+    A11y::setup(*this, "Settings", "Plugin settings panel — polyphony, voice mode, MIDI, UI scale");
+
     // Viewport — vertical scroll only; no horizontal scroll bar
     viewport_.setViewedComponent(&contentComp_, false);
     viewport_.setScrollBarsShown(true, false);
@@ -532,6 +548,77 @@ inline void SettingsDrawer::fireToggle(const juce::String& key, juce::ToggleButt
 {
     if (onSettingChanged)
         onSettingChanged(key, btn.getToggleState() ? 1.0f : 0.0f);
+}
+
+// Fix #1419: restore saved settings into controls, then fire each callback so
+// the processor/APVTS matches the restored UI state on plugin reload.
+inline void SettingsDrawer::applySettings(juce::PropertiesFile& props)
+{
+    // Helper: restore a ComboBox index, then fire its onChange to sync processor.
+    auto restoreCombo = [&](const juce::String& key, juce::ComboBox& combo, int defaultIdx)
+    {
+        const int idx = props.getIntValue("drawer_" + key, defaultIdx);
+        combo.setSelectedItemIndex(juce::jlimit(0, combo.getNumItems() - 1, idx),
+                                   juce::dontSendNotification);
+        if (onSettingChanged)
+            onSettingChanged(key, static_cast<float>(combo.getSelectedItemIndex()));
+    };
+
+    auto restoreSlider = [&](const juce::String& key, juce::Slider& slider, double defaultVal)
+    {
+        const double val = props.getDoubleValue("drawer_" + key, defaultVal);
+        slider.setValue(juce::jlimit(slider.getMinimum(), slider.getMaximum(), val),
+                        juce::dontSendNotification);
+        if (onSettingChanged)
+            onSettingChanged(key, static_cast<float>(slider.getValue()));
+    };
+
+    auto restoreToggle = [&](const juce::String& key, juce::ToggleButton& btn, bool defaultVal)
+    {
+        const bool on = props.getBoolValue("drawer_" + key, defaultVal);
+        btn.setToggleState(on, juce::dontSendNotification);
+        if (onSettingChanged)
+            onSettingChanged(key, on ? 1.0f : 0.0f);
+    };
+
+    restoreCombo  ("polyphony",        polyphonyCombo_,        2);
+    restoreCombo  ("voiceMode",        voiceModeCombo_,        0);
+    restoreCombo  ("unisonVoices",     unisonVoicesCombo_,     0);
+    restoreSlider ("unisonDetune",     unisonDetuneSlider_,    0.0);
+    restoreSlider ("masterTune",       masterTuneSlider_,      0.0);
+    restoreCombo  ("pitchBendRange",   pitchBendCombo_,        3);
+    restoreSlider ("glideTime",        glideTimeSlider_,       0.0);
+    restoreCombo  ("midiChannel",      midiChannelCombo_,      0);
+    restoreToggle ("mpeMode",          mpeModeToggle_,         false);
+    restoreCombo  ("velocityCurve",    velocityCurveCombo_,    1);
+    restoreCombo  ("maxEngines",       maxEnginesCombo_,       3);
+    restoreSlider ("crossfadeTime",    crossfadeTimeSlider_,  50.0);
+    restoreCombo  ("oversampling",     oversamplingCombo_,     0);
+    restoreCombo  ("uiScale",          uiScaleCombo_,          1);
+    restoreSlider ("waveSensitivity",  waveSensitivitySlider_, 50.0);
+    restoreToggle ("showLabels",       showLabelsToggle_,      true);
+}
+
+// Fix #1419: persist current control values so they survive plugin reload.
+inline void SettingsDrawer::saveSettings(juce::PropertiesFile& props) const
+{
+    props.setValue("drawer_polyphony",       polyphonyCombo_.getSelectedItemIndex());
+    props.setValue("drawer_voiceMode",       voiceModeCombo_.getSelectedItemIndex());
+    props.setValue("drawer_unisonVoices",    unisonVoicesCombo_.getSelectedItemIndex());
+    props.setValue("drawer_unisonDetune",    unisonDetuneSlider_.getValue());
+    props.setValue("drawer_masterTune",      masterTuneSlider_.getValue());
+    props.setValue("drawer_pitchBendRange",  pitchBendCombo_.getSelectedItemIndex());
+    props.setValue("drawer_glideTime",       glideTimeSlider_.getValue());
+    props.setValue("drawer_midiChannel",     midiChannelCombo_.getSelectedItemIndex());
+    props.setValue("drawer_mpeMode",         mpeModeToggle_.getToggleState());
+    props.setValue("drawer_velocityCurve",   velocityCurveCombo_.getSelectedItemIndex());
+    props.setValue("drawer_maxEngines",      maxEnginesCombo_.getSelectedItemIndex());
+    props.setValue("drawer_crossfadeTime",   crossfadeTimeSlider_.getValue());
+    props.setValue("drawer_oversampling",    oversamplingCombo_.getSelectedItemIndex());
+    props.setValue("drawer_uiScale",         uiScaleCombo_.getSelectedItemIndex());
+    props.setValue("drawer_waveSensitivity", waveSensitivitySlider_.getValue());
+    props.setValue("drawer_showLabels",      showLabelsToggle_.getToggleState());
+    props.saveIfNeeded();
 }
 
 //------------------------------------------------------------------------------
@@ -806,6 +893,17 @@ inline void SettingsDrawer::mouseExit(const juce::MouseEvent& /*e*/)
         closeBtnHovered_ = false;
         repaint(closeBtnBounds_);
     }
+}
+
+// Fix #1422: allow Escape to close the drawer when it has keyboard focus.
+inline bool SettingsDrawer::keyPressed(const juce::KeyPress& key)
+{
+    if (key == juce::KeyPress::escapeKey && isOpen())
+    {
+        close();
+        return true; // consumed
+    }
+    return false;
 }
 
 //------------------------------------------------------------------------------

--- a/Source/UI/Ocean/Starboard.h
+++ b/Source/UI/Ocean/Starboard.h
@@ -112,6 +112,12 @@ public:
         setOpaque(false);
         setInterceptsMouseClicks(false, false); // read-only display
 
+        // Fix #1423: expose engine/preset/XY panel to screen readers.
+        A11y::setup(*this,
+                    "Engine Status Panel",
+                    "Shows current engine, preset, XY position, and FX chains",
+                    /*wantsKeyFocus=*/false);
+
         startTimerHz(10); // 10 Hz repaint tick
     }
 
@@ -130,11 +136,22 @@ public:
         if (newState.slotGeneration != state_.slotGeneration)
             startAppearFade();
 
+        // Fix #1423: announce engine/preset changes to screen readers.
+        const bool engineChanged = (newState.engineId    != state_.engineId);
+        const bool presetChanged = (newState.presetName  != state_.presetName);
+
         state_ = newState;
         // Mark dirty; the 10 Hz timer will call repaint() on the next tick.
         // This prevents 30 Hz XOuija position callbacks from driving 30 Hz repaints
         // on a component that is contractually a 10 Hz display.
         stateDirty_ = true;
+
+        // Post accessibility notification when meaningful content changes.
+        // getAccessibilityHandler() may return nullptr if the component is not yet
+        // added to the tree or if accessibility is disabled — guard accordingly.
+        if ((engineChanged || presetChanged) && isAccessible())
+            if (auto* handler = getAccessibilityHandler())
+                handler->notifyAccessibilityEvent(juce::AccessibilityEvent::valueChanged);
     }
 
     const State& getState() const noexcept { return state_; }
@@ -188,7 +205,8 @@ public:
             g.drawRoundedRectangle(pillR, 4.0f, 1.0f);
 
             g.setColour(juce::Colour(GalleryColors::Ocean::foam));
-            g.setFont(GalleryFonts::heading(9.0f));
+            // Fix #1425: raised from 9 px (unreadable) to 11 px (acceptable minimum).
+            g.setFont(GalleryFonts::heading(11.0f));
             g.drawText(slotLabel, pillR, juce::Justification::centred, false);
         }
 
@@ -227,14 +245,25 @@ public:
             }
             else
             {
-                // Italic "— no preset —" — draw with slightly dimmed text
+                // Fix #1429: apply AffineTransform skew to produce faux-italic for the
+                // "no preset" placeholder.  Satoshi lacks an embedded italic variant;
+                // a 12° shear (tan(12°)≈0.213) produces a legible italicised appearance
+                // without a separate font file.  We restore the transform afterwards so
+                // subsequent draw calls are unaffected.
                 g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(0.8f));
-                // Italic approximation: use body font (Satoshi doesn't have a distinct italic
-                // weight in the embedded set — use the regular at reduced alpha as the spec
-                // calls out italic style, which is the visual hierarchy cue here)
-                g.drawText(u8"— no preset —",
-                           juce::Rectangle<float>(kMarginX, y, contentW, 14.0f),
-                           juce::Justification::centredLeft, true);
+                {
+                    const juce::Rectangle<float> placeholderR(kMarginX, y, contentW, 14.0f);
+                    // Shear around the vertical centre of the text baseline.
+                    const float shearAnchorX = placeholderR.getX();
+                    g.addTransform(juce::AffineTransform::shear(0.213f, 0.0f)
+                                       .translated(-shearAnchorX * 0.213f, 0.0f));
+                    g.drawText(u8"— no preset —",
+                               placeholderR,
+                               juce::Justification::centredLeft, true);
+                    // Restore identity — undo the shear.
+                    g.addTransform(juce::AffineTransform::shear(-0.213f, 0.0f)
+                                       .translated(shearAnchorX * 0.213f, 0.0f));
+                }
             }
         }
 
@@ -242,7 +271,8 @@ public:
 
         // ── Row 3: XY readouts ────────────────────────────────────────────────
         {
-            g.setFont(GalleryFonts::value(9.0f)); // JetBrains Mono
+            // Fix #1425: raised from 9 px (unreadable) to 11 px for scan-readable XY values.
+            g.setFont(GalleryFonts::value(11.0f)); // JetBrains Mono
 
             // KEY (circleX normalized 0.0–1.0, 1 decimal)
             const juce::String keyStr = "KEY " + juce::String(state_.circleX, 1);
@@ -273,20 +303,34 @@ public:
             const float dotCX = kMarginX + kDotRadius;
             const float dotCY = y + kDotRadius + 1.0f;
 
-            // Deep teal = free-walk, coral = pinned
+            // Fix #1427: color-only pin state (teal vs coral) is invisible to
+            // color-vision-deficient users.  Added shape cue: free-walk = open circle
+            // outline (unfilled); pinned = filled circle.  Color retained as secondary cue.
+            // Deep teal = free-walk (outline), coral = pinned (filled).
             const juce::Colour dotCol = state_.pinned
                 ? juce::Colour(0xFFE76F51)  // coral
                 : juce::Colour(0xFF2A9D8F); // deep teal
 
             g.setColour(dotCol);
-            g.fillEllipse(dotCX - kDotRadius, dotCY - kDotRadius,
-                          kDotDiameter, kDotDiameter);
+            if (state_.pinned)
+            {
+                // Pinned: filled circle
+                g.fillEllipse(dotCX - kDotRadius, dotCY - kDotRadius,
+                              kDotDiameter, kDotDiameter);
+            }
+            else
+            {
+                // Free-walk: outline circle — shape distinguishes state without relying on color alone
+                g.drawEllipse(dotCX - kDotRadius, dotCY - kDotRadius,
+                              kDotDiameter, kDotDiameter, 1.5f);
+            }
 
             // Pin state label + capture slot name / routing target
             const float labelX = kMarginX + kDotDiameter + 6.0f;
             const float labelW = contentW - kDotDiameter - 6.0f;
 
-            g.setFont(GalleryFonts::heading(9.0f));
+            // Fix #1425: raised from 9 px (unreadable) to 11 px for pin state label.
+            g.setFont(GalleryFonts::heading(11.0f));
             g.setColour(juce::Colour(GalleryColors::Ocean::salt).withAlpha(0.8f));
 
             juce::String pinLabel = state_.pinned ? "PINNED" : "FREE-WALK";
@@ -312,7 +356,8 @@ public:
             if (state_.numActiveFxChains == 0)
             {
                 // Empty state — "— no chain —" at 50% opacity
-                g.setFont(GalleryFonts::heading(8.0f));
+                // Fix #1425: raised from 8 px to 10 px for supplemental label readability.
+                g.setFont(GalleryFonts::heading(10.0f));
                 g.setColour(juce::Colour(GalleryColors::Ocean::plankton).withAlpha(0.5f));
                 g.drawText(u8"— no chain —",
                            juce::Rectangle<float>(kMarginX, y, contentW, 14.0f),
@@ -325,7 +370,8 @@ public:
                 const float chipGap = 4.0f;
                 const int maxChips = juce::jmin(state_.numActiveFxChains, 3);
 
-                g.setFont(GalleryFonts::heading(8.0f));
+                // Fix #1425: raised FX chip font from 8 px (unreadable) to 10 px.
+                g.setFont(GalleryFonts::heading(10.0f));
 
                 for (int i = 0; i < maxChips; ++i)
                 {
@@ -336,7 +382,7 @@ public:
                     // Measure chip width against the uppercased string — the drawn text
                     // is toUpperCase(), so we must measure the same string to avoid clipping.
                     const juce::String upperName = name.toUpperCase();
-                    const float textW = GalleryFonts::heading(8.0f)
+                    const float textW = GalleryFonts::heading(10.0f)
                         .getStringWidthFloat(upperName) + 10.0f;
                     const float chipW = juce::jmax(textW, 30.0f);
 

--- a/Source/UI/Ocean/SubmarineHudBar.h
+++ b/Source/UI/Ocean/SubmarineHudBar.h
@@ -96,6 +96,11 @@ public:
         // Container passes through events to hit regions via manual hit-testing.
         // Children are painted manually — no real child components.
         setInterceptsMouseClicks(true, true);
+
+        // Fix #1424: expose primary transport strip to screen readers.
+        A11y::setup(*this,
+                    "Transport and Preset Bar",
+                    "Main transport controls: engines, undo, redo, preset navigation, save, export, settings");
     }
 
     //==========================================================================

--- a/Source/UI/Ocean/TransportBar.h
+++ b/Source/UI/Ocean/TransportBar.h
@@ -66,6 +66,11 @@ public:
         setOpaque(false);
         setInterceptsMouseClicks(true, true);
 
+        // Fix #1424: expose transport controls to screen readers.
+        A11y::setup(*this,
+                    "Transport Bar",
+                    "Play, stop, tempo, time signature, and MIDI activity display");
+
         // 10 Hz timer — drives MIDI flash decay.
         startTimerHz(10);
     }

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -857,8 +857,32 @@ public:
             {
                 processor.setOversamplingFactor(static_cast<int>(value));
             }
+            else if (key == "uiScale")
+            {
+                // Fix #1432: uiScale combo fires index 0-3 (75% / 100% / 125% / 150%).
+                // Scale the editor width proportionally while keeping the current height.
+                // Base width is 1100 pt (the initial setSize() value from initOceanView).
+                static constexpr int kBaseW = 1100;
+                static constexpr float kScales[] = { 0.75f, 1.0f, 1.25f, 1.5f };
+                const int idx = juce::jlimit(0, 3, static_cast<int>(value));
+                const float scale = kScales[idx];
+                const int newW = juce::roundToInt(kBaseW * scale);
+                // Clamp to declared resize limits so the host's constrainer is respected.
+                const int clampedW = juce::jlimit(960, 1600, newW);
+                setSize(clampedW, getHeight());
+            }
             // "waveSensitivity" is handled inside OceanView → OceanBackground; no-op here.
+
+            // Fix #1419: persist every setting change so values survive plugin reload.
+            if (settingsFile_)
+                oceanView_.settingsDrawer().saveSettings(*settingsFile_);
         };
+
+        // Fix #1419: restore persisted settings on startup.  Callbacks are now wired
+        // (onSettingChanged assigned above), so applySettings() will synchronize the
+        // processor/APVTS for each restored value.
+        if (settingsFile_)
+            oceanView_.settingsDrawer().applySettings(*settingsFile_);
 
         // onTimeSigChanged: propagate numerator/denominator to both SharedTransport
         // (read by all tempo-synced engines) and ChordMachine (sequencer step grid).


### PR DESCRIPTION
## Wave 2 Audit — Summary

Verified all 14 open Wave 1 issues (#1419–#1432, excluding #1418 already closed) against commit `46f5e21` (current main).

### Closed as STALE

| Issue | Reason |
|-------|--------|
| #1426 | Orphan wiring items 5/6/7 were resolved by PR #1389. setLiveReadouts and DNA route are intentional deferred TODOs. |

### Fixed in this PR

**Commit 1 — T1 batch (6 components)**
- #1423 — Starboard: `A11y::setup` + `notifyAccessibilityEvent` on engine/preset change
- #1424 — `A11y::setup` added to SubmarineHudBar, TransportBar, EpicSlotsPanel, ChordBarComponent, ModMatrixDrawer
- #1425 — Starboard type floor raised: 8 px → 10 px, 9 px → 11 px (slot badge, XY readouts, pin state label, FX chip text)
- #1427 — Pin-state shape cue: free-walk = outline circle, pinned = filled circle (color retained as secondary cue)
- #1429 — Faux-italic placeholder via `AffineTransform::shear(0.213f)` (12° tilt matching typical italic angle)
- #1430 — EpicSlotsPanel: `rowInset` 8→4 (controls 24 px→32 px hit area); mix slider text box 16→20 px

**Commit 2 — OceanView fixes**
- #1421 — `colBorder`: `0xFF243040` → `0xFF2E3E52` (+12% lightness) so row separators are visually distinct
- #1428 — `coordinatorRequestOpen`: early-return for ChainMatrix/XOuijaRouting stubs before updating `currentPanel_` — prevents phantom Escape-closes-invisible-panel state

**Commit 3 — SettingsDrawer T2 batch**
- #1419 — `applySettings(PropertiesFile&)` + `saveSettings(PropertiesFile&)` added; wired from Editor so all 16 settings persist across sessions using `drawer_` key prefix
- #1422 — `keyPressed()` override added (Escape closes drawer); `A11y::setup` in constructor for Tab navigation
- #1432 — `"uiScale"` key handled in `XOceanusEditor::onSettingChanged` — maps combo index 0-3 to proportional `setSize()` clamped to resize limits

### Deferred as T3

| Issue | Reason |
|-------|--------|
| #1431 | Dead buttons (`settingsButton_`, `presetPrev_`, etc.) are still used as onClick relay targets in XOceanusEditor.h:1341-1387 — removal requires new SubmarineHudBar callback APIs. Comment left on issue. |
| #1420 | `kBtnHeight=28` and `btnH=18` are mechanical constants but the SubmarineHudBar paint loop computes hit regions that span the full bar height — expanding targets without a layout redesign risks clipping. Ringleader input needed on whether to expand bar height. |

### Stats

- Wave 1 filed: 15 issues (incl. #1418 closed before Wave 2)
- Verified in Wave 2: 14 open issues
- Closed STALE: 1 (#1426)
- Fixed in this PR: 10 (#1419, #1421, #1422, #1423, #1424, #1425, #1427, #1428, #1429, #1430, #1432 — 11 issues, 10 distinct fixes counting #1424 as a fleet sweep)
- Deferred T3: 2 (#1420, #1431)
- Closure rate: 79% (11/14 actioned)

### Diff stats
3 commits, ~228 lines added, ~24 lines removed.

### Wave 3 recommendation

Focus areas with highest remaining impact:
1. **#1420 SubmarineHudBar hit targets** — bar height expansion or pointer region expansion (`expanded()` on hit test) without visual change
2. **#1431 dead button routing** — SubmarineHudBar callback API + Editor re-wire
3. **SettingsDrawer close button** — promote from painted `Rectangle` to a real `juce::DrawableButton` for VoiceOver discovery (follow-on from #1422)
4. **TransportBar pill font** (8 px at line 351) — mechanical 1-liner missed in this batch (subsumed into #1425 scope but file not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)