### PR TITLE
feat(ModRouting): expose XOuija sources in ModSource picker (#1383 A3)

### DIFF
--- a/Source/Future/UI/ModRouting/ModMatrixBreakout.h
+++ b/Source/Future/UI/ModRouting/ModMatrixBreakout.h
@@ -583,6 +583,10 @@ private:
         { 15, 0xFF81D4FA }, // Seq Step
         { 16, 0xFFF48FB1 }, // Chord Tone
         { 17, 0xFF80CBC4 }, // Beat Phase
+        // ── #1383: XOuija live sources ───────────────────────────────────
+        { 28, 0xFFB57BEA }, // XOuija X
+        { 29, 0xFF9B5FC0 }, // XOuija Y
+        { 30, 0xFF7B3FA0 }, // XOuija Depth
     };
 
     //==========================================================================

--- a/Source/Future/UI/ModRouting/ModSourceHandle.h
+++ b/Source/Future/UI/ModRouting/ModSourceHandle.h
@@ -68,7 +68,16 @@ enum class ModSourceId
     XYY1 = 25,   // XY surface Y-axis, slot 1 (bipolar)
     XYY2 = 26,   // XY surface Y-axis, slot 2 (bipolar)
     XYY3 = 27,   // XY surface Y-axis, slot 3 (bipolar)
-    Count = 28
+    // ── #1383: XOuija live position sources ─────────────────────────────────
+    // Live planchette position from XOuijaPanel published via SlotModSourceRegistry.
+    // X: horizontal axis (circle-of-fifths / harmonic position), bipolar [-1, +1].
+    // Y: vertical axis (tension / brightness), bipolar [-1, +1].
+    // Depth: influence/pressure value from XOuija cell intensity, unipolar [0, 1].
+    // Registry IDs (string keys): "xouija.x", "xouija.y", "xouija.depth"
+    XouijaX     = 28,  // XOuija planchette X position (bipolar)
+    XouijaY     = 29,  // XOuija planchette Y position (bipolar)
+    XouijaDepth = 30,  // XOuija influence / cell depth (unipolar)
+    Count = 31
 };
 
 // Human-readable names used in tooltips and the route list panel.
@@ -125,6 +134,10 @@ inline juce::String modSourceName(ModSourceId id)
     case ModSourceId::XYY1: return "XY Y (Slot 2)";
     case ModSourceId::XYY2: return "XY Y (Slot 3)";
     case ModSourceId::XYY3: return "XY Y (Slot 4)";
+    // ── #1383: XOuija live sources ───────────────────────────────────────────
+    case ModSourceId::XouijaX:     return "XOuija X / Planchette Position";
+    case ModSourceId::XouijaY:     return "XOuija Y / Vertical";
+    case ModSourceId::XouijaDepth: return "XOuija Depth / Influence";
     default:
         return "?";
     }
@@ -192,6 +205,13 @@ inline juce::Colour modSourceColour(ModSourceId id)
     case ModSourceId::XYY2:
     case ModSourceId::XYY3:
         return juce::Colour(0xFF2A7FA5); // deep ocean blue — Y axis
+    // ── #1383: XOuija live sources — mystic violet/plum palette ─────────────
+    case ModSourceId::XouijaX:
+        return juce::Colour(0xFFB57BEA); // violet — horizontal planchette axis
+    case ModSourceId::XouijaY:
+        return juce::Colour(0xFF9B5FC0); // deeper violet — vertical axis
+    case ModSourceId::XouijaDepth:
+        return juce::Colour(0xFF7B3FA0); // dark plum — influence depth (unipolar)
     default:
         return juce::Colour(GalleryColors::xoGold);
     }
@@ -364,6 +384,16 @@ public:
             break;
         case ModSourceId::XouijaCell:
             glyph = "Y"; // "Y" for ouiJa — avoids ambiguity with Q=seq, J=none
+            break;
+        // ── #1383: XOuija live position sources ─────────────────────────────
+        case ModSourceId::XouijaX:
+            glyph = "X"; // X axis
+            break;
+        case ModSourceId::XouijaY:
+            glyph = "y"; // lowercase y — distinct from XouijaX
+            break;
+        case ModSourceId::XouijaDepth:
+            glyph = "d"; // depth
             break;
         default:
             glyph = "?";

--- a/Source/Future/UI/ModRouting/ModulateFromMenu.h
+++ b/Source/Future/UI/ModRouting/ModulateFromMenu.h
@@ -22,12 +22,13 @@
 // from mouseDown when e.mods.isRightButtonDown(). See XOceanusEditor.h.
 //
 // ────────────────────────────────────────────────────────────────────────────
-// Extended source list (D9 F4 + G3 spec)
+// Extended source list (D9 F4 + G3 spec + #1383 XOuija live sources)
 //
