### PR TITLE
feat(XOuija): register pin axes as ModSources via SlotModSourceRegistry (#1383 A1)

### DIFF
--- a/Source/UI/PlaySurface/PlaySurface.h
+++ b/Source/UI/PlaySurface/PlaySurface.h
@@ -1547,6 +1547,10 @@ public:
             processor_->onSetXOuijaState = nullptr;
         }
 
+        // #1383 part 1 — clear pin→registry bridge before swapping processor so
+        // the old processor never receives a callback after it is detached.
+        xouijaPanel_.getPinStore().onPinChanged = nullptr;
+
         processor_ = p;
         // Re-wire the onCCOutput callback now that we have the processor.
         wireOnCCOutput();
@@ -1565,6 +1569,23 @@ public:
         processor_->onGetXOuijaState = [this]() -> juce::ValueTree { return xouijaPanel_.toValueTree(); };
 
         processor_->onSetXOuijaState = [this](const juce::ValueTree& tree) { xouijaPanel_.fromValueTree(tree); };
+
+        // #1383 part 1 — XOuija pin → ModSource registry bridge.
+        // Each time the user pins/moves/unpins the XOuija planchette, the bipolar
+        // [-1,+1] (X, Y) values are pushed into SlotModSourceRegistry via an
+        // atomic store so the audio thread can read them from processBlock() as
+        // ModSourceId::XouijaCell (ID 18, preset-serialisation-stable).
+        //
+        // Message-thread safety: onPinChanged fires on the JUCE message thread
+        // (same thread as all UI callbacks); SlotModSourceRegistry::updateSourceValue
+        // uses std::atomic<float> relaxed stores — no locks, no GUI includes on
+        // the audio side.  A one-block-late value is acceptable for a continuous
+        // mod source (same policy as ModWheel / XY surface).
+        xouijaPanel_.getPinStore().onPinChanged = [this](float bx, float by)
+        {
+            processor_->getModSourceRegistry()
+                       .updateSourceValue(ModSourceId::XouijaCell, bx, by);
+        };
 
         // If the processor already has saved XOuija state in its APVTS tree
         // (e.g. setStateInformation was called before the PlaySurface window

--- a/Source/UI/PlaySurface/XouijaPinStore.h
+++ b/Source/UI/PlaySurface/XouijaPinStore.h
@@ -13,9 +13,10 @@
 // Coordination notes:
 //   - D1 (cell layers) reads XouijaPinStore to decorate cell badge overlays.
 //   - D2 (mood) reads targetSlot to determine per-engine mood filter.
-//   - C5 (slot-based ModSources): when C5 lands, hook XouijaPinStore::onPinChanged
-//     into the C5 SlotModSourceRegistry.  Until then, the live pin value is exposed
-//     via getPinnedCircleX() / getPinnedInfluenceY() for polling.
+//   - C5 (SlotModSourceRegistry, #1360 SHIPPED): XouijaPinStore::onPinChanged is
+//     wired in PlaySurface::setProcessor() to push bipolar X+Y values into
+//     SlotModSourceRegistry → processBlock reads them as ModSourceId::XouijaCell.
+//     See #1383 for the wiring implementation.
 //   - ModRoutingModel: call pinStore.registerWithModRouter(modModel) to create a
 //     live ModSourceId::XouijaCell route entry that tracks the pinned values.
 //
@@ -232,10 +233,14 @@ public:
     void removeListener(juce::ChangeListener* l) { broadcaster_.removeChangeListener(l); }
 
     //==========================================================================
-    // Callback for C5 integration (optional — set before using pin as ModSource).
+    // Callback for SlotModSourceRegistry bridge (#1383, closes wiring-sweep TODO).
     //
     // Fires whenever the pinned value changes (pin / unpin / position update).
-    // Wire this in PlaySurface::setProcessor() (or equivalent host site) as:
+    // When pinned, bx/by carry the bipolar [-1,+1] planchette position.
+    // When unpinned, bx=0/by=0 so the registry resets to neutral and no stale
+    // modulation leaks from the last pin position.
+    //
+    // Wired in PlaySurface::setProcessor():
     //
     //   xouijaPanel_.getPinStore().onPinChanged =
     //       [this](float bx, float by) {
@@ -243,11 +248,11 @@ public:
     //               .updateSourceValue(ModSourceId::XouijaCell, bx, by);
     //       };
     //
