### PR TITLE
feat: T5 Aftertouch mod source — wire channel pressure into mod-matrix eval loop (Path B Phase 2)

### DIFF
--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -1930,6 +1930,17 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                 modWheelValue_ = static_cast<float>(msg.getControllerValue()) / 127.0f;
             }
 
+            // Channel Pressure (Aftertouch): latch global scalar for the mod-matrix eval loop.
+            // Most-recent pressure event per block wins (mirrors ModWheel latch policy; pressure
+            // events arrive infrequently so sub-block overwrite is not a jitter risk).
+            // The value persists across blocks (held until next channel-pressure event arrives).
+            // Channel pressure is NOT filtered here — it still passes through to all slot MIDI
+            // buffers so engines that handle aftertouch internally continue to function.
+            if (msg.isChannelPressure())
+            {
+                aftertouchValue_ = static_cast<float>(msg.getChannelPressureValue()) / 127.0f;
+            }
+
             if (msg.isControllerOfType(64))
             {
                 const int ch = msg.getChannel() - 1; // 0-based
@@ -2442,8 +2453,18 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     // a ready-to-apply normalised offset without extra per-voice scaling.
                     srcVal = modWheelValue_;
                 }
+                else if (snap.sourceId == static_cast<int>(ModSourceId::Aftertouch))
+                {
+                    // T5: Aftertouch (channel pressure, 0xD0) is a global scalar — identical
+                    // strategy to ModWheel (Strategy 1).  aftertouchValue_ is latched from
+                    // channel-pressure events in the MIDI scan loop above (audio-thread-only
+                    // float, 0.0–1.0).  routeModAccum_[ri] receives the full modOffset
+                    // (srcVal * depth) — no engine-side multiply needed.
+                    // Completes the T5 mod-source trio: Velocity + ModWheel + Aftertouch.
+                    srcVal = aftertouchValue_;
+                }
                 else
-                    continue; // TODO(#mod-source-completion): add remaining sources (Aftertouch next)
+                    continue; // TODO(#mod-source-completion): add remaining sources
 
                 // Bipolar: use != 0 check so negative depths sweep downward.
                 if (snap.depth == 0.0f)

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -975,6 +975,15 @@ private:
     // Audio-thread-only; no atomics needed.
     float modWheelValue_{0.0f};
 
+    // ── Channel Pressure (Aftertouch) — block-latched scalar (audio thread only) ──
+    // aftertouchValue_: 0.0–1.0, latched from channel-pressure (0xD0) events.
+    // Latch policy mirrors modWheelValue_: most-recent event per block wins
+    // (no first-only guard — channel pressure events are rare relative to CC1,
+    // so sub-block jitter is not a practical concern; simpler to just overwrite).
+    // Persistent across blocks — retains last value until next pressure event.
+    // Audio-thread-only; no atomics needed.
+    float aftertouchValue_{0.0f};
+
     // ── CC64 sustain pedal — fleet-wide hold (audio thread only) ─────────────
     // sustainHeld_[ch]: true while CC64 >= 64 on MIDI channel ch (0-based).
     // sustainPendingNoteOffs_[slot][ch]: bitmask of notes (0–127) whose note-off


### PR DESCRIPTION
## Summary

- Latches MIDI channel pressure (0xD0, Aftertouch) into `aftertouchValue_` — a plain `float` audio-thread member alongside the existing `modWheelValue_` CC1 latch
- Adds a `ModSourceId::Aftertouch` branch in the eval loop's source dispatch, replacing the `else continue` dead-fall that was silently dropping all Aftertouch routes
- Aftertouch uses **Strategy 1 (global scalar)**: `srcVal = aftertouchValue_` falls through to the generic `srcVal * depth` path, writing the full `modOffset` to `routeModAccum_[ri]` — no engine-side multiply, no new snapshot tag
- Channel pressure events still pass through to all slot MIDI buffers; engines that consume aftertouch internally are unaffected
- **Completes the T5 mod-source trio**: Velocity (#1391) + ModWheel (#1473) + Aftertouch (this PR)

## Files Changed

| File | Change |
|------|--------|
| `Source/XOceanusProcessor.h` | +9 lines — `aftertouchValue_` member with comment block, placed after `modWheelValue_` |
| `Source/XOceanusProcessor.cpp` | +22 lines, -1 line — channel-pressure latch in MIDI scan loop + Aftertouch eval-loop branch |

## Latch Policy Note

ModWheel uses a first-only guard (ignores late CC1 events within the block to avoid sub-block jitter). Aftertouch uses **most-recent wins** — no first-only guard. Rationale: channel pressure events arrive far less frequently than CC1 events, so overwriting mid-block is not a practical jitter risk, and the simpler code is correct for the usage pattern.

## DSP Safety

- No allocation: `aftertouchValue_` is a POD float, zero heap impact
- No blocking I/O / locks / logging: plain float read/write, audio-thread-only
- No new atomics: value is written and read exclusively on the audio thread
- `isChannelPressure()` / `getChannelPressureValue()` — JUCE canonical API

## Precedents

- **PR #1391** — T5 Velocity mod source (Strategy 2, engine-side multiply)
- **PR #1473** — T5 ModWheel mod source (Strategy 1, global scalar — immediate template)

## Test Plan

- [x] Build green: `cmake --build .wt/aftertouch/build --target XOceanus_AU -j10` — 0 errors; AU installed
- [ ] CI green (auto)
- [ ] T6 engine opt-in PRs for engines consuming Aftertouch routes

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)