### PR TITLE
fix(ux): Walkthrough bounds for steps 3/4/6/7 (F-003 / #1395)

### DIFF
--- a/Source/UI/FirstHourWalkthrough.h
+++ b/Source/UI/FirstHourWalkthrough.h
@@ -507,6 +507,10 @@ private:
             return;
 
         const juce::Rectangle<int> target = getTargetForStep (currentStep_);
+        // F-003 / #1395: assert that every step resolves to a real on-screen region.
+        // If this fires, the accessor lambda for that step is returning {} and the
+        // fallback centred-rect is being used instead of a real component target.
+        jassert (!target.isEmpty());
         activeBubble_->positionNearTarget (target, getLocalBounds());
         repaint (target.expanded (8));
     }
@@ -642,12 +646,19 @@ private:
 
 //==============================================================================
 // Wave 9c mount COMPLETE — XOceanusEditor.h (applied 2026-04-26, PR #mount-final)
+// F-003 / #1395 fix applied 2026-04-29: steps 3/4/6/7 now point at real targets.
 //
 // All 6 mount points wired:
 //   1. Member: walkthrough_  (before toastOverlay_ in declaration order)
-//   2. Bound accessors wired in initOceanView() — steps 0/2/5 fully resolved;
-//      steps 3/4/6/7 return {} until DnaMapBrowser/EngineOrbit/favBtn/XOuija
-//      are accessible directly from the editor (post-Wave 7 decomp).
+//   2. Bound accessors wired in initOceanView() — all 8 steps resolved:
+//      Step 0: PlaySurface     — oceanView_.getPlaySurface().getBounds()
+//      Step 1: EngineOrbit[0]  — tiles[0]->getBounds()
+//      Step 2: Macros          — macros.getBounds()
+//      Step 3: Preset name     — oceanView_.getDnaMapBrowserBounds() → HudBar preset-name pill
+//      Step 4: CoupleOrbit[1]  — oceanView_.getOrbitBounds(1)
+//      Step 5: CM toggle       — cmToggleBtn.getBounds()
+//      Step 6: Fav button      — oceanView_.getHudFavBounds() → HudBar fav bounds
+//      Step 7: HARMONIC tab    — oceanView_.getOuijaPanelBounds() → DashboardTabBar HARMONIC tab
 //   3. addAndMakeVisible(walkthrough_) in initOceanView() before toastOverlay_.
 //   4. setBounds in resized() OceanView branch.
 //   5. promptIfEligible() fired on first timerCallback tick via walkthroughTriggeredThisSession_ guard.

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -1351,17 +1351,27 @@ public:
         return localFav.translated(hudBar_.getX(), hudBar_.getY());
     }
 
-    // wire(#orphan-sweep item 2): expose ouija panel bounds for walkthrough step 7.
+    // F-003 / #1395: expose HARMONIC tab in tabBar_ for walkthrough step 7.
+    // ouijaPanel_.getBounds() is always {} (ouijaPanel_ never gets setBounds);
+    // the HARMONIC tab in the dashboard tab bar is the correct visual target
+    // for "click here to open XOuija".
+    // Translates from tabBar_ local coords to OceanView local coords.
     juce::Rectangle<int> getOuijaPanelBounds() const noexcept
     {
-        return ouijaPanel_.getBounds();
+        auto localTab = tabBar_.getHarmonicTabBounds();
+        if (localTab.isEmpty()) return {};
+        return localTab.translated(tabBar_.getX(), tabBar_.getY());
     }
 
-    // wire(#orphan-sweep item 2): expose DnaMapBrowser bounds for walkthrough step 3.
-    // Returns browser_ bounds (always positioned at full OceanView size; hidden when closed).
+    // F-003 / #1395: expose preset-name pill in HudBar for walkthrough step 3.
+    // browser_.getBounds() is {} unless BrowserOpen state; use the preset-name
+    // label instead — it is always visible and opens the browser on click.
+    // Translates from hudBar_ local coords to OceanView local coords.
     juce::Rectangle<int> getDnaMapBrowserBounds() const noexcept
     {
-        return browser_.getBounds();
+        auto localName = hudBar_.getPresetNameBounds();
+        if (localName.isEmpty()) return {};
+        return localName.translated(hudBar_.getX(), hudBar_.getY());
     }
 
     // wire(#orphan-sweep item 2): expose orbit slot 1 bounds for walkthrough step 4 (couple).
@@ -1746,6 +1756,22 @@ private:
         juce::String activeTab() const noexcept
         {
             return kTabNames[activeIdx_];
+        }
+
+        /** F-003 / #1395: return the HARMONIC tab hit-rect in this component's
+            local coords.  Tab regions are built lazily in paint(); if not yet
+            computed this falls back to the right quarter of getLocalBounds()
+            (a reasonable approximation given HARMONIC is the rightmost tab).
+            Caller must translate to parent (OceanView) coordinates. */
+        juce::Rectangle<int> getHarmonicTabBounds() const noexcept
+        {
+            // HARMONIC is tab index 4 (last tab).
+            constexpr int kHarmonicIdx = 4;
+            if (static_cast<int>(tabRegions_.size()) > kHarmonicIdx)
+                return tabRegions_[static_cast<size_t>(kHarmonicIdx)].toNearestInt();
+            // Pre-paint fallback: rightmost ~80px of the tab bar height.
+            const auto lb = getLocalBounds();
+            return lb.withLeft(lb.getRight() - 80);
         }
 
         std::function<void(const juce::String&)> onTabChanged;

