### PR TITLE
fix(ux): SeqBreakout CallOutBox z-order via top-level launch (F-005 / #1396)

### DIFF
--- a/Source/UI/Ocean/SeqBreakoutComponent.h
+++ b/Source/UI/Ocean/SeqBreakoutComponent.h
@@ -1340,16 +1340,18 @@ private:
             static_cast<int>(ledW),
             static_cast<int>(stepRowBounds_.getHeight()));
 
-        // CallOutBox::launchAsynchronously takes the anchor rect in the coordinate
-        // space of the parent component pointer.  Passing 'this' = component-local coords.
-        // TODO Wave5-C4/C5 mount: pass the editor's top-level component so the callout
-        // renders above OceanView overlays.
-        // TODO Wave5-C4/C5 mount: consider mounting via XOceanusEditor.h or OceanView.h
-        // to ensure z-order above all Ocean overlays.
+        // Launch from the top-level editor so the CallOutBox renders above all
+        // OceanView overlays (DrawerOverlay, PlaySurfaceOverlay, DimOverlay).
+        // CallOutBox::launchAsynchronously requires areaToPointTo in the parent's
+        // local coordinate space — convert from SeqBreakout-local via getLocalArea.
+        // F-005 / #1396: fixes step-edit popups occluded by Ocean overlays.
+        auto* topLevel = getTopLevelComponent();
+        const juce::Rectangle<int> areaInTopLevel =
+            topLevel->getLocalArea(this, ledLocalRect);
         juce::CallOutBox::launchAsynchronously(
             std::unique_ptr<juce::Component>(content),
-            ledLocalRect,
-            this);
+            areaInTopLevel,
+            topLevel);
     }
 
     //==========================================================================


### PR DESCRIPTION
## Summary

- Step-edit CallOutBoxes in `SeqBreakoutComponent` were launched with `this` (SeqBreakoutComponent) as parent, placing them in SeqBreakout's z-layer beneath OceanView's DrawerOverlay, PlaySurfaceOverlay, and DimOverlay.
- Popups became invisible whenever any overlay was open — making step-edit functionally unusable in the primary workflow (editing while a drawer is open).
- Fix: launch from `getTopLevelComponent()` (XOceanusEditor) and convert the LED anchor rect from SeqBreakout-local space to editor-local space via `getLocalArea()`.

## Changes

- **1 launch site changed** in `Source/UI/Ocean/SeqBreakoutComponent.h` (~line 1348)
- Coordinate conversion: `topLevel->getLocalArea(this, ledLocalRect)` — matches JUCE's `CallOutBox` contract (area must be in parent's local coordinate space)
- Removed 2 TODO comments (Wave5-C4/C5 notes) that explicitly called out this fix

## Test plan

- [ ] Open SeqBreakout → long-press any step LED while no overlay is active → popup appears correctly anchored to the LED
- [ ] Open a drawer overlay → long-press a step LED → popup now renders above the drawer (was previously hidden)
- [ ] Close the drawer → popup still positioned correctly
- [ ] Verify no visual drift: popup arrow points to the correct LED position at all panel positions

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)