### PR TITLE
feat(XOuija): publish planchette drag to XouijaPinStore (#1383 A2)

### DIFF
--- a/Source/UI/PlaySurface/PlaySurface.h
+++ b/Source/UI/PlaySurface/PlaySurface.h
@@ -1556,6 +1556,10 @@ public:
             // Detaching: clear the bridge callbacks so the processor doesn't hold
             // dangling references to this PlaySurface after it is destroyed.
             // (processor itself may outlive the PlaySurface window)
+            //
+            // feat(#1383): also null out the pin→registry bridge so XouijaPinStore
+            // doesn't try to call into a dead processor after the editor closes.
+            xouijaPanel_.getPinStore().onPinChanged = nullptr;
             return;
         }
 
@@ -1565,6 +1569,26 @@ public:
         processor_->onGetXOuijaState = [this]() -> juce::ValueTree { return xouijaPanel_.toValueTree(); };
 
         processor_->onSetXOuijaState = [this](const juce::ValueTree& tree) { xouijaPanel_.fromValueTree(tree); };
+
+        // feat(#1383) Wave5-C5: Wire XouijaPinStore pin changes into SlotModSourceRegistry.
+        //
+        // When the user pins the XOuija planchette (right-click → "Pin as ModSource"),
+        // XouijaPinStore fires onPinChanged with bipolar (bx, by) in [-1, +1].
+        // This lambda pushes those values into the processor's lock-free atomic registry
+        // so the audio thread can read them from processBlock() as ModSourceId::XouijaCell.
+        //
+        // IDs: "xouija.x" maps to ouijaCellX_, "xouija.y" maps to ouijaCellY_
+        // (both frozen as ModSourceId::XouijaCell = 18 per SlotModSourceRegistry.h).
+        //
+        // Thread safety: onPinChanged fires on the message thread; updateSourceValue()
+        // writes only to std::atomic<float> with relaxed ordering — no mutex, no alloc,
+        // safe to call while the audio thread reads concurrently.
+        xouijaPanel_.getPinStore().onPinChanged =
+            [this](float bx, float by)
+            {
+                processor_->getModSourceRegistry()
+                    .updateSourceValue(ModSourceId::XouijaCell, bx, by);
+            };
 
         // If the processor already has saved XOuija state in its APVTS tree
         // (e.g. setStateInformation was called before the PlaySurface window

--- a/Source/UI/PlaySurface/XOuijaPanel.h
+++ b/Source/UI/PlaySurface/XOuijaPanel.h
@@ -1447,10 +1447,11 @@ public:
     // Wave5-D3: XouijaPinStore access
     //
     // D1 (cell layers), D2 (mood), and C5 (slot ModSources) all read/write
-    // the pin store via this reference.
+    // the pin store via this reference.  The panel owns the store; it does NOT
+    // directly publish to SlotModSourceRegistry.  All publishing goes through
+    // the store's onPinChanged callback, which is wired externally.
     //
-    // C5 wiring (#1360) — call in PlaySurface::setProcessor() after the
-    // processor pointer is valid:
+    // feat(#1383): C5 wiring is LIVE — PlaySurface::setProcessor() installs:
     //
     //   xouijaPanel_.getPinStore().onPinChanged =
     //       [this](float bx, float by) {
@@ -1458,8 +1459,10 @@ public:
     //               .updateSourceValue(ModSourceId::XouijaCell, bx, by);
     //       };
     //
-    // SlotModSourceRegistry lives in Source/Core/SlotModSourceRegistry.h.
-    // XOceanusProcessor exposes it via getModSourceRegistry().
+    // IDs: "xouija.x" (bx) and "xouija.y" (by), both exposed as
+    // ModSourceId::XouijaCell (ID 18, frozen for preset serialisation).
+    // SlotModSourceRegistry: Source/Core/SlotModSourceRegistry.h.
+    // XOceanusProcessor exposes the registry via getModSourceRegistry().
     //==========================================================================
     XouijaPinStore& getPinStore() noexcept { return pinStore_; }
     const XouijaPinStore& getPinStore() const noexcept { return pinStore_; }


### PR DESCRIPTION
## Summary

- Wires `XouijaPinStore::onPinChanged` → `SlotModSourceRegistry::updateSourceValue()` in `PlaySurface::setProcessor()`, completing the #1383 A2 slice.
- Installs the callback when a valid processor is attached; nulls it on detach (processor=nullptr path) so no dangling reference survives after the editor window closes.
- Updates the `XOuijaPanel.h` comment block to reflect C5 wiring is now live, not a future TODO.

## PlaySurface.h collision with A1's PR

**IMPORTANT:** Both this PR (A2) and A1's `feat/1383-xouija-pinstore` branch modify `Source/UI/PlaySurface/PlaySurface.h`. There will be a merge conflict at the `setProcessor()` call-site.

**Recommended merge order:** merge A1 first, then rebase this branch onto the updated main. The conflict is localized to the `setProcessor()` block and will resolve cleanly: A1 adds the store's own wiring (slot routing); this PR adds the `onPinChanged` callback installation and the detach-path null-out.

- A1 PR: (A1 sibling — `feat/1383-xouija-pinstore`, to be linked here when opened)
- This PR (A2): `feat/1383-xouija-panel-publish`

## Audio-thread safety guarantees

| Guarantee | Mechanism |
|-----------|-----------|
| No alloc on message thread | `onPinChanged` lambda captures `this` only; no heap ops |
| No alloc on audio thread | `getXouijaCellX/Y()` reads `std::atomic<float>` only |
| No mutex / lock | `std::atomic<float>` with `memory_order_relaxed` — one-block-late is acceptable for a continuous mod source |
| No dangling processor reference | Detach path (`processor_ == nullptr`) nulls `onPinChanged` before returning |
| No firing after editor destroy | `PlaySurface` destructor path hits `setProcessor(nullptr)` which nulls the callback |
| `onPinChanged` fires on message thread | `XouijaPinStore::notifyListeners()` is message-thread-only per store contract |
| Write-read ordering | Relaxed atomic store (message thread) / relaxed atomic load (audio thread) — safe because a one-block-late value is musically acceptable |

## Test plan

- [ ] Pin XOuija planchette (right-click → "Pin as ModSource") — verify `onPinChanged` fires and `SlotModSourceRegistry` receives bipolar values
- [ ] Unpin — verify registry receives (0, 0) via `notifyListeners()` path
- [ ] Close editor window — verify no crash (detach callback is null before processor outlives editor)
- [ ] Re-open editor with saved state — verify pin store restores correctly and callback re-installs
- [ ] Wire a mod route to `ModSourceId::XouijaCell` (ID 18) and confirm mod target moves when pin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)