--- a/Source/UI/Ocean/SubmarineHudBar.h
+++ b/Source/UI/Ocean/SubmarineHudBar.h
@@ -119,6 +119,12 @@ public:
         Returns empty rect before the first paint pass (bounds not yet computed). */
     juce::Rectangle<int> getFavBounds() const noexcept { return favBounds_.toNearestInt(); }
 
+    /** F-003 / #1395: expose preset name label hit-rect in local coords.
+        Used by FirstHourWalkthrough step 3 to point the bubble at the preset-name
+        pill (which opens the DnaMapBrowser when clicked).
+        Returns empty rect before the first layout pass (bounds not yet computed). */
+    juce::Rectangle<int> getPresetNameBounds() const noexcept { return presetNameBounds_.toNearestInt(); }
+
     void setPresetName(const juce::String& name)
     {
         if (presetName_ != name) { presetName_ = name; repaint(); }

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -1530,11 +1530,13 @@ public:
         };
         walkthrough_.getMacroBounds        = [this]() { return macros.getBounds(); };
         walkthrough_.getDnaBrowserBounds   = [this]() {
-            // wire(#orphan-sweep item 2): DnaMapBrowser bounds via new OceanView accessor.
-            // Returns full OceanView size area (browser is full-window overlay).
+            // F-003 / #1395: points at the HudBar preset-name pill (always visible;
+            // opens DnaMapBrowser when clicked). getDnaMapBrowserBounds() now
+            // returns the preset-name label bounds — not browser_.getBounds()
+            // (which is {} unless BrowserOpen state).
             auto b = oceanView_.getDnaMapBrowserBounds();
-            // Translate to editor coords.
-            return b.translated(oceanView_.getX(), oceanView_.getY());
+            return b.isEmpty() ? juce::Rectangle<int>{}
+                               : b.translated(oceanView_.getX(), oceanView_.getY());
         };
         walkthrough_.getCoupleOrbitBounds  = [this]() {
             // wire(#orphan-sweep item 2): orbit slot 1 bounds for the coupling step.
@@ -1551,7 +1553,9 @@ public:
                                : b.translated(oceanView_.getX(), oceanView_.getY());
         };
         walkthrough_.getXouijaBounds       = [this]() {
-            // wire(#orphan-sweep item 2): ouija panel bounds via new OceanView accessor.
+            // F-003 / #1395: points at the HARMONIC tab in DashboardTabBar.
+            // ouijaPanel_.getBounds() is always {} (never gets setBounds);
+            // getOuijaPanelBounds() now returns the HARMONIC tab hit-rect.
             auto b = oceanView_.getOuijaPanelBounds();
             return b.isEmpty() ? juce::Rectangle<int>{}
                                : b.translated(oceanView_.getX(), oceanView_.getY());


### PR DESCRIPTION
## Summary

- `getDnaMapBrowserBounds()` returned `browser_.getBounds()` which is `{}` unless in `BrowserOpen` state — step 3 arrow pointed at origin.
- `getOuijaPanelBounds()` returned `ouijaPanel_.getBounds()` which is always `{}` (panel is `setVisible(false)` in every layout path, never gets `setBounds`) — step 7 arrow pointed at origin.
- Added `SubmarineHudBar::getPresetNameBounds()` and `DashboardTabBar::getHarmonicTabBounds()` as the correct visual targets.
- Added `jassert(!target.isEmpty())` in `repositionBubble()` to catch future regressions in debug builds.

**Step → Component mapping after fix:**
| Step | Description | Target |
|------|-------------|--------|
| 3 | Browse the ocean | HudBar preset-name pill (`getPresetNameBounds()`) |
| 4 | Couple two engines | `orbits_[1].getBounds()` — was already wired correctly |
| 6 | Save your first preset | HudBar fav button (`getFavBounds()`) — was already wired correctly |
| 7 | XOuija | HARMONIC tab in DashboardTabBar (`getHarmonicTabBounds()`) |

## Test plan
- [ ] Build passes: `cmake --build build` — 0 errors confirmed
- [ ] AU PASS: `auval -v aumu Xocn XoOx` — confirmed
- [ ] Launch XOceanus fresh (clear `onboardingWalkthroughStep` from prefs) — step 3 bubble arrow points at preset name pill in HudBar, not at origin
- [ ] Step 7 bubble arrow points at the HARMONIC tab in the dashboard tab bar
- [ ] Steps 1/2/5/8 (previously working) still point at correct targets

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)