-    // SlotModSourceRegistry is implemented in Source/Core/SlotModSourceRegistry.h.
-    // The registry forwards bx/by to std::atomic<float> pairs read by processBlock
-    // as ModSourceId::XouijaCell (ID 18, frozen for preset serialisation).
+    // SlotModSourceRegistry (Source/Core/SlotModSourceRegistry.h) stores bx/by in
+    // std::atomic<float> pairs read lock-free from processBlock as
+    // ModSourceId::XouijaCell (ID 18, frozen for preset serialisation).
     //
-    // bx / by are bipolar [-1, +1].
+    // bx / by are bipolar [-1, +1].  Message-thread only.
     //
     std::function<void(float /*bx*/, float /*by*/)> onPinChanged;
 
@@ -295,8 +300,16 @@ private:
     void notifyListeners()
     {
         broadcaster_.sendChangeMessage();
-        if (isPinned_ && onPinChanged)
-            onPinChanged(getPinnedCircleX(), getPinnedInfluenceY());
+        if (onPinChanged)
+        {
+            // When pinned, forward the bipolar [-1,+1] position.
+            // When unpinned, send (0,0) so the registry resets to neutral
+            // and does not apply stale modulation from the last pin position.
+            if (isPinned_)
+                onPinChanged(getPinnedCircleX(), getPinnedInfluenceY());
+            else
+                onPinChanged(0.0f, 0.0f);
+        }
     }
 
     // Live pin state


### PR DESCRIPTION
## Summary

Closes the store-domain slice of #1383 (XOuija → ModSource bridge, A1).

- **XouijaPinStore.notifyListeners()**: `onPinChanged` now fires unconditionally (was gated on `isPinned_`). When unpinned it sends `(0.0f, 0.0f)` so `SlotModSourceRegistry` resets to neutral — prevents stale modulation leaking from the last pinned position.
- **PlaySurface.setProcessor()**: wires `xouijaPanel_.getPinStore().onPinChanged` → `processor_->getModSourceRegistry().updateSourceValue(ModSourceId::XouijaCell, bx, by)`. Uses `std::atomic<float>` relaxed stores (lock-free, audio-safe). Callback is nulled out before each processor swap so the old processor never receives callbacks after detach.
- **Header/doc cleanup**: stale "when C5 lands" future-tense comment replaced with "C5 (#1360) SHIPPED"; `onPinChanged` doc clarifies the unpin-resets-to-zero contract and that this is message-thread only.

## Architecture notes

- No allocations on the audio thread — registry stores values in pre-existing `std::atomic<float>` pairs.
- Registration is stable: wired once per `setProcessor()` call, not on every paint/tick.
- `ModSourceId::XouijaCell = 18` is frozen (preset-serialisation-stable, #1360).
- Depth axis: the current `XouijaPinStore` design exposes X (circle-of-fifths) and Y (influence depth) as the two bipolar axes pushed into `SlotModSourceRegistry`. There is no separate "depth" capture slot beyond Y — no additional axis was needed.

## Slice boundaries

| Slice | Scope | Status |
|-------|-------|--------|
| **A1 (this PR)** | XouijaPinStore store + PlaySurface host wiring | Done |
| A2 | XOuijaPanel drag interactions publish into store | Sibling — not touched here |
| A3 | ModRouting picker UI shows XouijaCell as source | Sibling — not touched here |

## Test plan

- [ ] Pin XOuija planchette → `SlotModSourceRegistry::getXouijaCellX/Y()` returns non-zero
- [ ] Unpin → registry immediately returns `(0, 0)` (no stale modulation)
- [ ] Swap processor (simulate DAW track bounce) → no crash, new processor receives callbacks
- [ ] `setProcessor(nullptr)` → `onPinChanged` is null before processor swap completes

## Auditor flags

- A2 (XOuijaPanel drag publish) should call `pinStore_.pin(x, y)` on drag-move while pinned to keep the registry live during continuous drag. That publish path is A2's scope.
- `fromValueTree()` calls `notifyListeners()` at restore time — this will now fire `onPinChanged` if the callback is already wired when state is restored. This is correct behaviour (registry should reflect saved state), but auditors should confirm the restore ordering in `setProcessor()` (currently: wire callback → restore state, which is the right order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)