-// ModSourceId in ModSourceHandle.h now defines all 18 sources (IDs 0–17)
-// matching spec D9 F4 + G3. All entries in kAllModSources below have valid
-// enum values and are routable via ModRoutingModel. The "extended" sentinel
-// logic (id >= Count) no longer applies — Count is now 18.
+// ModSourceId in ModSourceHandle.h defines all sources (IDs 0–17 original,
+// 28–30 XOuija live, Count = 31) matching spec D9 F4 + G3 plus #1383.
+// All entries in kAllModSources below have valid enum values and are routable
+// via ModRoutingModel. The "extended" sentinel logic (id >= Count) no longer
+// applies — Count is now 31 (after #1383).
 //
 #pragma once
 
@@ -51,8 +52,8 @@ struct ExtModSourceInfo
 };
 
 //==============================================================================
-// Full source catalogue — matches spec D9 F4 + G3.
-// All 18 sources have valid ModSourceId enum values (Count = 18).
+// Full source catalogue — matches spec D9 F4 + G3, extended for #1383 XOuija.
+// All sources have valid ModSourceId enum values (Count = 31 after #1383).
 // All are routable via ModRoutingModel (which stores int sourceId).
 //
 // JUCE PopupMenu item IDs start at 1.  We encode id + 1 as the JUCE item ID
@@ -88,6 +89,13 @@ static const ExtModSourceInfo kAllModSources[] = {
     { 15, "Seq Step Value",  "Musical",   true,  0xFF81D4FA },
     { 16, "Chord Tone Idx",  nullptr,     false, 0xFFF48FB1 },
     { 17, "Beat Phase",      nullptr,     true,  0xFF80CBC4 },
+
+    // ── XOuija (#1383) ────────────────────────────────────────────────────
+    // Live planchette position published by XOuijaPanel via SlotModSourceRegistry.
+    // Registry string keys: "xouija.x", "xouija.y", "xouija.depth"
+    { 28, "XOuija X / Planchette Position", "XOuija", true,  0xFFB57BEA },
+    { 29, "XOuija Y / Vertical",             nullptr,  true,  0xFF9B5FC0 },
+    { 30, "XOuija Depth / Influence",        nullptr,  false, 0xFF7B3FA0 },
 };
 
 static constexpr int kNumModSources = static_cast<int>(sizeof(kAllModSources) / sizeof(kAllModSources[0]));


### PR DESCRIPTION
## Summary

- Adds `XouijaX` (ID=28), `XouijaY` (ID=29), `XouijaDepth` (ID=30) to `ModSourceId` enum in `ModSourceHandle.h`, with `Count` advancing from 28 → 31.
- Wires all three into `modSourceName()`, `modSourceColour()`, and the `ModSourceHandle` glyph switcher.
- Surfaces all three in `ModulateFromMenu::kAllModSources` under a dedicated **"XOuija"** group section.
- Adds colour entries to `ModMatrixBreakout::kAllModSourcesForStrip` so the strip chips light up in the right violet/plum colour when an XOuija route is active.
- Fixes a stale preamble comment in `ModulateFromMenu.h` that still said `Count is now 18`.

## Exact label strings (single source of truth: `modSourceName()` in `ModSourceHandle.h`)

| `ModSourceId` | ID | Label | Bipolar |
|---|---|---|---|
| `XouijaX` | 28 | `"XOuija X / Planchette Position"` | yes |
| `XouijaY` | 29 | `"XOuija Y / Vertical"` | yes |
| `XouijaDepth` | 30 | `"XOuija Depth / Influence"` | no (unipolar) |

Colours: violet family — 0xFFB57BEA / 0xFF9B5FC0 / 0xFF7B3FA0.

## Runtime gate

This PR only adds UI-side enum entries and picker metadata. The actual live values are **not available until A1+A2 land** and `SlotModSourceRegistry` is extended to store `xouija.x`, `xouija.y`, `xouija.depth` atomics (currently the registry only holds `XouijaCell` / `ouijaCellX_` + `ouijaCellY_`). Until then, these sources will appear in the picker and matrix but will return 0.0f at the audio thread.

## Files touched

- `Source/Future/UI/ModRouting/ModSourceHandle.h` — enum IDs, names, colours, glyphs
- `Source/Future/UI/ModRouting/ModulateFromMenu.h` — kAllModSources catalogue + stale comment fix
- `Source/Future/UI/ModRouting/ModMatrixBreakout.h` — kAllModSourcesForStrip colour table

No changes to `PlaySurface.h`, `XOuijaPanel.h`, or `XouijaPinStore.h` (A1/A2 territory).

## Test plan

- [ ] Confirm three new items appear under "XOuija" section heading in the right-click "Modulate from…" menu
- [ ] Confirm drag handles for IDs 28/29/30 render with violet/plum colours in the ModMatrixPanel source strip
- [ ] Confirm strip chips show violet dots when XOuija routes are active
- [ ] Confirm tooltip labels read exactly "XOuija X / Planchette Position", "XOuija Y / Vertical", "XOuija Depth / Influence"
- [ ] After A1+A2 land: drag XOuija pin → verify mod target moves in real time (ear test prerequisite: surrounding UI scaffolding must be present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)