### PR TITLE
fix(ux): Wave 2 sweep — lifecycle, serialization, state restoration

### DIFF
--- a/Source/UI/Ocean/CouplingSubstrate.h
+++ b/Source/UI/Ocean/CouplingSubstrate.h
@@ -810,6 +810,9 @@ private:
     /** Timer callback — advances animation state at kTimerHz and repaints. */
     void timerCallback() override
     {
+        // F2-009: Skip all processing when hidden — no visual output, no CPU waste.
+        if (!isShowing()) return;
+
         const bool reducedMotion = A11y::prefersReducedMotion();
 
         // Poll mouse position during chain-in-progress for smooth line tracking.

--- a/Source/UI/Ocean/DotMatrixDisplay.h
+++ b/Source/UI/Ocean/DotMatrixDisplay.h
@@ -91,6 +91,7 @@ public:
         waveHead_.store(next, std::memory_order_release);
 
         lastPushMs_ = juce::Time::getMillisecondCounterHiRes();
+        dataDirty_ = true;  // F2-018
     }
 
     /** Push 16 normalised frequency bins (0–1). Used by Spectrum mode. */
@@ -100,6 +101,7 @@ public:
         for (int i = 0; i < n; ++i)
             specBins_[i] = std::max(specBins_[i], juce::jlimit(0.0f, 1.0f, bins[i]));
         lastPushMs_ = juce::Time::getMillisecondCounterHiRes();
+        dataDirty_ = true;  // F2-018
     }
 
     /** Push 4 engine activity levels (0–1). Used by EnginePulse mode. */
@@ -109,6 +111,7 @@ public:
             engineLevels_[i] = std::max(engineLevels_[i],
                                         juce::jlimit(0.0f, 1.0f, levels[i]));
         lastPushMs_ = juce::Time::getMillisecondCounterHiRes();
+        dataDirty_ = true;  // F2-018
     }
 
     /** Push current sequencer step state. Used by SequencerMirror mode. */
@@ -119,6 +122,7 @@ public:
         if (currentStep >= 0 && currentStep < 16)
             seqActive_[currentStep] = active;
         lastPushMs_ = juce::Time::getMillisecondCounterHiRes();
+        dataDirty_ = true;  // F2-018
     }
 
 private:
@@ -449,7 +453,16 @@ private:
         if (! isShowing())
             return;
 
-        repaint();
+        // F2-018: Only repaint when new data was pushed or the breathing phase changed.
+        // The breathing phase changes every tick (animation), so always repaint when
+        // idle to keep the breath animation smooth.  When active data arrives, dataDirty_
+        // ensures we never miss a frame.  Clear the flag BEFORE repaint() so a push that
+        // arrives during paint() is not silently dropped.
+        if (dataDirty_ || !isIdle())
+        {
+            dataDirty_ = false;
+            repaint();
+        }
     }
 
     //==========================================================================
@@ -489,6 +502,10 @@ private:
 
     // Last time data was pushed (ms)
     double lastPushMs_ = 0.0;
+
+    // F2-018: Set by any push method; cleared by timerCallback before repaint().
+    // Ensures repaint() is only called when content has actually changed.
+    bool dataDirty_ = false;
 
     // Cached grid dimensions (computed in paint from current size)
     mutable int cols_ = 0;

--- a/Source/UI/Ocean/EngineOrbit.h
+++ b/Source/UI/Ocean/EngineOrbit.h
@@ -856,6 +856,10 @@ public:
 
     void setWreathData(const float* samples, int count, float rms)
     {
+        // F2-021: Wreath data must be pushed from the message thread only —
+        // it is read by paint() on the same thread without any synchronisation.
+        jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
+
         const int n = std::min(count, kWreathBufferSize);
         for (int i = 0; i < n; ++i)
             wreathBuffer_[static_cast<size_t>(i)] = samples[i];
@@ -995,6 +999,15 @@ public:
     void stepAnimation()
     {
         if (!hasEngine_) return;
+
+        // F2-008: Recover from system-yanked mouse capture (Alt+Tab, Cmd+Tab, window focus loss).
+        // JUCE has no mouseLostCapture() virtual — poll in the animation tick instead.
+        // If we believe a drag is in progress but no mouse button is down, cancel it.
+        if (isDragging_ && !juce::Desktop::getInstance().getMainMouseSource().isDragging())
+        {
+            isDragging_ = false;
+            inputState_ = InputState::Settling;
+        }
 
         const bool reducedMotion = A11y::prefersReducedMotion();
         constexpr float twoPi = juce::MathConstants<float>::twoPi;

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -742,6 +742,10 @@ public:
             layout_->layoutForState(s, getLocalBounds(), 1.0f);
             layout_->reorderZStack();
             repaint();
+
+            // F2-006: Notify editor of ViewState change so it can persist the state.
+            if (onViewStateChanged)
+                onViewStateChanged(static_cast<int>(s), stateMachine_.selectedSlot());
         };
 
         // onAnimationFrame: stubbed for future animated transitions.
@@ -1175,6 +1179,15 @@ public:
 
     void mouseExit(const juce::MouseEvent& /*e*/) override
     {
+        // F2-013: Cancel any in-progress coupling chain when the cursor leaves OceanView.
+        // Without this, the ghost chain line stays rendered indefinitely.
+        if (chainStartSlot_ >= 0)
+        {
+            chainStartSlot_ = -1;
+            substrate_.setChainInProgress(false, -1, {});
+            setMouseCursor(juce::MouseCursor::NormalCursor);
+            repaint();
+        }
     }
 
     //==========================================================================
@@ -1508,6 +1521,16 @@ public:
     /** Fired when an engine slot is selected (zoom-in). -1 means deselected. */
     std::function<void(int slot)> onEngineSelected;
 
+    /** F2-006: Fired when the OceanView transitions to a new ViewState.
+        @param stateInt  0=Orbital, 1=ZoomIn, 2=SplitTransform, 3=BrowserOpen.
+        @param slot      Active engine slot for ZoomIn/SplitTransform; -1 otherwise. */
+    std::function<void(int stateInt, int slot)> onViewStateChanged;
+
+    /** F2-012: Called from OceanView's 30Hz timerCallback to pull per-slot waveform
+        data from the processor.  Wire in the editor to call pushSlotWaveData() for
+        each active slot so wreath data is updated at the same rate as the animation. */
+    std::function<void()> onPullWaveformData;
+
     /** Fired when an engine slot enters SplitTransform (double-click dive). */
     std::function<void(int slot)> onEngineDiveDeep;
 
@@ -1621,6 +1644,15 @@ public:
     // Phase 3 (#1184): viewState_ removed — read from OceanStateMachine.
     ViewState getViewState()    const noexcept { return stateMachine_.currentState(); }
     int       getSelectedSlot() const noexcept { return stateMachine_.selectedSlot(); }
+
+    /** F2-006/F2-015: Public entry point for externally triggering a ZoomIn transition.
+        Used by the editor to restore persisted navigation state on session reload.
+        Safe to call before the component is visible (deferred via callAfterDelay). */
+    void requestZoomIn(int slot)
+    {
+        if (slot >= 0 && slot < 5)
+            transitionToZoomIn(slot);
+    }
 
     bool isSlotMuted  (int slot) const noexcept
     {
@@ -2120,6 +2152,12 @@ private:
 
     void timerCallback() override
     {
+        // F2-012: Pull per-slot waveform data at the same 30Hz rate as orbit animation,
+        // so wreath visualisation is always in sync with the animation frame.
+        // The callback is wired by the editor to read from processor WaveformFifos.
+        if (onPullWaveformData)
+            onPullWaveformData();
+
         // Drive all orbit animations from one synchronized 30 Hz timer.
         for (auto& orbit : orbits_)
             orbit.stepAnimation();
@@ -2144,7 +2182,7 @@ private:
         // when it reaches zero we flush all 5 positions in one PropertiesFile write.
         if (positionSaveCountdown_ > 0)
         {
-            positionSaveCountdown_ -= 1000 / 30; // subtract one tick worth of ms
+            positionSaveCountdown_ -= getTimerInterval(); // F2-020: use actual interval, not hardcoded 1000/30
             if (positionSaveCountdown_ <= 0)
             {
                 positionSaveCountdown_ = 0;

--- a/Source/UI/Ocean/SettingsDrawer.h
+++ b/Source/UI/Ocean/SettingsDrawer.h
@@ -581,6 +581,10 @@ inline void SettingsDrawer::applySettings(juce::PropertiesFile& props)
             onSettingChanged(key, on ? 1.0f : 0.0f);
     };
 
+    // F2-016: Restore drawer open state.
+    if (props.getBoolValue("drawer_isOpen", false))
+        open();
+
     restoreCombo  ("polyphony",        polyphonyCombo_,        2);
     restoreCombo  ("voiceMode",        voiceModeCombo_,        0);
     restoreCombo  ("unisonVoices",     unisonVoicesCombo_,     0);
@@ -602,6 +606,8 @@ inline void SettingsDrawer::applySettings(juce::PropertiesFile& props)
 // Fix #1419: persist current control values so they survive plugin reload.
 inline void SettingsDrawer::saveSettings(juce::PropertiesFile& props) const
 {
+    // F2-016: Persist drawer open state so it survives plugin reload.
+    props.setValue("drawer_isOpen",          isOpen());
     props.setValue("drawer_polyphony",       polyphonyCombo_.getSelectedItemIndex());
     props.setValue("drawer_voiceMode",       voiceModeCombo_.getSelectedItemIndex());
     props.setValue("drawer_unisonVoices",    unisonVoicesCombo_.getSelectedItemIndex());

--- a/Source/UI/Ocean/TideWaterline.h
+++ b/Source/UI/Ocean/TideWaterline.h
@@ -107,6 +107,7 @@ public:
     {
         juce::ValueTree tree("TideWaterlineSteps");
         tree.setProperty("stepCount", currentSteps_, nullptr);
+        tree.setProperty("expanded",  expanded_ ? 1 : 0, nullptr);  // F2-011
         for (int i = 0; i < kMaxSteps; ++i)
         {
             juce::ValueTree step("Step");
@@ -129,6 +130,10 @@ public:
 
         if (tree.hasProperty("stepCount"))
             currentSteps_ = juce::jlimit(1, kMaxSteps, static_cast<int>(tree.getProperty("stepCount")));
+
+        // F2-011: Restore expanded state.
+        if (tree.hasProperty("expanded"))
+            setExpanded(static_cast<int>(tree.getProperty("expanded")) != 0);
 
         int childIdx = 0;
         for (auto child : tree)

--- a/Source/UI/PlaySurface/PlaySurface.h
+++ b/Source/UI/PlaySurface/PlaySurface.h
@@ -1537,6 +1537,16 @@ public:
     // processor's lock-free CC queue.  The processor pointer is NOT owned here.
     void setProcessor(XOceanusProcessor* p)
     {
+        // F2-001 (CRIT): Before updating processor_, null out XOuija bridge callbacks
+        // on the OLD processor so it never calls back into a soon-to-be-invalid lambda.
+        // This handles the case where setProcessor(nullptr) is called from the editor
+        // destructor and the DAW calls getStateInformation() after editor close.
+        if (processor_)
+        {
+            processor_->onGetXOuijaState = nullptr;
+            processor_->onSetXOuijaState = nullptr;
+        }
+
         processor_ = p;
         // Re-wire the onCCOutput callback now that we have the processor.
         wireOnCCOutput();

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -906,6 +906,30 @@ public:
         oceanView_.onRedoRequested = [this]() { processor.getUndoManager().redo(); };
         oceanView_.onEngineSelected = [this](int slot) { if (slot >= 0) selectSlot(slot); };
         oceanView_.onEngineDiveDeep = [this](int slot) { selectSlot(slot); };
+        // F2-006: Persist OceanView ViewState + slot so DAW session recall restores navigation.
+        oceanView_.onViewStateChanged = [this](int stateInt, int slot)
+        {
+            processor.setPersistedOceanViewState(stateInt);
+            processor.setPersistedOceanViewSlot(slot);
+        };
+        // F2-012: Pull per-slot waveform data inside OceanView's 30Hz timer so wreath
+        // animation and data updates are synchronised.  Moved from editor's 10Hz timer.
+        oceanView_.onPullWaveformData = [this]()
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                if (processor.getEngine(i) != nullptr)
+                {
+                    std::array<float, 128> wreathSamples{};
+                    processor.getWaveformFifo(i).readLatest(wreathSamples.data(), 128);
+                    float slotRms = 0.0f;
+                    for (int s = 64; s < 128; ++s)
+                        slotRms += wreathSamples[static_cast<size_t>(s)] * wreathSamples[static_cast<size_t>(s)];
+                    slotRms = std::sqrt(slotRms / 64.0f);
+                    oceanView_.pushSlotWaveData(i, wreathSamples.data(), 128, slotRms);
+                }
+            }
+        };
         oceanView_.onEngineSelectedFromDrawer = [this](const juce::String& engineId)
         {
             // If a slot is explicitly selected, always replace it directly.
@@ -1680,6 +1704,26 @@ public:
             const auto& sp = processor.getSlotPreset(i);
             oceanView_.setOrbitPresetName(i, sp.name);
         }
+
+        // F2-006: Restore OceanView ViewState from session.  Uses a one-tick deferred
+        // call so OceanView layout is fully settled before any state transition.
+        {
+            const int restoredState = proc.getPersistedOceanViewState();
+            const int restoredSlot  = proc.getPersistedOceanViewSlot();
+            // Only restore non-trivial states — Orbital (0) is the default and needs no action.
+            if (restoredState == 1 && restoredSlot >= 0) // ZoomIn
+            {
+                // F2-015: Schedule zoom-in so the first layout pass has completed.
+                juce::Timer::callAfterDelay(50,
+                    [safeThis = juce::Component::SafePointer<XOceanusEditor>(this), restoredSlot]()
+                    {
+                        if (safeThis != nullptr)
+                            safeThis->oceanView_.requestZoomIn(restoredSlot);
+                    });
+            }
+            // SplitTransform (2) and BrowserOpen (3) are not restored — too complex and
+            // rarely persisted intentionally; users re-enter them manually.
+        }
     }
 
     ~XOceanusEditor() override
@@ -1689,6 +1733,16 @@ public:
         // #1356: Unsubscribe from per-slot preset change notifications before teardown.
         processor.removeSlotPresetListener(this);
         processor.onEngineChanged = nullptr; // prevent callback after editor is destroyed
+
+        // F2-001 (CRIT): Null TideWaterline + MIDILearn callbacks before members are
+        // destroyed.  DAW may call getStateInformation() after editor close — these
+        // lambdas capture local pointers and would be UAF without the null-out.
+        processor.onGetTideWaterlineState = nullptr;
+        processor.onSetTideWaterlineState = nullptr;
+
+        // F2-004 (CRIT): Null MIDILearnManager learn-complete callback.
+        // The callback captures `this` (editor) — null it out before teardown.
+        processor.getMIDILearnManager().setLearnCompleteCallback({});
 
         // #1379: Remove Starboard listeners before any member is destroyed.
         // Order mirrors registration in initOceanView (reversed for safety).
@@ -1797,6 +1851,13 @@ public:
                 return true;
             }
             showOverview();
+            return true;
+        }
+        // F2-014: Cmd+S — save current preset (mirrors the SAVE button in the sidebar).
+        if (key == juce::KeyPress('s', juce::ModifierKeys::commandModifier, 0))
+        {
+            if (oceanView_.onSavePreset)
+                oceanView_.onSavePreset();
             return true;
         }
         // Cmd+Z — undo last parameter change or preset load
@@ -2700,16 +2761,8 @@ private:
 
                     oceanView_.setVoiceCount(i, newVoices);
 
-                    // Step 8a: Push waveform data to buoy wreath.
-                    {
-                        std::array<float, 128> wreathSamples {};
-                        processor.getWaveformFifo(i).readLatest(wreathSamples.data(), 128);
-                        float slotRms = 0.0f;
-                        for (int s = 64; s < 128; ++s)
-                            slotRms += wreathSamples[static_cast<size_t>(s)] * wreathSamples[static_cast<size_t>(s)];
-                        slotRms = std::sqrt(slotRms / 64.0f);
-                        oceanView_.pushSlotWaveData(i, wreathSamples.data(), 128, slotRms);
-                    }
+                    // Step 8a: Waveform data is now pushed via oceanView_.onPullWaveformData
+                    // (F2-012) from OceanView's 30Hz timer — removed from here (10Hz).
 
                     if (zone == EngineOrbit::DepthZone::Sunlit)   hasSunlit   = true;
                     if (zone == EngineOrbit::DepthZone::Twilight)  hasTwilight = true;

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -3270,6 +3270,19 @@ void XOceanusProcessor::getStateInformation(juce::MemoryBlock& destData)
         xml->setAttribute("editorSignalFlowSection", persistedSignalFlowSection);
         xml->setAttribute("editorCockpitBypass", persistedCockpitBypass ? 1 : 0);
 
+        // F2-002: Persist atomic settings so session recall restores them correctly.
+        // Without this, polyphony/voiceMode/midiChannel/oversampling reset to defaults
+        // on every DAW session reload.
+        xml->setAttribute("polyphony",    polyphonyCap_.load());
+        xml->setAttribute("voiceMode",    voiceMode_.load());
+        xml->setAttribute("midiChannel",  midiChannel_.load());
+        xml->setAttribute("oversampling", oversamplingFactor_.load());
+
+        // F2-006: Persist OceanView ViewState + zoomed slot so DAW session recall
+        // restores the user's last navigation state.
+        xml->setAttribute("oceanViewState", persistedOceanViewState_);
+        xml->setAttribute("oceanViewSlot",  persistedOceanViewSlot_);
+
         // D4 — Save register lock + current register (per-instance, per-session).
         xml->setAttribute("registerLocked",  persistedRegisterLocked  ? 1 : 0);
         xml->setAttribute("registerCurrent", persistedRegisterCurrent);
@@ -3493,6 +3506,18 @@ void XOceanusProcessor::setStateInformation(const void* data, int sizeInBytes)
         // Clamp to valid range (0=Gallery, 1=Performance, 2=Coupling).
         if (persistedRegisterCurrent < 0 || persistedRegisterCurrent > 2)
             persistedRegisterCurrent = 0;
+
+        // F2-002: Restore atomic settings.  Defaults match init values so old sessions
+        // (predating F2-002) are safe — they simply reload as defaults.
+        polyphonyCap_.store(xml->getIntAttribute("polyphony",    16));
+        voiceMode_.store(xml->getIntAttribute("voiceMode",       0));
+        midiChannel_.store(xml->getIntAttribute("midiChannel",   0));
+        oversamplingFactor_.store(xml->getIntAttribute("oversampling", 0));
+
+        // F2-006: Restore OceanView ViewState + slot.
+        // Default 0 (Orbital) and -1 (no slot) match OceanView's initial state.
+        persistedOceanViewState_ = xml->getIntAttribute("oceanViewState", 0);
+        persistedOceanViewSlot_  = xml->getIntAttribute("oceanViewSlot",  -1);
 
         // #1378 — Restore per-slot preset names.
         // Only the name field is round-tripped; all other PresetData fields remain

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -563,6 +563,13 @@ public:
     void setPersistedRegisterCurrent(int r) noexcept { persistedRegisterCurrent = r; }
     int  getPersistedRegisterCurrent() const noexcept { return persistedRegisterCurrent; }
 
+    // F2-006: OceanView ViewState + zoomed slot persistence.
+    // Written by OceanView's onStateEntered callback (message thread only).
+    void setPersistedOceanViewState(int state) noexcept { persistedOceanViewState_ = state; }
+    int  getPersistedOceanViewState() const noexcept    { return persistedOceanViewState_; }
+    void setPersistedOceanViewSlot(int slot)  noexcept  { persistedOceanViewSlot_  = slot;  }
+    int  getPersistedOceanViewSlot()  const noexcept    { return persistedOceanViewSlot_;  }
+
     // #1179 — TideWaterline deferred state pickup.
     // OceanView calls this in initWaterline() to apply state that arrived via
     // setStateInformation() before the editor window was first opened.
@@ -1057,6 +1064,8 @@ private:
     bool persistedCockpitBypass = false; // #357: Dark Cockpit bypass state
     bool persistedRegisterLocked = false; // D4: register lock toggle
     int  persistedRegisterCurrent = 0;   // D4: current register index (0=Gallery, 1=Performance, 2=Coupling)
+    int  persistedOceanViewState_ = 0;   // F2-006: OceanView ViewState (0=Orbital,1=ZoomIn,2=Split,3=Browser)
+    int  persistedOceanViewSlot_  = -1;  // F2-006: slot index when ViewState is ZoomIn/Split
 
     // ── #1178: TideWaterline deferred step-sequence state ────────────────────
     // Holds the "TideWaterlineSteps" tree from setStateInformation() when the


### PR DESCRIPTION
## Summary

Phase 5 Wave 2 audit — 15 fixes across lifecycle safety, session serialization, and state restoration:

- **F2-001 (CRIT)**: Null `onGetTideWaterlineState`/`onSetTideWaterlineState` + XOuija callbacks at editor destruction — prevents UAF when DAW calls `getStateInformation()` after editor close
- **F2-002 (CRIT)**: Persist `polyphonyCap_`, `voiceMode_`, `midiChannel_`, `oversamplingFactor_` atomics to session XML — these were silently reset to defaults on every DAW session reload
- **F2-004 (CRIT)**: Null `MIDILearnManager.setLearnCompleteCallback({})` at editor destruction
- **F2-006 (HIGH)**: Add `onViewStateChanged` callback + `requestZoomIn()` public API on OceanView; persist ViewState+slot to processor; restore on editor open
- **F2-008 (HIGH)**: `EngineOrbit::stepAnimation()` polls `isDragging_` vs `MouseSource.isDragging()` to recover from OS-yanked capture (JUCE has no `mouseLostCapture()`)
- **F2-009 (HIGH)**: `CouplingSubstrate::timerCallback()` early-return guard `if (!isShowing()) return`
- **F2-011 (HIGH)**: `TideWaterline::toValueTree()`/`fromValueTree()` now persists `expanded_` state
- **F2-012 (HIGH)**: Move wreath data push from editor 10Hz timer to OceanView 30Hz timer via new `onPullWaveformData` callback — wreath now syncs with animation at correct rate
- **F2-013 (MED)**: `OceanView::mouseExit()` cancels in-progress coupling chain
- **F2-014 (MED)**: Cmd+S triggers save-preset dialog via existing `onSavePreset` callback
- **F2-015 (MED)**: Session restore triggers `requestZoomIn()` via `callAfterDelay(50ms)` after init
- **F2-016 (MED)**: `SettingsDrawer::applySettings()`/`saveSettings()` persists `isOpen()` state
- **F2-017 (MED)**: Already correct — C2 comment verified at line 89, no change needed
- **F2-018 (MED)**: `DotMatrixDisplay` dirty-flag — each push method sets `dataDirty_`; timer only repaints when dirty or display is active (breathing animation preserved)
- **F2-020 (MED)**: `positionSaveCountdown_` uses `getTimerInterval()` instead of hardcoded `1000/30`
- **F2-021 (MED)**: `jassert(MessageThread)` in `EngineOrbit::setWreathData()`

## Build / validation
- AU build: 0 errors, 0 new warnings (all pre-existing unused-parameter warnings in engine files)
- AUVAL: **PASS** (`auval -v aumu Xocn XoOx`)

## Architecture notes
- **F2-006**: Editor↔processor channel did NOT pre-exist for ViewState — added `persistedOceanViewState_`/`persistedOceanViewSlot_` ints to processor + getter/setter pair + `onViewStateChanged` callback on OceanView. Follows exact same pattern as `persistedSelectedSlot` (FIX 9 / #357).
- **F2-014**: Existing save-preset entry point is `oceanView_.onSavePreset` (std::function wired in `initSidebarAndWiring`).
- **F2-008**: JUCE `Component` has no `mouseLostCapture()` virtual; polling in `stepAnimation()` is the correct JUCE idiom for this scenario.

## Test plan
- [ ] Open DAW session with ZoomIn on slot 2; close + reopen editor; verify slot 2 is zoomed in
- [ ] Set polyphony=8, voiceMode=Mono, MIDI channel=5, oversampling=2x; reload session; verify values restored
- [ ] Open editor, drag an orbit, Alt+Tab mid-drag; verify orbit snaps back (no stuck drag state)
- [ ] Chain mode: click first slot, move cursor outside OceanView; verify chain ghost disappears
- [ ] Cmd+S in editor opens save-preset dialog
- [ ] Open SettingsDrawer; reload session; verify drawer is open on reload
- [ ] Expand TideWaterline; reload session; verify expanded state restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)