### PR TITLE
fix(XOuija): reconcile ModSource IDs — A4 followup to #1479 #1480 #1481

### DIFF
--- a/Source/Core/SlotModSourceRegistry.h
+++ b/Source/Core/SlotModSourceRegistry.h
@@ -62,22 +62,21 @@ public:
     {
         ouijaCellX_.store(0.0f, std::memory_order_relaxed);
         ouijaCellY_.store(0.0f, std::memory_order_relaxed);
+        ouijaLiveX_.store(0.0f, std::memory_order_relaxed);
+        ouijaLiveY_.store(0.0f, std::memory_order_relaxed);
     }
 
     // Non-copyable, non-movable — owned by value in XOceanusProcessor.
-    SlotModSourceRegistry(const SlotModSourceRegistry&)            = delete;
+    SlotModSourceRegistry(const SlotModSourceRegistry&) = delete;
     SlotModSourceRegistry& operator=(const SlotModSourceRegistry&) = delete;
-    SlotModSourceRegistry(SlotModSourceRegistry&&)                 = delete;
-    SlotModSourceRegistry& operator=(SlotModSourceRegistry&&)      = delete;
+    SlotModSourceRegistry(SlotModSourceRegistry&&) = delete;
+    SlotModSourceRegistry& operator=(SlotModSourceRegistry&&) = delete;
 
     //==========================================================================
-    // updateSourceValue — message thread only.
-    //
-    // Called from UI-thread callbacks (e.g. XouijaPinStore::onPinChanged) to
-    // push new live values into the registry.  Values are bipolar [-1, +1].
-    //
-    // Only ModSourceId::XouijaCell is handled here; all other sources either
-    // live on the audio thread (sequencers) or are not yet implemented.
+    // updateSourceValue (two-float overload) — message thread only.
+    // Legacy overload for XouijaCell (ID=18): packs X+Y into one call.
+    // Kept for back-compat; PlaySurface also calls the single-float overload
+    // so new routes on XouijaX/Y IDs work independently.
     //
     void updateSourceValue(ModSourceId id, float bx, float by) noexcept
     {
@@ -86,38 +85,51 @@ public:
             ouijaCellX_.store(bx, std::memory_order_relaxed);
             ouijaCellY_.store(by, std::memory_order_relaxed);
         }
-        // Additional sources: add else-if branches as each lands.
+    }
+
+    // updateSourceValue (single-float overload) — message thread only.
+    // Handles XouijaX (ID=28) and XouijaY (ID=29) from #1383 A4.
+    //
+    void updateSourceValue(ModSourceId id, float value) noexcept
+    {
+        if (id == ModSourceId::XouijaX)
+            ouijaLiveX_.store(value, std::memory_order_relaxed);
+        else if (id == ModSourceId::XouijaY)
+            ouijaLiveY_.store(value, std::memory_order_relaxed);
     }
 
     //==========================================================================
     // Audio-thread read accessors — called from XOceanusProcessor::processBlock.
 
-    /// Pinned XOuija X-axis (circle-of-fifths), bipolar [-1, +1].
-    float getXouijaCellX() const noexcept
-    {
-        return ouijaCellX_.load(std::memory_order_relaxed);
-    }
+    /// Legacy XouijaCell X-axis (ID=18), bipolar [-1, +1].
+    float getXouijaCellX() const noexcept { return ouijaCellX_.load(std::memory_order_relaxed); }
 
-    /// Pinned XOuija Y-axis (influence depth), bipolar [-1, +1].
-    float getXouijaCellY() const noexcept
-    {
-        return ouijaCellY_.load(std::memory_order_relaxed);
-    }
+    /// Legacy XouijaCell Y-axis (ID=18), bipolar [-1, +1].
+    float getXouijaCellY() const noexcept { return ouijaCellY_.load(std::memory_order_relaxed); }
+
+    /// XouijaX (ID=28): live planchette X axis.  #1383 A4.
+    float getXouijaX() const noexcept { return ouijaLiveX_.load(std::memory_order_relaxed); }
+
+    /// XouijaY (ID=29): live planchette Y axis (influence depth).  #1383 A4.
+    float getXouijaY() const noexcept { return ouijaLiveY_.load(std::memory_order_relaxed); }
 
     //==========================================================================
     // reset — called from XOceanusProcessor::reset() / prepareToPlay().
-    // Clears all live values back to neutral (0.0f).  Audio-thread safe.
     void reset() noexcept
     {
         ouijaCellX_.store(0.0f, std::memory_order_relaxed);
         ouijaCellY_.store(0.0f, std::memory_order_relaxed);
+        ouijaLiveX_.store(0.0f, std::memory_order_relaxed);
+        ouijaLiveY_.store(0.0f, std::memory_order_relaxed);
     }
 
 private:
-    // XouijaCell (ModSourceId::XouijaCell = 18) — bipolar [-1, +1].
-    // Initialised to 0.0f so unconnected XouijaCell routes produce zero offset.
+    // XouijaCell (ID=18) — back-compat atomics, bipolar [-1, +1].
     std::atomic<float> ouijaCellX_{0.0f};
     std::atomic<float> ouijaCellY_{0.0f};
+    // XouijaX/Y (IDs=28/29) — per-axis atomics, #1383 A4.
+    std::atomic<float> ouijaLiveX_{0.0f};
+    std::atomic<float> ouijaLiveY_{0.0f};
 };
 
 } // namespace xoceanus

--- a/Source/Future/UI/ModRouting/ModMatrixBreakout.h
+++ b/Source/Future/UI/ModRouting/ModMatrixBreakout.h
@@ -49,13 +49,9 @@ public:
     // Animation speed: fraction of distance to cover per frame at 60 Hz.
     static constexpr float kSpringDecay = 0.72f;
 
-    explicit ModMatrixPanel(juce::AudioProcessorValueTreeState& apvts,
-                             ModRoutingModel& modModel,
-                             DragDropModRouter& router)
-        : apvts_(apvts)
-        , modModel_(modModel)
-        , router_(router)
-        , drawer_(apvts)
+    explicit ModMatrixPanel(juce::AudioProcessorValueTreeState& apvts, ModRoutingModel& modModel,
+                            DragDropModRouter& router)
+        : apvts_(apvts), modModel_(modModel), router_(router), drawer_(apvts)
     {
         setOpaque(false);
         setInterceptsMouseClicks(true, true);
@@ -82,17 +78,14 @@ public:
 
         // ── Close button ─────────────────────────────────────────────────
         closeButton_.setButtonText("CLOSE");
-        closeButton_.setColour(juce::TextButton::buttonColourId,
-                               juce::Colour(200, 204, 216).withAlpha(0.04f));
-        closeButton_.setColour(juce::TextButton::textColourOffId,
-                               juce::Colour(200, 204, 216).withAlpha(0.55f));
+        closeButton_.setColour(juce::TextButton::buttonColourId, juce::Colour(200, 204, 216).withAlpha(0.04f));
+        closeButton_.setColour(juce::TextButton::textColourOffId, juce::Colour(200, 204, 216).withAlpha(0.55f));
         closeButton_.onClick = [this]() { close(); };
         addAndMakeVisible(closeButton_);
 
         modModel_.addListener(this);
 
-        A11y::setup(*this, "Mod Matrix Panel",
-                    "Slide-up modulation matrix editor. Press Escape to close.");
+        A11y::setup(*this, "Mod Matrix Panel", "Slide-up modulation matrix editor. Press Escape to close.");
 
         setVisible(false);
     }
@@ -119,7 +112,7 @@ public:
         editorBounds_ = editorBounds;
         // Reposition immediately if already visible
         if (isVisible())
-            applyCurrentPosition(/* animate = */false);
+            applyCurrentPosition(/* animate = */ false);
     }
 
     //==========================================================================
@@ -168,11 +161,7 @@ public:
         // Title
         g.setFont(GalleryFonts::heading(11.0f));
         g.setColour(juce::Colour(GalleryColors::t1()).withAlpha(0.60f));
-        g.drawText("MOD MATRIX",
-                   static_cast<int>(b.getX()) + 18,
-                   static_cast<int>(b.getY()),
-                   160,
-                   kTitleBarH,
+        g.drawText("MOD MATRIX", static_cast<int>(b.getX()) + 18, static_cast<int>(b.getY()), 160, kTitleBarH,
                    juce::Justification::centredLeft, false);
 
         // Route count badge
@@ -182,18 +171,13 @@ public:
             juce::String badge = juce::String(count) + (count == 1 ? " route" : " routes");
             g.setFont(GalleryFonts::label(8.5f));
             g.setColour(juce::Colour(GalleryColors::t2()));
-            g.drawText(badge,
-                       static_cast<int>(b.getX()) + 18 + 104,
-                       static_cast<int>(b.getY()),
-                       120,
-                       kTitleBarH,
+            g.drawText(badge, static_cast<int>(b.getX()) + 18 + 104, static_cast<int>(b.getY()), 120, kTitleBarH,
                        juce::Justification::centredLeft, false);
         }
 
         // Separator under title bar
         g.setColour(juce::Colour(200, 204, 216).withAlpha(0.05f));
-        g.fillRect(b.getX(), b.getY() + static_cast<float>(kTitleBarH),
-                   b.getWidth(), 1.0f);
+        g.fillRect(b.getX(), b.getY() + static_cast<float>(kTitleBarH), b.getWidth(), 1.0f);
 
         // Source strip label
         g.setFont(GalleryFonts::label(7.5f));
@@ -203,8 +187,7 @@ public:
 
         // Separator above source strip
         g.setColour(juce::Colour(200, 204, 216).withAlpha(0.04f));
-        g.fillRect(b.getX(), b.getBottom() - static_cast<float>(kHandleStripH + 1),
-                   b.getWidth(), 1.0f);
+        g.fillRect(b.getX(), b.getBottom() - static_cast<float>(kHandleStripH + 1), b.getWidth(), 1.0f);
     }
 
     void resized() override
@@ -269,33 +252,25 @@ public:
 
 private:
     //==========================================================================
-    static constexpr int kTitleBarH    = 30;
+    static constexpr int kTitleBarH = 30;
     static constexpr int kHandleStripH = 32;
-    static constexpr int kBodyH        = 220; // drawer + list body height
+    static constexpr int kBodyH = 220; // drawer + list body height
 
     //==========================================================================
     // Compute the full panel bounds within the editor coordinate space.
     juce::Rectangle<int> computeFullBounds() const
     {
-        const int panelH = juce::roundToInt(
-            static_cast<float>(editorBounds_.getHeight()) * kPanelHeightFraction);
-        return { editorBounds_.getX(),
-                 editorBounds_.getBottom() - panelH,
-                 editorBounds_.getWidth(),
-                 panelH };
+        const int panelH = juce::roundToInt(static_cast<float>(editorBounds_.getHeight()) * kPanelHeightFraction);
+        return {editorBounds_.getX(), editorBounds_.getBottom() - panelH, editorBounds_.getWidth(), panelH};
     }
 
-    void computeTargetBounds()
-    {
-        targetBounds_ = computeFullBounds();
-    }
+    void computeTargetBounds() { targetBounds_ = computeFullBounds(); }
 
     void applyCurrentPosition(bool animate = true)
     {
         if (!animate)
         {
-            panelY_ = static_cast<float>(isOpen_ ? targetBounds_.getY()
-                                                  : editorBounds_.getBottom());
+            panelY_ = static_cast<float>(isOpen_ ? targetBounds_.getY() : editorBounds_.getBottom());
             setBounds(targetBounds_.withY(static_cast<int>(panelY_)));
             if (!isOpen_)
                 setVisible(false);
@@ -303,8 +278,7 @@ private:
         }
 
         // Spring step
-        float targetY = static_cast<float>(isOpen_ ? targetBounds_.getY()
-                                                    : editorBounds_.getBottom());
+        float targetY = static_cast<float>(isOpen_ ? targetBounds_.getY() : editorBounds_.getBottom());
         panelY_ += (targetY - panelY_) * (1.0f - kSpringDecay);
 
         setBounds(targetBounds_.withY(static_cast<int>(panelY_)));
@@ -314,10 +288,9 @@ private:
     void timerCallback() override
     {
         computeTargetBounds();
-        applyCurrentPosition(/* animate = */true);
+        applyCurrentPosition(/* animate = */ true);
 
-        float targetY = static_cast<float>(isOpen_ ? targetBounds_.getY()
-                                                    : editorBounds_.getBottom());
+        float targetY = static_cast<float>(isOpen_ ? targetBounds_.getY() : editorBounds_.getBottom());
         const float remaining = std::abs(panelY_ - targetY);
 
         if (remaining < 0.8f)
@@ -333,10 +306,10 @@ private:
 
     //==========================================================================
     [[maybe_unused]] juce::AudioProcessorValueTreeState& apvts_;
-    ModRoutingModel&                    modModel_;
+    ModRoutingModel& modModel_;
     [[maybe_unused]] DragDropModRouter& router_;
 
-    ModMatrixDrawer  drawer_;
+    ModMatrixDrawer drawer_;
     ModRouteListPanel routeList_;
     std::vector<std::unique_ptr<ModSourceHandle>> handles_;
     juce::TextButton closeButton_;
@@ -344,7 +317,7 @@ private:
     juce::Rectangle<int> editorBounds_{};
     juce::Rectangle<int> targetBounds_{};
 
-    bool  isOpen_{false};
+    bool isOpen_{false};
     float panelY_{0.f};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModMatrixPanel)
@@ -362,11 +335,9 @@ class ModMatrixStrip : public juce::Component, public juce::ChangeListener
 public:
     static constexpr int kStripHeight = 28;
 
-    explicit ModMatrixStrip(juce::AudioProcessorValueTreeState& apvts,
-                             ModRoutingModel& modModel,
-                             DragDropModRouter& router)
-        : modModel_(modModel)
-        , panel_(apvts, modModel, router)
+    explicit ModMatrixStrip(juce::AudioProcessorValueTreeState& apvts, ModRoutingModel& modModel,
+                            DragDropModRouter& router)
+        : modModel_(modModel), panel_(apvts, modModel, router)
     {
         setOpaque(false);
         setInterceptsMouseClicks(true, false);
@@ -374,23 +345,16 @@ public:
         modModel_.addListener(this);
 
         A11y::setup(*this, "Mod Matrix Strip",
-                    "Click to open the modulation matrix editor. "
-                    + juce::String(modModel_.getRouteCount())
-                    + " active routes.",
-                    /* wantsKeyFocus = */true);
+                    "Click to open the modulation matrix editor. " + juce::String(modModel_.getRouteCount()) +
+                        " active routes.",
+                    /* wantsKeyFocus = */ true);
     }
 
-    ~ModMatrixStrip() override
-    {
-        modModel_.removeListener(this);
-    }
+    ~ModMatrixStrip() override { modModel_.removeListener(this); }
 
     //==========================================================================
     // loadEngine — called when active engine changes.
-    void loadEngine(const juce::String& paramPrefix)
-    {
-        panel_.loadEngine(paramPrefix);
-    }
+    void loadEngine(const juce::String& paramPrefix) { panel_.loadEngine(paramPrefix); }
 
     //==========================================================================
     // setEditorBounds — must be called from XOceanusEditor::resized() so the
@@ -406,10 +370,7 @@ public:
     // addPanelToParent — add the slide-up panel to the editor root component
     // so it floats above all other UI.  Call once during editor construction
     // after addAndMakeVisible(*modMatrixStrip_).
-    void addPanelToParent(juce::Component& editorRoot)
-    {
-        editorRoot.addChildComponent(panel_);
-    }
+    void addPanelToParent(juce::Component& editorRoot) { editorRoot.addChildComponent(panel_); }
 
     //==========================================================================
     void paint(juce::Graphics& g) override
@@ -419,7 +380,7 @@ public:
         const float midY = h * 0.5f;
 
         const bool panelOpen = panel_.isOpen();
-        const int  routeCount = modModel_.getRouteCount();
+        const int routeCount = modModel_.getRouteCount();
         const bool hasRoutes = (routeCount > 0);
 
         // Background
@@ -440,8 +401,7 @@ public:
         {
             // Outer glow
             g.setColour(juce::Colour(0xFF7FDBCA).withAlpha(0.15f));
-            g.fillEllipse(dotX - dotR - 2.f, dotY - dotR - 2.f,
-                          (dotR + 2.f) * 2.f, (dotR + 2.f) * 2.f);
+            g.fillEllipse(dotX - dotR - 2.f, dotY - dotR - 2.f, (dotR + 2.f) * 2.f, (dotR + 2.f) * 2.f);
             // Core
             g.setColour(juce::Colour(0xFF7FDBCA).withAlpha(0.85f));
             g.fillEllipse(dotX - dotR, dotY - dotR, dotR * 2.f, dotR * 2.f);
@@ -455,9 +415,7 @@ public:
         // ── "MOD MATRIX" label ────────────────────────────────────────────
         g.setFont(GalleryFonts::heading(9.5f));
         g.setColour(juce::Colour(200, 204, 216).withAlpha(panelOpen ? 0.85f : 0.50f));
-        g.drawText("MOD MATRIX",
-                   26, 0, 90, static_cast<int>(h),
-                   juce::Justification::centredLeft, false);
+        g.drawText("MOD MATRIX", 26, 0, 90, static_cast<int>(h), juce::Justification::centredLeft, false);
 
         // ── Route count badge ─────────────────────────────────────────────
         if (hasRoutes)
@@ -475,12 +433,8 @@ public:
 
             g.setFont(GalleryFonts::value(8.0f));
             g.setColour(juce::Colour(0xFF7FDBCA));
-            g.drawText(badge,
-                       static_cast<int>(badgeX),
-                       static_cast<int>(badgeY),
-                       static_cast<int>(badgeW),
-                       static_cast<int>(badgeH),
-                       juce::Justification::centred, false);
+            g.drawText(badge, static_cast<int>(badgeX), static_cast<int>(badgeY), static_cast<int>(badgeW),
+                       static_cast<int>(badgeH), juce::Justification::centred, false);
         }
 
         // ── Per-source activity chips (mini dots in source colors) ────────
@@ -493,7 +447,12 @@ public:
             for (const auto& r : routes)
             {
                 bool found = false;
-                for (int s : seenSources) if (s == r.sourceId) { found = true; break; }
+                for (int s : seenSources)
+                    if (s == r.sourceId)
+                    {
+                        found = true;
+                        break;
+                    }
                 if (!found)
                     seenSources.push_back(r.sourceId);
             }
@@ -505,7 +464,11 @@ public:
                 // Find colour
                 juce::Colour chipCol(GalleryColors::xoGold);
                 for (const auto& info : kAllModSourcesForStrip)
-                    if (info.id == srcId) { chipCol = juce::Colour(info.colour); break; }
+                    if (info.id == srcId)
+                    {
+                        chipCol = juce::Colour(info.colour);
+                        break;
+                    }
 
                 g.setColour(chipCol.withAlpha(0.80f));
                 g.fillEllipse(chipX - chipR, midY - chipR, chipR * 2.f, chipR * 2.f);
@@ -519,10 +482,8 @@ public:
         // ── Caret ▲ / ▼ (right edge) ──────────────────────────────────────
         g.setFont(juce::Font(9.0f));
         g.setColour(juce::Colour(200, 204, 216).withAlpha(panelOpen ? 0.75f : 0.35f));
-        g.drawText(panelOpen ? juce::CharPointer_UTF8("\xe2\x96\xbc")
-                             : juce::CharPointer_UTF8("\xe2\x96\xb2"),
-                   static_cast<int>(w) - 20, 0, 16, static_cast<int>(h),
-                   juce::Justification::centred, false);
+        g.drawText(panelOpen ? juce::CharPointer_UTF8("\xe2\x96\xbc") : juce::CharPointer_UTF8("\xe2\x96\xb2"),
+                   static_cast<int>(w) - 20, 0, 16, static_cast<int>(h), juce::Justification::centred, false);
 
         // Hover highlight
         if (isMouseOver())
@@ -542,7 +503,7 @@ public:
     }
 
     void mouseEnter(const juce::MouseEvent&) override { repaint(); }
-    void mouseExit(const juce::MouseEvent&)  override { repaint(); }
+    void mouseExit(const juce::MouseEvent&) override { repaint(); }
 
     bool keyPressed(const juce::KeyPress& key) override
     {
@@ -563,31 +524,38 @@ private:
     // Small mirror of the source colour table used for the strip chips.
     // We can't reference ModulateFromMenu.h here to avoid a circular dep —
     // duplicate the minimal data we need.
-    struct SourceColorEntry { int id; uint32_t colour; };
+    struct SourceColorEntry
+    {
+        int id;
+        uint32_t colour;
+    };
     static constexpr SourceColorEntry kAllModSourcesForStrip[] = {
-        { 0,  0xFF00CED1 }, // LFO1
-        { 1,  0xFFA8D8EA }, // LFO2
-        { 6,  0xFF7EC8E3 }, // LFO3
-        { 2,  0xFFE8701A }, // Envelope
-        { 7,  0xFFFFAA55 }, // ENV2
-        { 8,  0xFFE9C46A }, // TONE
-        { 9,  0xFF7FDBCA }, // TIDE
-        { 10, 0xFFFF8A65 }, // COUPLE
-        { 11, 0xFF9B89D4 }, // DEPTH
-        { 3,  0xFFC6E377 }, // Velocity
-        { 4,  0xFFFF8A7A }, // Aftertouch
-        { 5,  0xFF4169E1 }, // ModWheel
-        { 12, 0xFF9898D0 }, // MIDI CC
-        { 13, 0xFFFFD54F }, // MPE Pressure
-        { 14, 0xFFFF7043 }, // MPE Slide
-        { 15, 0xFF81D4FA }, // Seq Step
-        { 16, 0xFFF48FB1 }, // Chord Tone
-        { 17, 0xFF80CBC4 }, // Beat Phase
+        {0, 0xFF00CED1},  // LFO1
+        {1, 0xFFA8D8EA},  // LFO2
+        {6, 0xFF7EC8E3},  // LFO3
+        {2, 0xFFE8701A},  // Envelope
+        {7, 0xFFFFAA55},  // ENV2
+        {8, 0xFFE9C46A},  // TONE
+        {9, 0xFF7FDBCA},  // TIDE
+        {10, 0xFFFF8A65}, // COUPLE
+        {11, 0xFF9B89D4}, // DEPTH
+        {3, 0xFFC6E377},  // Velocity
+        {4, 0xFFFF8A7A},  // Aftertouch
+        {5, 0xFF4169E1},  // ModWheel
+        {12, 0xFF9898D0}, // MIDI CC
+        {13, 0xFFFFD54F}, // MPE Pressure
+        {14, 0xFFFF7043}, // MPE Slide
+        {15, 0xFF81D4FA}, // Seq Step
+        {16, 0xFFF48FB1}, // Chord Tone
+        {17, 0xFF80CBC4}, // Beat Phase
+        // #1383 A4: XOuija live sources (XouijaDepth dropped)
+        {28, 0xFFB57BEA}, // XouijaX — violet
+        {29, 0xFF9B5FC0}, // XouijaY — deeper violet
     };
 
     //==========================================================================
     ModRoutingModel& modModel_;
-    ModMatrixPanel   panel_;
+    ModMatrixPanel panel_;
     juce::Rectangle<int> editorBounds_{};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModMatrixStrip)

--- a/Source/Future/UI/ModRouting/ModSourceHandle.h
+++ b/Source/Future/UI/ModRouting/ModSourceHandle.h
@@ -28,21 +28,21 @@ enum class ModSourceId
     Aftertouch = 4, // Mono/poly aftertouch (0–1, continuous)
     ModWheel = 5,   // MIDI CC 1 mod wheel (0–1, continuous)
     // ── Extended sources added Wave5-A3 to match D9 F4 + G3 spec ──────────
-    LFO3 = 6,           // Engine LFO 3 (free-running, bipolar)
-    Envelope2 = 7,      // ENV 2 (auxiliary envelope, bipolar)
-    MacroTone = 8,      // Macro knob: TONE (unipolar)
-    MacroTide = 9,      // Macro knob: TIDE (unipolar)
-    MacroCouple = 10,   // Macro knob: COUPLE (unipolar)
-    MacroDepth = 11,    // Macro knob: DEPTH (unipolar)
-    MidiCC = 12,        // Assignable MIDI CC (unipolar)
-    MpePressure = 13,   // MPE per-note pressure (unipolar)
-    MpeSlide = 14,      // MPE per-note slide / Y-axis (unipolar)
-    SeqStepValue = 15,  // Sequencer step value output (bipolar)
+    LFO3 = 6,          // Engine LFO 3 (free-running, bipolar)
+    Envelope2 = 7,     // ENV 2 (auxiliary envelope, bipolar)
+    MacroTone = 8,     // Macro knob: TONE (unipolar)
+    MacroTide = 9,     // Macro knob: TIDE (unipolar)
+    MacroCouple = 10,  // Macro knob: COUPLE (unipolar)
+    MacroDepth = 11,   // Macro knob: DEPTH (unipolar)
+    MidiCC = 12,       // Assignable MIDI CC (unipolar)
+    MpePressure = 13,  // MPE per-note pressure (unipolar)
+    MpeSlide = 14,     // MPE per-note slide / Y-axis (unipolar)
+    SeqStepValue = 15, // Sequencer step value output (bipolar)
     // Renamed from ChordToneIdx — actual chord tone index is pending C5 phase.
     // Currently returns getLiveGate() (0 or 1, unipolar) from the slot sequencer.
     // The integer ID (16) is stable and must not change (preset serialisation).
-    LiveGate = 16,      // Sequencer gate state (0 or 1, unipolar)
-    BeatPhase = 17,     // Beat phase ramp 0→1 per bar (bipolar)
+    LiveGate = 16,  // Sequencer gate state (0 or 1, unipolar)
+    BeatPhase = 17, // Beat phase ramp 0→1 per bar (bipolar)
     // ── Wave5-D3: XOuija pin source ─────────────────────────────────────────
     // A pinned XOuija position exposes two bipolar values:
     //   X-axis (circle-of-fifths)  → normalized [-1, +1] mapped from [0, 1]
@@ -50,25 +50,29 @@ enum class ModSourceId
     // The ModRoutingModel routes these as a single source; the DSP engine reads
     // the X or Y component depending on the parameter's semantic (see D9 wiring).
     // Capture slots 0-3 are differentiated by the ModRoute's destParamId suffix.
-    XouijaCell = 18,    // Pinned XOuija position (bipolar X+Y, 4 capture slots)
+    XouijaCell = 18, // Pinned XOuija position (bipolar X+Y, 4 capture slots)
     // ── #1289: per-step pitch offset ModSource ───────────────────────────────
     // Bipolar -1..+1 mapped from ±12 semitones (0.0 on silent / rest steps).
     // Deferred from C5; depends on C3 per-step pitch data in PerEnginePatternSequencer.
-    SeqStepPitch = 19,  // Per-step pitch offset bipolar -1..+1 (from ±12 semitones)
+    SeqStepPitch = 19, // Per-step pitch offset bipolar -1..+1 (from ±12 semitones)
     // ── #1357: XY Surface position sources (W8B mount) ──────────────────────
     // XY surface X-axis value for each engine slot, bipolar [-1, +1] (centred on 0.5).
     // Read from XOceanusProcessor::xyX_[slot] atomics updated by XYSurface::onXYChanged.
     // Slot is determined by the ModRoute's destParamId suffix convention.
-    XYX0 = 20,   // XY surface X-axis, slot 0 (bipolar)
-    XYX1 = 21,   // XY surface X-axis, slot 1 (bipolar)
-    XYX2 = 22,   // XY surface X-axis, slot 2 (bipolar)
-    XYX3 = 23,   // XY surface X-axis, slot 3 (bipolar)
+    XYX0 = 20, // XY surface X-axis, slot 0 (bipolar)
+    XYX1 = 21, // XY surface X-axis, slot 1 (bipolar)
+    XYX2 = 22, // XY surface X-axis, slot 2 (bipolar)
+    XYX3 = 23, // XY surface X-axis, slot 3 (bipolar)
     // XY surface Y-axis value for each engine slot, bipolar [-1, +1].
-    XYY0 = 24,   // XY surface Y-axis, slot 0 (bipolar)
-    XYY1 = 25,   // XY surface Y-axis, slot 1 (bipolar)
-    XYY2 = 26,   // XY surface Y-axis, slot 2 (bipolar)
-    XYY3 = 27,   // XY surface Y-axis, slot 3 (bipolar)
-    Count = 28
+    XYY0 = 24, // XY surface Y-axis, slot 0 (bipolar)
+    XYY1 = 25, // XY surface Y-axis, slot 1 (bipolar)
+    XYY2 = 26, // XY surface Y-axis, slot 2 (bipolar)
+    XYY3 = 27, // XY surface Y-axis, slot 3 (bipolar)
+    // ── #1383 A4: XOuija live position sources ─────────────────────────────
+    // XouijaDepth (originally proposed ID=30) DROPPED — Y-axis IS the depth.
+    XouijaX = 28, // XOuija planchette X (bipolar, circle-of-fifths)
+    XouijaY = 29, // XOuija planchette Y (bipolar, influence depth)
+    Count = 30
 };
 
 // Human-readable names used in tooltips and the route list panel.
@@ -117,14 +121,27 @@ inline juce::String modSourceName(ModSourceId id)
     case ModSourceId::SeqStepPitch:
         return "Seq Step Pitch";
     // ── #1357: XY Surface sources ───────────────────────────────────────────
-    case ModSourceId::XYX0: return "XY X (Slot 1)";
-    case ModSourceId::XYX1: return "XY X (Slot 2)";
-    case ModSourceId::XYX2: return "XY X (Slot 3)";
-    case ModSourceId::XYX3: return "XY X (Slot 4)";
-    case ModSourceId::XYY0: return "XY Y (Slot 1)";
-    case ModSourceId::XYY1: return "XY Y (Slot 2)";
-    case ModSourceId::XYY2: return "XY Y (Slot 3)";
-    case ModSourceId::XYY3: return "XY Y (Slot 4)";
+    case ModSourceId::XYX0:
+        return "XY X (Slot 1)";
+    case ModSourceId::XYX1:
+        return "XY X (Slot 2)";
+    case ModSourceId::XYX2:
+        return "XY X (Slot 3)";
+    case ModSourceId::XYX3:
+        return "XY X (Slot 4)";
+    case ModSourceId::XYY0:
+        return "XY Y (Slot 1)";
+    case ModSourceId::XYY1:
+        return "XY Y (Slot 2)";
+    case ModSourceId::XYY2:
+        return "XY Y (Slot 3)";
+    case ModSourceId::XYY3:
+        return "XY Y (Slot 4)";
+    // ── #1383 A4: XOuija live sources ─────────────────────────────────────
+    case ModSourceId::XouijaX:
+        return "XOuija X / Planchette Position";
+    case ModSourceId::XouijaY:
+        return "XOuija Y / Influence Depth";
     default:
         return "?";
     }
@@ -192,6 +209,11 @@ inline juce::Colour modSourceColour(ModSourceId id)
     case ModSourceId::XYY2:
     case ModSourceId::XYY3:
         return juce::Colour(0xFF2A7FA5); // deep ocean blue — Y axis
+    // ── #1383 A4: XOuija live sources ─────────────────────────────────────
+    case ModSourceId::XouijaX:
+        return juce::Colour(0xFFB57BEA); // violet — planchette horizontal
+    case ModSourceId::XouijaY:
+        return juce::Colour(0xFF9B5FC0); // deeper violet — influence depth
     default:
         return juce::Colour(GalleryColors::xoGold);
     }
@@ -330,7 +352,7 @@ public:
             glyph = "3";
             break;
         case ModSourceId::Envelope2:
-            glyph = "F";  // "F" = second envelope (E already taken by ENV1)
+            glyph = "F"; // "F" = second envelope (E already taken by ENV1)
             break;
         case ModSourceId::MacroTone:
             glyph = "T";
@@ -363,7 +385,14 @@ public:
             glyph = "B";
             break;
         case ModSourceId::XouijaCell:
-            glyph = "Y"; // "Y" for ouiJa — avoids ambiguity with Q=seq, J=none
+            glyph = "Y"; // legacy ID=18
+            break;
+        // ── #1383 A4: XOuija live position sources ─────────────────────────
+        case ModSourceId::XouijaX:
+            glyph = "X";
+            break;
+        case ModSourceId::XouijaY:
+            glyph = "y"; // lowercase — distinct from X
             break;
         default:
             glyph = "?";

--- a/Source/Future/UI/ModRouting/ModulateFromMenu.h
+++ b/Source/Future/UI/ModRouting/ModulateFromMenu.h
@@ -22,12 +22,12 @@
 // from mouseDown when e.mods.isRightButtonDown(). See XOceanusEditor.h.
 //
 // ────────────────────────────────────────────────────────────────────────────
-// Extended source list (D9 F4 + G3 spec)
+// Extended source list (D9 F4 + G3 spec + #1383 A4 XOuija live sources)
 //
-// ModSourceId in ModSourceHandle.h now defines all 18 sources (IDs 0–17)
-// matching spec D9 F4 + G3. All entries in kAllModSources below have valid
-// enum values and are routable via ModRoutingModel. The "extended" sentinel
-// logic (id >= Count) no longer applies — Count is now 18.
+// ModSourceId in ModSourceHandle.h defines all sources (IDs 0-17 original,
+// 28-29 XOuija A4, Count = 30).  XouijaDepth (proposed ID=30) DROPPED.
+// All entries in kAllModSources below have valid enum values and are routable
+// via ModRoutingModel. Count is now 30 (after #1383 A4).
 //
 #pragma once
 
@@ -43,16 +43,16 @@ namespace xoceanus
 // ExtModSourceInfo — metadata for a single source entry in the popup menu.
 struct ExtModSourceInfo
 {
-    int         id;          // cast to ModSourceId if id < Count, else extended
-    const char* label;       // short display label (e.g. "LFO 1")
-    const char* group;       // section header (nullptr = continue current section)
-    bool        bipolar;     // true = source generates ±1 range
-    uint32_t    colour;      // 0xAARRGGBB accent colour
+    int id;            // cast to ModSourceId if id < Count, else extended
+    const char* label; // short display label (e.g. "LFO 1")
+    const char* group; // section header (nullptr = continue current section)
+    bool bipolar;      // true = source generates ±1 range
+    uint32_t colour;   // 0xAARRGGBB accent colour
 };
 
 //==============================================================================
-// Full source catalogue — matches spec D9 F4 + G3.
-// All 18 sources have valid ModSourceId enum values (Count = 18).
+// Full source catalogue — matches spec D9 F4 + G3, extended for #1383 A4.
+// All sources have valid ModSourceId enum values (Count = 30 after #1383 A4).
 // All are routable via ModRoutingModel (which stores int sourceId).
 //
 // JUCE PopupMenu item IDs start at 1.  We encode id + 1 as the JUCE item ID
@@ -60,34 +60,39 @@ struct ExtModSourceInfo
 //
 static const ExtModSourceInfo kAllModSources[] = {
     // ── Oscillator modulators ─────────────────────────────────────────────
-    { 0,  "LFO 1",           "LFOs",      true,  0xFF00CED1 },
-    { 1,  "LFO 2",           nullptr,     true,  0xFFA8D8EA },
-    { 6,  "LFO 3",           nullptr,     true,  0xFF7EC8E3 },
+    {0, "LFO 1", "LFOs", true, 0xFF00CED1},
+    {1, "LFO 2", nullptr, true, 0xFFA8D8EA},
+    {6, "LFO 3", nullptr, true, 0xFF7EC8E3},
 
     // ── Envelopes ─────────────────────────────────────────────────────────
-    { 2,  "ENV 1 (Amp)",     "Envelopes", true,  0xFFE8701A },
-    { 7,  "ENV 2",           nullptr,     true,  0xFFFFAA55 },
+    {2, "ENV 1 (Amp)", "Envelopes", true, 0xFFE8701A},
+    {7, "ENV 2", nullptr, true, 0xFFFFAA55},
 
     // ── Macros ────────────────────────────────────────────────────────────
-    { 8,  "Macro: TONE",     "Macros",    false, 0xFFE9C46A },
-    { 9,  "Macro: TIDE",     nullptr,     false, 0xFF7FDBCA },
-    { 10, "Macro: COUPLE",   nullptr,     false, 0xFFFF8A65 },
-    { 11, "Macro: DEPTH",    nullptr,     false, 0xFF9B89D4 },
+    {8, "Macro: TONE", "Macros", false, 0xFFE9C46A},
+    {9, "Macro: TIDE", nullptr, false, 0xFF7FDBCA},
+    {10, "Macro: COUPLE", nullptr, false, 0xFFFF8A65},
+    {11, "Macro: DEPTH", nullptr, false, 0xFF9B89D4},
 
     // ── Performance / MIDI ───────────────────────────────────────────────
-    { 3,  "Velocity",        "MIDI",      false, 0xFFC6E377 },
-    { 4,  "Aftertouch",      nullptr,     false, 0xFFFF8A7A },
-    { 5,  "Mod Wheel",       nullptr,     false, 0xFF4169E1 },
-    { 12, "MIDI CC",         nullptr,     false, 0xFF9898D0 },
+    {3, "Velocity", "MIDI", false, 0xFFC6E377},
+    {4, "Aftertouch", nullptr, false, 0xFFFF8A7A},
+    {5, "Mod Wheel", nullptr, false, 0xFF4169E1},
+    {12, "MIDI CC", nullptr, false, 0xFF9898D0},
 
     // ── MPE ───────────────────────────────────────────────────────────────
-    { 13, "MPE Pressure",    "MPE",       false, 0xFFFFD54F },
-    { 14, "MPE Slide",       nullptr,     false, 0xFFFF7043 },
+    {13, "MPE Pressure", "MPE", false, 0xFFFFD54F},
+    {14, "MPE Slide", nullptr, false, 0xFFFF7043},
 
     // ── Sequencer / musical ───────────────────────────────────────────────
-    { 15, "Seq Step Value",  "Musical",   true,  0xFF81D4FA },
-    { 16, "Chord Tone Idx",  nullptr,     false, 0xFFF48FB1 },
-    { 17, "Beat Phase",      nullptr,     true,  0xFF80CBC4 },
+    {15, "Seq Step Value", "Musical", true, 0xFF81D4FA},
+    {16, "Chord Tone Idx", nullptr, false, 0xFFF48FB1},
+    {17, "Beat Phase", nullptr, true, 0xFF80CBC4},
+
+    // ── XOuija (#1383 A4) — live planchette position ─────────────────────
+    // XouijaDepth (proposed ID=30) dropped — Y-axis IS the depth axis.
+    {28, "XOuija X / Planchette Position", "XOuija", true, 0xFFB57BEA},
+    {29, "XOuija Y / Influence Depth", nullptr, true, 0xFF9B5FC0},
 };
 
 static constexpr int kNumModSources = static_cast<int>(sizeof(kAllModSources) / sizeof(kAllModSources[0]));
@@ -104,9 +109,7 @@ public:
     // shows the current depth and clicking it opens an adjust dialog rather
     // than adding a duplicate.
     //
-    static void show(ModRoutingModel& model,
-                     const juce::String& destParamId,
-                     juce::Component* anchorComponent)
+    static void show(ModRoutingModel& model, const juce::String& destParamId, juce::Component* anchorComponent)
     {
         juce::PopupMenu menu;
 
@@ -123,21 +126,18 @@ public:
                 g.drawRoundedRectangle(0.5f, 0.5f, (float)w - 1.f, (float)h - 1.f, 6.f, 1.f);
             }
 
-            void drawPopupMenuSectionHeader(juce::Graphics& g,
-                                             const juce::Rectangle<int>& area,
-                                             const juce::String& sectionName) override
+            void drawPopupMenuSectionHeader(juce::Graphics& g, const juce::Rectangle<int>& area,
+                                            const juce::String& sectionName) override
             {
                 g.setFont(GalleryFonts::label(8.0f));
                 g.setColour(juce::Colour(200, 204, 216).withAlpha(0.28f));
                 g.drawText(sectionName, area.reduced(8, 0), juce::Justification::centredLeft, false);
             }
 
-            void drawPopupMenuItem(juce::Graphics& g, const juce::Rectangle<int>& area,
-                                    bool isSeparator, bool isActive, bool isHighlighted,
-                                    bool /*isTicked*/, bool /*hasSubMenu*/,
-                                    const juce::String& text, const juce::String& /*shortcutKey*/,
-                                    const juce::Drawable* /*icon*/,
-                                    const juce::Colour* customColour) override
+            void drawPopupMenuItem(juce::Graphics& g, const juce::Rectangle<int>& area, bool isSeparator, bool isActive,
+                                   bool isHighlighted, bool /*isTicked*/, bool /*hasSubMenu*/, const juce::String& text,
+                                   const juce::String& /*shortcutKey*/, const juce::Drawable* /*icon*/,
+                                   const juce::Colour* customColour) override
             {
                 if (isSeparator)
                 {
@@ -160,16 +160,14 @@ public:
                 }
 
                 g.setFont(GalleryFonts::value(9.5f));
-                g.setColour(isActive
-                    ? juce::Colour(200, 204, 216).withAlpha(isHighlighted ? 0.90f : 0.65f)
-                    : juce::Colour(200, 204, 216).withAlpha(0.25f));
+                g.setColour(isActive ? juce::Colour(200, 204, 216).withAlpha(isHighlighted ? 0.90f : 0.65f)
+                                     : juce::Colour(200, 204, 216).withAlpha(0.25f));
 
-                g.drawText(text, area.withTrimmedLeft(10).reduced(2, 0),
-                            juce::Justification::centredLeft, true);
+                g.drawText(text, area.withTrimmedLeft(10).reduced(2, 0), juce::Justification::centredLeft, true);
             }
 
             int getPopupMenuItemHeight() override { return 22; }
-            int getPopupMenuBorderSize() override  { return 6; }
+            int getPopupMenuBorderSize() override { return 6; }
         };
 
         // NOTE: The LnF must outlive the menu's async execution.  We use a
@@ -208,7 +206,7 @@ public:
                 // Offset by 1000 to distinguish from "add new" IDs
                 juce::PopupMenu::Item item;
                 item.itemID = 1000 + i;
-                item.text   = label;
+                item.text = label;
                 item.colour = juce::Colour(srcColour);
                 item.isEnabled = true;
                 menu.addItem(item);
@@ -226,7 +224,11 @@ public:
             // Check if this source already has a route to this param
             bool hasRoute = false;
             for (const auto& r : existingRoutes)
-                if (r.sourceId == info.id) { hasRoute = true; break; }
+                if (r.sourceId == info.id)
+                {
+                    hasRoute = true;
+                    break;
+                }
 
             if (info.group != nullptr && info.group != currentGroup)
             {
@@ -244,11 +246,11 @@ public:
 
             // Item ID = info.id + 1 (0-based ID -> 1-based JUCE item)
             juce::PopupMenu::Item item;
-            item.itemID   = info.id + 1;
-            item.text     = label;
-            item.colour   = juce::Colour(info.colour).withAlpha(hasRoute ? 0.85f : 1.0f);
+            item.itemID = info.id + 1;
+            item.text = label;
+            item.colour = juce::Colour(info.colour).withAlpha(hasRoute ? 0.85f : 1.0f);
             item.isEnabled = true;
-            item.isTicked  = hasRoute;
+            item.isTicked = hasRoute;
             menu.addItem(item);
         }
 
@@ -259,74 +261,75 @@ public:
         }
 
         // ── Show async ────────────────────────────────────────────────────
-        auto opts = juce::PopupMenu::Options{}
-            .withTargetComponent(anchorComponent)
-            .withMaximumNumColumns(1);
+        auto opts = juce::PopupMenu::Options{}.withTargetComponent(anchorComponent).withMaximumNumColumns(1);
 
         menu.showMenuAsync(opts,
-            [&model, destParamId, lnf,
-             existingRoutes = std::move(existingRoutes)](int result) mutable
-            {
-                if (result <= 0)
-                    return; // dismissed
+                           [&model, destParamId, lnf, existingRoutes = std::move(existingRoutes)](int result) mutable
+                           {
+                               if (result <= 0)
+                                   return; // dismissed
 
-                // ── Remove-all existing routes ──────────────────────────
-                if (result == 999)
-                {
-                    model.removeRoutesForParam(destParamId);
-                    return;
-                }
+                               // ── Remove-all existing routes ──────────────────────────
+                               if (result == 999)
+                               {
+                                   model.removeRoutesForParam(destParamId);
+                                   return;
+                               }
 
-                // ── Adjust existing route (depth editor) ────────────────
-                if (result >= 1000)
-                {
-                    const int subIdx = result - 1000;
-                    if (subIdx >= 0 && subIdx < static_cast<int>(existingRoutes.size()))
-                    {
-                        const auto& r = existingRoutes[static_cast<size_t>(subIdx)];
-                        // Find the index in the full model
-                        auto allRoutes = model.getRoutesCopy();
-                        for (int j = 0; j < static_cast<int>(allRoutes.size()); ++j)
-                        {
-                            if (allRoutes[static_cast<size_t>(j)].sourceId == r.sourceId &&
-                                allRoutes[static_cast<size_t>(j)].destParamId == r.destParamId)
-                            {
-                                showDepthEditor(model, j);
-                                break;
-                            }
-                        }
-                    }
-                    return;
-                }
+                               // ── Adjust existing route (depth editor) ────────────────
+                               if (result >= 1000)
+                               {
+                                   const int subIdx = result - 1000;
+                                   if (subIdx >= 0 && subIdx < static_cast<int>(existingRoutes.size()))
+                                   {
+                                       const auto& r = existingRoutes[static_cast<size_t>(subIdx)];
+                                       // Find the index in the full model
+                                       auto allRoutes = model.getRoutesCopy();
+                                       for (int j = 0; j < static_cast<int>(allRoutes.size()); ++j)
+                                       {
+                                           if (allRoutes[static_cast<size_t>(j)].sourceId == r.sourceId &&
+                                               allRoutes[static_cast<size_t>(j)].destParamId == r.destParamId)
+                                           {
+                                               showDepthEditor(model, j);
+                                               break;
+                                           }
+                                       }
+                                   }
+                                   return;
+                               }
 
-                // ── Add new route (result = sourceId + 1) ───────────────
-                const int sourceId = result - 1;
+                               // ── Add new route (result = sourceId + 1) ───────────────
+                               const int sourceId = result - 1;
 
-                // Check for existing route with this source → bump to depth editor
-                {
-                    auto allRoutes = model.getRoutesCopy();
-                    for (int j = 0; j < static_cast<int>(allRoutes.size()); ++j)
-                    {
-                        if (allRoutes[static_cast<size_t>(j)].sourceId == sourceId &&
-                            allRoutes[static_cast<size_t>(j)].destParamId == destParamId)
-                        {
-                            showDepthEditor(model, j);
-                            return;
-                        }
-                    }
-                }
+                               // Check for existing route with this source → bump to depth editor
+                               {
+                                   auto allRoutes = model.getRoutesCopy();
+                                   for (int j = 0; j < static_cast<int>(allRoutes.size()); ++j)
+                                   {
+                                       if (allRoutes[static_cast<size_t>(j)].sourceId == sourceId &&
+                                           allRoutes[static_cast<size_t>(j)].destParamId == destParamId)
+                                       {
+                                           showDepthEditor(model, j);
+                                           return;
+                                       }
+                                   }
+                               }
 
-                if (model.isFull())
-                    return;
+                               if (model.isFull())
+                                   return;
 
-                // Determine bipolar flag from catalogue
-                bool bipolar = false;
-                for (const auto& info : kAllModSources)
-                    if (info.id == sourceId) { bipolar = info.bipolar; break; }
+                               // Determine bipolar flag from catalogue
+                               bool bipolar = false;
+                               for (const auto& info : kAllModSources)
+                                   if (info.id == sourceId)
+                                   {
+                                       bipolar = info.bipolar;
+                                       break;
+                                   }
 
-                const float defaultDepth = bipolar ? 0.5f : 0.35f;
-                model.addRoute(sourceId, destParamId, defaultDepth, bipolar);
-            });
+                               const float defaultDepth = bipolar ? 0.5f : 0.35f;
+                               model.addRoute(sourceId, destParamId, defaultDepth, bipolar);
+                           });
     }
 
 private:
@@ -342,35 +345,36 @@ private:
         // Find display label
         const char* srcLabel = "Source";
         for (const auto& info : kAllModSources)
-            if (info.id == r.sourceId) { srcLabel = info.label; break; }
+            if (info.id == r.sourceId)
+            {
+                srcLabel = info.label;
+                break;
+            }
 
-        auto* alert = new juce::AlertWindow(
-            "Adjust Mod Depth",
-            juce::String(srcLabel) + "  →  " + r.destParamId,
-            juce::MessageBoxIconType::NoIcon);
+        auto* alert = new juce::AlertWindow("Adjust Mod Depth", juce::String(srcLabel) + "  →  " + r.destParamId,
+                                            juce::MessageBoxIconType::NoIcon);
 
         alert->addTextEditor("depth", juce::String(r.depth, 3), "Depth  (−1.0 to +1.0):");
-        alert->addButton("OK",     1, juce::KeyPress(juce::KeyPress::returnKey));
+        alert->addButton("OK", 1, juce::KeyPress(juce::KeyPress::returnKey));
         alert->addButton("Remove", 2);
         alert->addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
 
-        alert->enterModalState(
-            true,
-            juce::ModalCallbackFunction::create(
-                [&model, routeIdx, alert](int res)
-                {
-                    if (res == 1)
-                    {
-                        float newDepth = alert->getTextEditorContents("depth").getFloatValue();
-                        model.setRouteDepth(routeIdx, newDepth);
-                    }
-                    else if (res == 2)
-                    {
-                        model.removeRoute(routeIdx);
-                    }
-                    delete alert;
-                }),
-            false);
+        alert->enterModalState(true,
+                               juce::ModalCallbackFunction::create(
+                                   [&model, routeIdx, alert](int res)
+                                   {
+                                       if (res == 1)
+                                       {
+                                           float newDepth = alert->getTextEditorContents("depth").getFloatValue();
+                                           model.setRouteDepth(routeIdx, newDepth);
+                                       }
+                                       else if (res == 2)
+                                       {
+                                           model.removeRoute(routeIdx);
+                                       }
+                                       delete alert;
+                                   }),
+                               false);
     }
 
     ModulateFromMenu() = delete; // static-only class

--- a/Source/UI/PlaySurface/PlaySurface.h
+++ b/Source/UI/PlaySurface/PlaySurface.h
@@ -1272,13 +1272,14 @@ public:
             modeButtons[i].setRadioGroupId(101);
             addAndMakeVisible(modeButtons[i]);
         }
-        static const char* kModeTabLabels[kNumModeTabs] = { "KEYS", "PADS", "XY", "OUIJA" };
+        static const char* kModeTabLabels[kNumModeTabs] = {"KEYS", "PADS", "XY", "OUIJA"};
         for (int i = 0; i < kNumModeTabs; ++i)
             modeButtons[i].setButtonText(kModeTabLabels[i]);
         modeButtons[0].setToggleState(true, juce::dontSendNotification); // default = KEYS
-        A11y::setup(modeButtons[0], "Keys Mode",  "Switch to piano-keyboard play surface");
-        A11y::setup(modeButtons[1], "Pads Mode",  "Switch to velocity-sensitive pad grid (scale-aware or drum-kit sub-mode)");
-        A11y::setup(modeButtons[2], "XY Mode",    "Switch to full-screen XY performance strip");
+        A11y::setup(modeButtons[0], "Keys Mode", "Switch to piano-keyboard play surface");
+        A11y::setup(modeButtons[1], "Pads Mode",
+                    "Switch to velocity-sensitive pad grid (scale-aware or drum-kit sub-mode)");
+        A11y::setup(modeButtons[2], "XY Mode", "Switch to full-screen XY performance strip");
         A11y::setup(modeButtons[3], "Ouija Mode", "Switch to full-screen XOuija harmonic navigator");
 
         // D4 tab callbacks — each tab updates surfaceTab_ and calls resized()
@@ -1325,8 +1326,7 @@ public:
         padsSubModeBtn_.setButtonText(kPadsSubModeLabels[0]); // default = ♪
         padsSubModeBtn_.setToggleState(false, juce::dontSendNotification);
         addAndMakeVisible(padsSubModeBtn_);
-        A11y::setup(padsSubModeBtn_,
-                    "Pads Sub-mode Toggle",
+        A11y::setup(padsSubModeBtn_, "Pads Sub-mode Toggle",
                     "Toggle between scale-aware note pads (musical mode) and drum-kit labelled pads (percussion mode)");
         padsSubModeBtn_.onClick = [this]()
         {
@@ -1445,18 +1445,14 @@ public:
         latchBadge_.setTooltip("Keys mode latches notes — release does not stop them. "
                                "Click another mode to release all held notes.");
         // Amber background (PS::kAmber) + dark text for high contrast on the deep bg.
-        latchBadge_.setColour(juce::TextButton::buttonColourId,
-                               juce::Colour(PS::kAmber).withAlpha(0.85f));
-        latchBadge_.setColour(juce::TextButton::buttonOnColourId,
-                               juce::Colour(PS::kAmber));
+        latchBadge_.setColour(juce::TextButton::buttonColourId, juce::Colour(PS::kAmber).withAlpha(0.85f));
+        latchBadge_.setColour(juce::TextButton::buttonOnColourId, juce::Colour(PS::kAmber));
         latchBadge_.setColour(juce::TextButton::textColourOffId,
-                               juce::Colour(0xFF1A1208)); // near-black — legible on amber
-        latchBadge_.setColour(juce::TextButton::textColourOnId,
-                               juce::Colour(0xFF1A1208));
+                              juce::Colour(0xFF1A1208)); // near-black — legible on amber
+        latchBadge_.setColour(juce::TextButton::textColourOnId, juce::Colour(0xFF1A1208));
         addAndMakeVisible(latchBadge_);
         latchBadge_.setVisible(surfaceTab_ == SurfaceTab::Keys); // default = Keys → visible
-        A11y::setup(latchBadge_,
-                    "Latch Active",
+        A11y::setup(latchBadge_, "Latch Active",
                     "Keys mode is active: notes latch and sustain after you release. "
                     "Switch to another mode to release all held notes.");
 
@@ -1547,15 +1543,18 @@ public:
             processor_->onSetXOuijaState = nullptr;
         }
 
+        // #1383 A4: null out pin callback before swapping processor.
+        xouijaPanel_.getPinStore().onPinChanged = nullptr;
+
         processor_ = p;
         // Re-wire the onCCOutput callback now that we have the processor.
         wireOnCCOutput();
 
         if (processor_ == nullptr)
         {
-            // Detaching: clear the bridge callbacks so the processor doesn't hold
-            // dangling references to this PlaySurface after it is destroyed.
-            // (processor itself may outlive the PlaySurface window)
+            // Detaching: bridge callbacks already cleared above.
+            // (processor may outlive the PlaySurface window)
+            xouijaPanel_.getPinStore().onPinChanged = nullptr;
             return;
         }
 
@@ -1565,6 +1564,17 @@ public:
         processor_->onGetXOuijaState = [this]() -> juce::ValueTree { return xouijaPanel_.toValueTree(); };
 
         processor_->onSetXOuijaState = [this](const juce::ValueTree& tree) { xouijaPanel_.fromValueTree(tree); };
+
+        // #1383 A4: XOuija pin → ModSource registry bridge (reconciled).
+        // Writes XouijaX (28) + XouijaY (29) for new routes, plus XouijaCell (18) for back-compat.
+        // XouijaDepth (proposed ID=30) is dropped — influenceY IS the depth axis.
+        xouijaPanel_.getPinStore().onPinChanged = [this](float bx, float by)
+        {
+            auto& reg = processor_->getModSourceRegistry();
+            reg.updateSourceValue(ModSourceId::XouijaX, bx);
+            reg.updateSourceValue(ModSourceId::XouijaY, by);
+            reg.updateSourceValue(ModSourceId::XouijaCell, bx, by);
+        };
 
         // If the processor already has saved XOuija state in its APVTS tree
         // (e.g. setStateInformation was called before the PlaySurface window
@@ -1658,8 +1668,8 @@ public:
             return;
 
         // Auto-switch to PADS tab + drum sub-mode
-        surfaceTab_   = SurfaceTab::Pads;
-        drumSubMode_  = true;
+        surfaceTab_ = SurfaceTab::Pads;
+        drumSubMode_ = true;
         padsSubModeBtn_.setToggleState(true, juce::dontSendNotification);
         padsSubModeBtn_.setButtonText(kPadsSubModeLabels[1]); // ▦
         applyPadsSubMode();
@@ -1695,10 +1705,7 @@ public:
     /// The controller will call setValueNotifyingHost() on this parameter
     /// whenever the wave-surface mean height changes.
     /// Pass nullptr to detach.
-    void setTideTargetParameter(juce::RangedAudioParameter* param)
-    {
-        tideController_.setTargetParameter(param);
-    }
+    void setTideTargetParameter(juce::RangedAudioParameter* param) { tideController_.setTargetParameter(param); }
 
     void resized() override
     {
@@ -1756,18 +1763,18 @@ public:
         //
         // The bottom PerformanceStrip is always shown except in XY/OUIJA full-screen tabs.
 
-        bool showStrip    = (surfaceTab_ != SurfaceTab::XY && surfaceTab_ != SurfaceTab::Ouija);
-        bool showLeftCol  = (surfaceTab_ == SurfaceTab::Keys || surfaceTab_ == SurfaceTab::Pads);
-        bool showKeys     = (surfaceTab_ == SurfaceTab::Keys);
+        bool showStrip = (surfaceTab_ != SurfaceTab::XY && surfaceTab_ != SurfaceTab::Ouija);
+        bool showLeftCol = (surfaceTab_ == SurfaceTab::Keys || surfaceTab_ == SurfaceTab::Pads);
+        bool showKeys = (surfaceTab_ == SurfaceTab::Keys);
         bool showNoteInput = (surfaceTab_ == SurfaceTab::Pads);
-        bool showXY       = (surfaceTab_ == SurfaceTab::XY);
-        bool showOuija    = (surfaceTab_ == SurfaceTab::Ouija);
+        bool showXY = (surfaceTab_ == SurfaceTab::XY);
+        bool showOuija = (surfaceTab_ == SurfaceTab::Ouija);
 
         // ── Performance Strip — full width, bottom (hidden in XY/OUIJA tabs) ──
         if (showStrip)
             strip.setBounds(bounds.removeFromBottom(PS::kStripH));
         else
-            strip.setBounds({});  // zero bounds — invisible in XY/OUIJA
+            strip.setBounds({}); // zero bounds — invisible in XY/OUIJA
         strip.setVisible(showStrip);
 
         // ── Full-screen XY mode — PerformanceStrip takes all remaining space ──
@@ -1891,15 +1898,21 @@ public:
     /// Live XOuija panel accessor for external wiring (Starboard #1379, etc).
     XOuijaPanel& getXOuijaPanel() noexcept { return xouijaPanel_; }
     const XOuijaPanel& getXOuijaPanel() const noexcept { return xouijaPanel_; }
-private:
 
+private:
     // TideController — wave-surface expression controller.
     // Shown in the left panel slot when tideActive_ is true.
     TideController tideController_;
     bool tideActive_ = false;
 
     // ── D4 (Wave 6): Top-level surface tab state ──────────────────────────────
-    enum class SurfaceTab { Keys = 0, Pads = 1, XY = 2, Ouija = 3 };
+    enum class SurfaceTab
+    {
+        Keys = 0,
+        Pads = 1,
+        XY = 2,
+        Ouija = 3
+    };
     SurfaceTab surfaceTab_ = SurfaceTab::Keys; // default = KEYS tab
 
     // PADS sub-mode: false = scale-aware (♪), true = drum-kit (▦)
@@ -1907,15 +1920,12 @@ private:
 
     static constexpr int kNumModeTabs = 4; // KEYS | PADS | XY | OUIJA
     // Sub-mode toggle labels — ♪ = musical/scale-aware, ▦ = drum-kit
-    static constexpr const char* kPadsSubModeLabels[2] = { "\xe2\x99\xaa", "\xe2\x96\xa6" };
+    static constexpr const char* kPadsSubModeLabels[2] = {"\xe2\x99\xaa", "\xe2\x96\xa6"};
     //    ♪  = U+266A = \xe2\x99\xaa (UTF-8)
     //    ▦  = U+25A6 = \xe2\x96\xa6 (UTF-8)
 
     // ── Helper: apply NoteInputZone mode from pads sub-mode state ────────────
-    void applyPadsSubMode()
-    {
-        noteInput.setMode(drumSubMode_ ? NoteInputZone::Mode::Drum : NoteInputZone::Mode::Pad);
-    }
+    void applyPadsSubMode() { noteInput.setMode(drumSubMode_ ? NoteInputZone::Mode::Drum : NoteInputZone::Mode::Pad); }
 
     std::array<juce::TextButton, kNumModeTabs> modeButtons;
     juce::TextButton padsSubModeBtn_; // D4: ♪/▦ sub-mode toggle inside PADS tab
@@ -1923,8 +1933,8 @@ private:
     std::array<juce::TextButton, 4> bankButtons; // A / B / C / D bank selectors
     juce::TextButton octDownBtn, octUpBtn;
     juce::Label octLabel;
-    juce::TextButton scaleModeBtn;  // Cycles: SCL (Off) → FLT (Filter) → HLT (Highlight)
-    juce::TextButton tideModeBtn_;  // Toggles TideController in the left panel slot
+    juce::TextButton scaleModeBtn; // Cycles: SCL (Off) → FLT (Filter) → HLT (Highlight)
+    juce::TextButton tideModeBtn_; // Toggles TideController in the left panel slot
 
     // F-004: LATCH indicator badge — amber read-only badge shown only in Keys mode.
     // Keys mode silently latches notes (handleKeysUp does not fire noteOff).

--- a/Source/UI/PlaySurface/XOuijaPanel.h
+++ b/Source/UI/PlaySurface/XOuijaPanel.h
@@ -973,8 +973,8 @@ public:
     struct MoodValues
     {
         float brightness = 0.5f; // 0=dark,   1=bright
-        float tension    = 0.5f; // 0=calm,   1=tense
-        float density    = 0.5f; // 0=sparse, 1=dense
+        float tension = 0.5f;    // 0=calm,   1=tense
+        float density = 0.5f;    // 0=sparse, 1=dense
     };
 
     std::function<void(const MoodValues&)> onMoodChanged;
@@ -997,14 +997,18 @@ public:
     {
         mood_ = v;
         mood_.brightness = juce::jlimit(0.0f, 1.0f, mood_.brightness);
-        mood_.tension    = juce::jlimit(0.0f, 1.0f, mood_.tension);
-        mood_.density    = juce::jlimit(0.0f, 1.0f, mood_.density);
+        mood_.tension = juce::jlimit(0.0f, 1.0f, mood_.tension);
+        mood_.density = juce::jlimit(0.0f, 1.0f, mood_.density);
         repaint();
     }
 
     const MoodValues& getMoodValues() const noexcept { return mood_; }
 
-    void setAccentColour(juce::Colour c) { accentColour_ = c; repaint(); }
+    void setAccentColour(juce::Colour c)
+    {
+        accentColour_ = c;
+        repaint();
+    }
 
     //==========================================================================
     // Rendering
@@ -1034,16 +1038,15 @@ public:
         for (int i = 0; i < kN; ++i)
         {
             const float slotLeft = b.getX() + static_cast<float>(i) * slotW;
-            const float trackLeft  = slotLeft + thumbR + 2.0f;
+            const float trackLeft = slotLeft + thumbR + 2.0f;
             const float trackRight = slotLeft + slotW - thumbR - 2.0f;
-            const float trackLen   = trackRight - trackLeft;
+            const float trackLen = trackRight - trackLeft;
 
             // Label above the track
             const float labelY = b.getY() + 2.0f;
             g.setColour(juce::Colours::white.withAlpha(0.55f));
-            g.drawText(kLabels[i],
-                       juce::Rectangle<float>(slotLeft, labelY, slotW, 12.0f),
-                       juce::Justification::centred, false);
+            g.drawText(kLabels[i], juce::Rectangle<float>(slotLeft, labelY, slotW, 12.0f), juce::Justification::centred,
+                       false);
 
             // Track background — two halves
             const float trackMid = trackLeft + trackLen * 0.5f;
@@ -1052,19 +1055,17 @@ public:
 
             // Left half (neutral→negative pole) — slightly cooler color
             g.setColour(juce::Colour(0xFF2a2a30));
-            g.fillRoundedRectangle(trackLeft, trackY - trackH * 0.5f,
-                                   trackLen, trackH, 2.0f);
+            g.fillRoundedRectangle(trackLeft, trackY - trackH * 0.5f, trackLen, trackH, 2.0f);
 
             // Active fill — from centre to thumb
-            const float fillLeft  = std::min(thumbX, trackMid);
+            const float fillLeft = std::min(thumbX, trackMid);
             const float fillRight = std::max(thumbX, trackMid);
             const float fillW = fillRight - fillLeft;
             if (fillW > 0.5f)
             {
                 const float alpha = 0.5f + std::abs(v - 0.5f); // brighter when away from neutral
                 g.setColour(accentColour_.withAlpha(alpha));
-                g.fillRoundedRectangle(fillLeft, trackY - trackH * 0.5f,
-                                       fillW, trackH, 2.0f);
+                g.fillRoundedRectangle(fillLeft, trackY - trackH * 0.5f, fillW, trackH, 2.0f);
             }
 
             // Thumb
@@ -1073,8 +1074,7 @@ public:
 
             // Neutral tick mark at centre
             g.setColour(juce::Colours::white.withAlpha(0.20f));
-            g.fillRect(juce::Rectangle<float>(trackMid - 0.5f, trackY - trackH * 0.5f - 1.0f,
-                                              1.0f, trackH + 2.0f));
+            g.fillRect(juce::Rectangle<float>(trackMid - 0.5f, trackY - trackH * 0.5f - 1.0f, 1.0f, trackH + 2.0f));
         }
     }
 
@@ -1085,8 +1085,8 @@ public:
     void mouseDrag(const juce::MouseEvent& e) override { updateFromMouse(e); }
 
 private:
-    MoodValues   mood_;
-    juce::Colour accentColour_{ juce::Colour(0xFFE9C46A) }; // XO Gold default
+    MoodValues mood_;
+    juce::Colour accentColour_{juce::Colour(0xFFE9C46A)}; // XO Gold default
 
     //==========================================================================
     // Map mouse X to [0,1] within the appropriate slider slot.
@@ -1103,10 +1103,10 @@ private:
         const float thumbR = 5.0f;
 
         const int slot = juce::jlimit(0, kN - 1, static_cast<int>(mx / slotW));
-        const float slotLeft  = static_cast<float>(slot) * slotW;
-        const float trackLeft  = slotLeft + thumbR + 2.0f;
+        const float slotLeft = static_cast<float>(slot) * slotW;
+        const float trackLeft = slotLeft + thumbR + 2.0f;
         const float trackRight = slotLeft + slotW - thumbR - 2.0f;
-        const float trackLen   = trackRight - trackLeft;
+        const float trackLen = trackRight - trackLeft;
 
         if (trackLen <= 0.0f)
             return;
@@ -1115,10 +1115,17 @@ private:
 
         switch (slot)
         {
-        case 0: mood_.brightness = v; break;
-        case 1: mood_.tension    = v; break;
-        case 2: mood_.density    = v; break;
-        default: break;
+        case 0:
+            mood_.brightness = v;
+            break;
+        case 1:
+            mood_.tension = v;
+            break;
+        case 2:
+            mood_.density = v;
+            break;
+        default:
+            break;
         }
 
         repaint();
@@ -1129,7 +1136,6 @@ private:
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MoodSliderBar)
 };
-
 
 /** GoodbyeButton (Task 7 — Spec Section 7)
     Warm Terracotta full-width button that resets the XOuija session.
@@ -1211,9 +1217,9 @@ public:
     //==========================================================================
     // Reserved layout heights (for Tasks 5-7)
     //==========================================================================
-    static constexpr int kGestureBarH = 34; // Task 7: GestureButtonBar
-    static constexpr int kGoodbyeH = 32;    // Task 7: GOODBYE button
-    static constexpr int kMoodBarH  = MoodSliderBar::kMoodBarH; // Wave 5 D2: mood sliders
+    static constexpr int kGestureBarH = 34;                    // Task 7: GestureButtonBar
+    static constexpr int kGoodbyeH = 32;                       // Task 7: GOODBYE button
+    static constexpr int kMoodBarH = MoodSliderBar::kMoodBarH; // Wave 5 D2: mood sliders
 
     //==========================================================================
     // Constructor / Destructor
@@ -1447,19 +1453,21 @@ public:
     // Wave5-D3: XouijaPinStore access
     //
     // D1 (cell layers), D2 (mood), and C5 (slot ModSources) all read/write
-    // the pin store via this reference.
+    // the pin store via this reference.  Publishing to SlotModSourceRegistry
+    // goes through the store's onPinChanged callback wired in setProcessor().
     //
-    // C5 wiring (#1360) — call in PlaySurface::setProcessor() after the
-    // processor pointer is valid:
+    // feat(#1383 A4): C5 wiring is LIVE — PlaySurface::setProcessor() installs:
     //
     //   xouijaPanel_.getPinStore().onPinChanged =
     //       [this](float bx, float by) {
-    //           processor_->getModSourceRegistry()
-    //               .updateSourceValue(ModSourceId::XouijaCell, bx, by);
+    //           auto& reg = processor_->getModSourceRegistry();
+    //           reg.updateSourceValue(ModSourceId::XouijaX, bx);    // ID=28
+    //           reg.updateSourceValue(ModSourceId::XouijaY, by);    // ID=29
+    //           reg.updateSourceValue(ModSourceId::XouijaCell, bx, by); // ID=18
     //       };
     //
-    // SlotModSourceRegistry lives in Source/Core/SlotModSourceRegistry.h.
-    // XOceanusProcessor exposes it via getModSourceRegistry().
+    // SlotModSourceRegistry: Source/Core/SlotModSourceRegistry.h.
+    // XOceanusProcessor exposes the registry via getModSourceRegistry().
     //==========================================================================
     XouijaPinStore& getPinStore() noexcept { return pinStore_; }
     const XouijaPinStore& getPinStore() const noexcept { return pinStore_; }
@@ -1476,8 +1484,8 @@ public:
         float macroRange[4] = {0.5f, 0.5f, 0.5f, 0.5f};
 
         // 6D Sonic DNA (0-1 each), sourced from PresetDNA.
-        float dnaMovement   = 0.5f; // weights X-axis sensitivity contribution
-        float dnaSpace      = 0.5f; // weights Y-axis sensitivity contribution
+        float dnaMovement = 0.5f;   // weights X-axis sensitivity contribution
+        float dnaSpace = 0.5f;      // weights Y-axis sensitivity contribution
         float dnaAggression = 0.5f; // sharpens the overall contrast of the map
 
         // True when a real preset hint has been pushed (not default-constructed).
@@ -1534,8 +1542,8 @@ public:
     {
         moodState_ = v;
         moodState_.brightness = juce::jlimit(0.0f, 1.0f, moodState_.brightness);
-        moodState_.tension    = juce::jlimit(0.0f, 1.0f, moodState_.tension);
-        moodState_.density    = juce::jlimit(0.0f, 1.0f, moodState_.density);
+        moodState_.tension = juce::jlimit(0.0f, 1.0f, moodState_.tension);
+        moodState_.density = juce::jlimit(0.0f, 1.0f, moodState_.density);
         moodSliderBar_.setMoodValues(moodState_);
         moodHeatmapDirty_ = true;
         repaint();
@@ -1624,8 +1632,8 @@ public:
 
         // Wave 5 D2: mood state + heatmap visibility
         tree.setProperty("moodBrightness", static_cast<double>(moodState_.brightness), nullptr);
-        tree.setProperty("moodTension",    static_cast<double>(moodState_.tension),    nullptr);
-        tree.setProperty("moodDensity",    static_cast<double>(moodState_.density),    nullptr);
+        tree.setProperty("moodTension", static_cast<double>(moodState_.tension), nullptr);
+        tree.setProperty("moodDensity", static_cast<double>(moodState_.density), nullptr);
         tree.setProperty("heatmapVisible", heatmapVisible_, nullptr);
 
         return tree;
@@ -1685,12 +1693,9 @@ public:
         if (tree.hasProperty("moodBrightness"))
         {
             MoodSliderBar::MoodValues m;
-            m.brightness = juce::jlimit(0.0f, 1.0f,
-                               static_cast<float>(static_cast<double>(tree["moodBrightness"])));
-            m.tension    = juce::jlimit(0.0f, 1.0f,
-                               static_cast<float>(static_cast<double>(tree["moodTension"])));
-            m.density    = juce::jlimit(0.0f, 1.0f,
-                               static_cast<float>(static_cast<double>(tree["moodDensity"])));
+            m.brightness = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(tree["moodBrightness"])));
+            m.tension = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(tree["moodTension"])));
+            m.density = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(tree["moodDensity"])));
             moodState_ = m;
             moodSliderBar_.setMoodValues(moodState_);
             moodHeatmapDirty_ = true;
@@ -1856,18 +1861,17 @@ public:
         if (e.mods.isRightButtonDown() && harmonicSurfaceBounds_.contains(e.getPosition()))
         {
             auto [nx, ny] = mouseToNormalized(e);
-            XouijaPinContextMenu::show(
-                pinStore_, nx, ny, this,
-                [this](float rx, float ry)
-                {
-                    // Recall: move panel to the captured position.
-                    circleX_     = rx;
-                    influenceY_  = ry;
-                    planchette_.springTo(rx, ry);
-                    updatePlanchetteText();
-                    repaint();
-                    fireCallbacks();
-                });
+            XouijaPinContextMenu::show(pinStore_, nx, ny, this,
+                                       [this](float rx, float ry)
+                                       {
+                                           // Recall: move panel to the captured position.
+                                           circleX_ = rx;
+                                           influenceY_ = ry;
+                                           planchette_.springTo(rx, ry);
+                                           updatePlanchetteText();
+                                           repaint();
+                                           fireCallbacks();
+                                       });
         }
     }
 
@@ -1917,11 +1921,11 @@ private:
     GoodbyeButton goodbyeButton_;
 
     // Wave 5 D2 — Mood sliders + heatmap
-    MoodSliderBar          moodSliderBar_;
-    MoodSliderBar::MoodValues moodState_;      // current mood (brightness/tension/density)
-    bool                   heatmapVisible_ = true;   // toggle for the overlay
-    juce::Image            moodHeatmapImage_;         // 64×64 ARGB, coloured heatmap
-    bool                   moodHeatmapDirty_ = true;  // triggers lazy recompute
+    MoodSliderBar moodSliderBar_;
+    MoodSliderBar::MoodValues moodState_; // current mood (brightness/tension/density)
+    bool heatmapVisible_ = true;          // toggle for the overlay
+    juce::Image moodHeatmapImage_;        // 64×64 ARGB, coloured heatmap
+    bool moodHeatmapDirty_ = true;        // triggers lazy recompute
 
     // Per-bank button definitions: indexed by GestureButtonBar::Bank enum.
     // Populated in setupDefaultButtonBank() / setupDubButtonBank() /
@@ -1964,8 +1968,8 @@ private:
     // sensitivityMapDirty_ is set true on construction and whenever a preset
     // is loaded (fromValueTree). recomputeSensitivityMap() is called lazily
     // on the first paint() call after the flag is raised.
-    juce::Image sensitivityMap_;        // 64×64 ARGB luminance texture (white pixels, alpha = sensitivity)
-    bool sensitivityMapDirty_ = true;   // triggers recompute on next paint()
+    juce::Image sensitivityMap_;      // 64×64 ARGB luminance texture (white pixels, alpha = sensitivity)
+    bool sensitivityMapDirty_ = true; // triggers recompute on next paint()
 
     // ── Preset Sensitivity Hint ───────────────────────────────────────────────
     // Pushed by the host (PlaySurface / PresetManager listener) after each
@@ -2128,8 +2132,8 @@ private:
         float buf[kW * kH];
 
         const float mB = moodState_.brightness; // [0,1]
-        const float mT = moodState_.tension;     // [0,1]
-        const float mD = moodState_.density;     // [0,1]
+        const float mT = moodState_.tension;    // [0,1]
+        const float mD = moodState_.density;    // [0,1]
 
         for (int row = 0; row < kH; ++row)
         {
@@ -2143,15 +2147,15 @@ private:
 
                 // ── Implicit cell texture vector (placeholder for D1 data) ──
                 // D1 will replace these three lines with per-cell stored vectors.
-                const float cellBrightness = nx;                               // left=dark, right=bright
-                const float cellTension    = 1.0f - ny;                       // top=tense, bottom=calm
-                const float cellDensity    = 2.0f * std::sqrt((nx - 0.5f) * (nx - 0.5f)
-                                                             + (ny - 0.5f) * (ny - 0.5f));  // radial [0,√2] → clamp to [0,1]
+                const float cellBrightness = nx;     // left=dark, right=bright
+                const float cellTension = 1.0f - ny; // top=tense, bottom=calm
+                const float cellDensity = 2.0f * std::sqrt((nx - 0.5f) * (nx - 0.5f) +
+                                                           (ny - 0.5f) * (ny - 0.5f)); // radial [0,√2] → clamp to [0,1]
                 const float cellDensityClamped = juce::jlimit(0.0f, 1.0f, cellDensity);
 
                 // Euclidean distance in mood-space [0, √3]
-                const float dB = cellBrightness  - mB;
-                const float dT = cellTension     - mT;
+                const float dB = cellBrightness - mB;
+                const float dT = cellTension - mT;
                 const float dD = cellDensityClamped - mD;
                 const float dist = std::sqrt(dB * dB + dT * dT + dD * dD);
 
@@ -2170,7 +2174,7 @@ private:
             for (int col = 0; col < kW; ++col)
             {
                 float sum = 0.0f;
-                int   cnt = 0;
+                int cnt = 0;
                 for (int dr = -1; dr <= 1; ++dr)
                 {
                     const int nr = juce::jlimit(0, kH - 1, row + dr);
@@ -2191,8 +2195,8 @@ private:
         moodHeatmapImage_ = juce::Image(juce::Image::ARGB, kW, kH, true);
         {
             const float r = accentColour_.getFloatRed();
-            const float gr= accentColour_.getFloatGreen();
-            const float bl= accentColour_.getFloatBlue();
+            const float gr = accentColour_.getFloatGreen();
+            const float bl = accentColour_.getFloatBlue();
 
             juce::Image::BitmapData data(moodHeatmapImage_, juce::Image::BitmapData::writeOnly);
             for (int row = 0; row < kH; ++row)
@@ -2202,9 +2206,9 @@ private:
                     const float heat = blurred[row * kW + col];
                     // Alpha: 0 at heat=0, up to 153 (~60%) at heat=1.0
                     const uint8_t alpha = static_cast<uint8_t>(heat * 153.0f);
-                    const uint8_t rc    = static_cast<uint8_t>(r  * 255.0f);
-                    const uint8_t gc    = static_cast<uint8_t>(gr * 255.0f);
-                    const uint8_t bc    = static_cast<uint8_t>(bl * 255.0f);
+                    const uint8_t rc = static_cast<uint8_t>(r * 255.0f);
+                    const uint8_t gc = static_cast<uint8_t>(gr * 255.0f);
+                    const uint8_t bc = static_cast<uint8_t>(bl * 255.0f);
                     data.setPixelColour(col, row, juce::Colour::fromRGBA(rc, gc, bc, alpha));
                 }
             }
@@ -2229,8 +2233,7 @@ private:
 
         const auto surfaceBounds = harmonicSurfaceBounds_.toFloat();
         g.setOpacity(0.30f);
-        g.drawImage(moodHeatmapImage_, surfaceBounds,
-                    juce::RectanglePlacement::fillDestination, false);
+        g.drawImage(moodHeatmapImage_, surfaceBounds, juce::RectanglePlacement::fillDestination, false);
         g.setOpacity(1.0f);
     }
 
@@ -2297,21 +2300,20 @@ private:
             // further scaled by the movement DNA dimension.
             // A dead macro (range=0) contributes nothing; a full-sweep macro (range=1)
             // contributes maximally.
-            const float xMacroStrength = (presetHint_.macroRange[0] + presetHint_.macroRange[1])
-                                         * (0.5f + presetHint_.dnaMovement * 0.5f); // [0, 2] * [0.5, 1]
+            const float xMacroStrength = (presetHint_.macroRange[0] + presetHint_.macroRange[1]) *
+                                         (0.5f + presetHint_.dnaMovement * 0.5f); // [0, 2] * [0.5, 1]
 
             // Y-axis contribution weights: COUPLE + DEPTH macro range widths, [D11]
             // further scaled by the space DNA dimension.
-            const float yMacroStrength = (presetHint_.macroRange[2] + presetHint_.macroRange[3])
-                                         * (0.5f + presetHint_.dnaSpace * 0.5f);
+            const float yMacroStrength =
+                (presetHint_.macroRange[2] + presetHint_.macroRange[3]) * (0.5f + presetHint_.dnaSpace * 0.5f);
 
             // Axis balance: 0 = pure X, 1 = pure Y.
             // When both are equal we blend 50/50.  Clamp to avoid a fully-black map
             // (total = 0 should never happen in practice, but guard defensively).
             const float totalStrength = xMacroStrength + yMacroStrength;
-            const float axisBalance   = (totalStrength > 1e-6f)
-                                        ? (yMacroStrength / totalStrength)
-                                        : 0.5f; // equal blend if all macros are dead
+            const float axisBalance =
+                (totalStrength > 1e-6f) ? (yMacroStrength / totalStrength) : 0.5f; // equal blend if all macros are dead
 
             // Normalised X-axis contribution magnitudes (saturate to [0, 1]).
             const float xNorm = juce::jlimit(0.0f, 1.0f, xMacroStrength * 0.5f);
@@ -2327,8 +2329,8 @@ private:
             // influence depth.  We model this as two Gaussian peaks at y=0 and y=1.
             // Their relative weights follow influenceY_ so the current position
             // pulls the glow toward whichever pole is active.
-            const float yPoleLow  = 1.0f - influenceY_; // weight for the NO=0 pole
-            const float yPoleHigh = influenceY_;          // weight for the YES=1 pole
+            const float yPoleLow = 1.0f - influenceY_; // weight for the NO=0 pole
+            const float yPoleHigh = influenceY_;       // weight for the YES=1 pole
 
             // Aggression drives the contrast (power curve exponent).
             // Low aggression (0) → exponent 1 (linear, soft glow)
@@ -2354,9 +2356,9 @@ private:
 
                     // --- Y sensitivity ---
                     // Two Gaussian poles at ny=0 and ny=1 weighted by current influenceY_.
-                    const float dyLow  = ny;         // distance from y=0 (NO pole)
-                    const float dyHigh = 1.0f - ny;  // distance from y=1 (YES pole)
-                    const float gaussLow  = std::exp(-dyLow  * dyLow  * 12.0f); // σ ≈ 0.20
+                    const float dyLow = ny;                                  // distance from y=0 (NO pole)
+                    const float dyHigh = 1.0f - ny;                          // distance from y=1 (YES pole)
+                    const float gaussLow = std::exp(-dyLow * dyLow * 12.0f); // σ ≈ 0.20
                     const float gaussHigh = std::exp(-dyHigh * dyHigh * 12.0f);
                     const float ySens = yNorm * (yPoleLow * gaussLow + yPoleHigh * gaussHigh);
 
@@ -2409,7 +2411,7 @@ private:
             {
                 // Accumulate the 3×3 neighbourhood (clamped to image edges).
                 float sum = 0.0f;
-                int   cnt = 0;
+                int cnt = 0;
                 for (int dr = -1; dr <= 1; ++dr)
                 {
                     const int nr = juce::jlimit(0, kH - 1, row + dr);
@@ -2435,8 +2437,8 @@ private:
             {
                 for (int col = 0; col < kW; ++col)
                 {
-                    const uint8_t alpha = static_cast<uint8_t>(
-                        juce::jlimit(0.0f, 1.0f, blurred[row * kW + col]) * 255.0f);
+                    const uint8_t alpha =
+                        static_cast<uint8_t>(juce::jlimit(0.0f, 1.0f, blurred[row * kW + col]) * 255.0f);
                     data.setPixelColour(col, row, juce::Colour::fromRGBA(255, 255, 255, alpha));
                 }
             }
@@ -2533,14 +2535,14 @@ private:
 
         // DEEP — near the top of the harmonic surface (high influence)
         const float deepY = b.getY() + 10.0f;
-        g.drawText("DEEP", juce::Rectangle<float>(b.getX(), deepY, b.getWidth(), 14.0f),
-                   juce::Justification::centred, false);
+        g.drawText("DEEP", juce::Rectangle<float>(b.getX(), deepY, b.getWidth(), 14.0f), juce::Justification::centred,
+                   false);
 
         // FREE — above the bottom reserved area (no harmonic constraint)
         const float reservedBottom = static_cast<float>(kGestureBarH + kGoodbyeH);
         const float freeY = b.getBottom() - reservedBottom - 18.0f;
-        g.drawText("FREE", juce::Rectangle<float>(b.getX(), freeY, b.getWidth(), 14.0f),
-                   juce::Justification::centred, false);
+        g.drawText("FREE", juce::Rectangle<float>(b.getX(), freeY, b.getWidth(), 14.0f), juce::Justification::centred,
+                   false);
 
         // ── Onboarding axis labels (translucent guide text, issue #887) ──────
         // Watermark-style text that helps first-time users understand the axes.
@@ -2561,14 +2563,11 @@ private:
             const float rightEdgeX = b.getRight() - 12.0f;
 
             juce::GlyphArrangement glyphs;
-            glyphs.addLineOfText(kGuideFont,
-                                 juce::CharPointer_UTF8("HARMONIC DEPTH \xe2\x86\x95"),
-                                 0.0f, 0.0f);
+            glyphs.addLineOfText(kGuideFont, juce::CharPointer_UTF8("HARMONIC DEPTH \xe2\x86\x95"), 0.0f, 0.0f);
 
             // Rotate -90° around the right-edge anchor, then translate to position
-            const juce::AffineTransform rotate =
-                juce::AffineTransform::rotation(-juce::MathConstants<float>::halfPi)
-                    .translated(rightEdgeX, surfaceCentreY);
+            const juce::AffineTransform rotate = juce::AffineTransform::rotation(-juce::MathConstants<float>::halfPi)
+                                                     .translated(rightEdgeX, surfaceCentreY);
             glyphs.draw(g, rotate);
         }
     }
@@ -2713,7 +2712,8 @@ private:
         for (int i = 0; i < XouijaPinStore::kNumCaptureSlots; ++i)
         {
             const auto& s = pinStore_.getSlot(i);
-            if (!s.hasCapture) continue;
+            if (!s.hasCapture)
+                continue;
             juce::String label = "C" + juce::String(i + 1);
             if (s.targetSlot != XouijaCaptureSlot::EngineTarget::Global)
                 label += "  " + XouijaCaptureSlot::engineTargetName(s.targetSlot);

--- a/Source/UI/PlaySurface/XouijaPinStore.h
+++ b/Source/UI/PlaySurface/XouijaPinStore.h
@@ -13,11 +13,12 @@
 // Coordination notes:
 //   - D1 (cell layers) reads XouijaPinStore to decorate cell badge overlays.
 //   - D2 (mood) reads targetSlot to determine per-engine mood filter.
-//   - C5 (slot-based ModSources): when C5 lands, hook XouijaPinStore::onPinChanged
-//     into the C5 SlotModSourceRegistry.  Until then, the live pin value is exposed
-//     via getPinnedCircleX() / getPinnedInfluenceY() for polling.
+//   - C5 (SlotModSourceRegistry, #1360 SHIPPED): XouijaPinStore::onPinChanged is
+//     wired in PlaySurface::setProcessor() to push bipolar X+Y values into
+//     SlotModSourceRegistry → processBlock reads them as ModSourceId::XouijaX /
+//     ModSourceId::XouijaY.  See #1383 A4 for the reconciled wiring.
 //   - ModRoutingModel: call pinStore.registerWithModRouter(modModel) to create a
-//     live ModSourceId::XouijaCell route entry that tracks the pinned values.
+//     live ModSourceId::XouijaX / XouijaY route entry that tracks the pinned values.
 //
 // Thread safety: all methods are message-thread-only (same as ModRoutingModel).
 //
@@ -40,7 +41,7 @@ struct XouijaCaptureSlot
     juce::String name;
 
     // Normalized [0, 1] position captured from XOuijaPanel.
-    float circleX  = 0.5f;
+    float circleX = 0.5f;
     float influenceY = 0.0f;
 
     // Whether this slot contains a valid snapshot (vs. empty/default).
@@ -58,10 +59,10 @@ struct XouijaCaptureSlot
     enum class EngineTarget : uint8_t
     {
         Global = 0,
-        Slot0  = 1,
-        Slot1  = 2,
-        Slot2  = 3,
-        Slot3  = 4,
+        Slot0 = 1,
+        Slot1 = 2,
+        Slot2 = 3,
+        Slot3 = 4,
     };
     EngineTarget targetSlot = EngineTarget::Global;
 
@@ -71,11 +72,11 @@ struct XouijaCaptureSlot
     juce::ValueTree toValueTree() const
     {
         juce::ValueTree vt("XouijaCaptureSlot");
-        vt.setProperty("name",       name,                                nullptr);
-        vt.setProperty("circleX",    static_cast<double>(circleX),        nullptr);
-        vt.setProperty("influenceY", static_cast<double>(influenceY),     nullptr);
-        vt.setProperty("hasCapture", hasCapture,                          nullptr);
-        vt.setProperty("targetSlot", static_cast<int>(targetSlot),        nullptr);
+        vt.setProperty("name", name, nullptr);
+        vt.setProperty("circleX", static_cast<double>(circleX), nullptr);
+        vt.setProperty("influenceY", static_cast<double>(influenceY), nullptr);
+        vt.setProperty("hasCapture", hasCapture, nullptr);
+        vt.setProperty("targetSlot", static_cast<int>(targetSlot), nullptr);
         return vt;
     }
 
@@ -83,26 +84,31 @@ struct XouijaCaptureSlot
     {
         if (!vt.isValid() || !vt.hasType("XouijaCaptureSlot"))
             return;
-        name        = vt.getProperty("name", "").toString();
-        circleX     = juce::jlimit(0.0f, 1.0f,
-                          static_cast<float>(static_cast<double>(vt.getProperty("circleX", 0.5))));
-        influenceY  = juce::jlimit(0.0f, 1.0f,
-                          static_cast<float>(static_cast<double>(vt.getProperty("influenceY", 0.0))));
-        hasCapture  = static_cast<bool>(vt.getProperty("hasCapture", false));
+        name = vt.getProperty("name", "").toString();
+        circleX = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(vt.getProperty("circleX", 0.5))));
+        influenceY =
+            juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(vt.getProperty("influenceY", 0.0))));
+        hasCapture = static_cast<bool>(vt.getProperty("hasCapture", false));
         const int t = static_cast<int>(vt.getProperty("targetSlot", 0));
-        targetSlot  = (t >= 0 && t <= 4) ? static_cast<EngineTarget>(t) : EngineTarget::Global;
+        targetSlot = (t >= 0 && t <= 4) ? static_cast<EngineTarget>(t) : EngineTarget::Global;
     }
 
     static juce::String engineTargetName(EngineTarget t)
     {
         switch (t)
         {
-        case EngineTarget::Global: return "Global";
-        case EngineTarget::Slot0:  return "Slot 0";
-        case EngineTarget::Slot1:  return "Slot 1";
-        case EngineTarget::Slot2:  return "Slot 2";
-        case EngineTarget::Slot3:  return "Slot 3";
-        default:                   return "Global";
+        case EngineTarget::Global:
+            return "Global";
+        case EngineTarget::Slot0:
+            return "Slot 0";
+        case EngineTarget::Slot1:
+            return "Slot 1";
+        case EngineTarget::Slot2:
+            return "Slot 2";
+        case EngineTarget::Slot3:
+            return "Slot 3";
+        default:
+            return "Global";
         }
     }
 };
@@ -147,7 +153,7 @@ public:
     // Pin the current XOuija position as a ModSource.  Fires onPinChanged.
     void pin(float circleX, float influenceY)
     {
-        isPinned_     = true;
+        isPinned_ = true;
         pinnedCircleX_ = juce::jlimit(0.0f, 1.0f, circleX);
         pinnedInfluenceY_ = juce::jlimit(0.0f, 1.0f, influenceY);
         notifyListeners();
@@ -156,7 +162,8 @@ public:
     // Remove the live pin.  Fires onPinChanged.
     void unpin()
     {
-        if (!isPinned_) return;
+        if (!isPinned_)
+            return;
         isPinned_ = false;
         notifyListeners();
     }
@@ -165,11 +172,11 @@ public:
 
     // Bipolar [-1, +1] version of the pinned circle position.
     // Returns 0 when not pinned.
-    float getPinnedCircleX()    const noexcept { return isPinned_ ? (pinnedCircleX_    * 2.0f - 1.0f) : 0.0f; }
+    float getPinnedCircleX() const noexcept { return isPinned_ ? (pinnedCircleX_ * 2.0f - 1.0f) : 0.0f; }
     float getPinnedInfluenceY() const noexcept { return isPinned_ ? (pinnedInfluenceY_ * 2.0f - 1.0f) : 0.0f; }
 
     // Raw [0,1] versions (for recalling to the panel position).
-    float getRawPinnedCircleX()    const noexcept { return pinnedCircleX_; }
+    float getRawPinnedCircleX() const noexcept { return pinnedCircleX_; }
     float getRawPinnedInfluenceY() const noexcept { return pinnedInfluenceY_; }
 
     //==========================================================================
@@ -177,12 +184,12 @@ public:
 
     // Snapshot the given position into slot n (0-3).
     // Silently clamps n to [0, kNumCaptureSlots-1].
-    void captureToSlot(int n, float circleX, float influenceY,
-                       const juce::String& slotName = {})
+    void captureToSlot(int n, float circleX, float influenceY, const juce::String& slotName = {})
     {
-        if (n < 0 || n >= kNumCaptureSlots) return;
+        if (n < 0 || n >= kNumCaptureSlots)
+            return;
         auto& s = slots_[static_cast<std::size_t>(n)];
-        s.circleX    = juce::jlimit(0.0f, 1.0f, circleX);
+        s.circleX = juce::jlimit(0.0f, 1.0f, circleX);
         s.influenceY = juce::jlimit(0.0f, 1.0f, influenceY);
         s.hasCapture = true;
         if (slotName.isNotEmpty())
@@ -195,7 +202,8 @@ public:
     // Clear a capture slot.
     void clearSlot(int n)
     {
-        if (n < 0 || n >= kNumCaptureSlots) return;
+        if (n < 0 || n >= kNumCaptureSlots)
+            return;
         slots_[static_cast<std::size_t>(n)] = {};
         notifyListeners();
     }
@@ -211,7 +219,8 @@ public:
     // Set the engine routing target for capture slot n.
     void setTargetSlot(int n, XouijaCaptureSlot::EngineTarget target)
     {
-        if (n < 0 || n >= kNumCaptureSlots) return;
+        if (n < 0 || n >= kNumCaptureSlots)
+            return;
         slots_[static_cast<std::size_t>(n)].targetSlot = target;
         notifyListeners();
     }
@@ -232,22 +241,23 @@ public:
     void removeListener(juce::ChangeListener* l) { broadcaster_.removeChangeListener(l); }
 
     //==========================================================================
-    // Callback for C5 integration (optional — set before using pin as ModSource).
+    // Callback for SlotModSourceRegistry bridge (#1383 A4).
     //
     // Fires whenever the pinned value changes (pin / unpin / position update).
-    // Wire this in PlaySurface::setProcessor() (or equivalent host site) as:
+    // When pinned, bx/by carry the bipolar [-1,+1] planchette position.
+    // When unpinned, bx=0/by=0 so the registry resets to neutral.
+    //
+    // Wired in PlaySurface::setProcessor():
     //
     //   xouijaPanel_.getPinStore().onPinChanged =
     //       [this](float bx, float by) {
-    //           processor_->getModSourceRegistry()
-    //               .updateSourceValue(ModSourceId::XouijaCell, bx, by);
+    //           auto& reg = processor_->getModSourceRegistry();
+    //           reg.updateSourceValue(ModSourceId::XouijaX, bx);
+    //           reg.updateSourceValue(ModSourceId::XouijaY, by);
+    //           reg.updateSourceValue(ModSourceId::XouijaCell, bx, by);
     //       };
     //
-    // SlotModSourceRegistry is implemented in Source/Core/SlotModSourceRegistry.h.
-    // The registry forwards bx/by to std::atomic<float> pairs read by processBlock
-    // as ModSourceId::XouijaCell (ID 18, frozen for preset serialisation).
-    //
-    // bx / by are bipolar [-1, +1].
+    // bx / by are bipolar [-1, +1].  Message-thread only.
     //
     std::function<void(float /*bx*/, float /*by*/)> onPinChanged;
 
@@ -257,10 +267,10 @@ public:
     juce::ValueTree toValueTree() const
     {
         juce::ValueTree vt("XouijaPinStore");
-        vt.setProperty("isPinned",        isPinned_,                                nullptr);
-        vt.setProperty("pinnedCircleX",   static_cast<double>(pinnedCircleX_),      nullptr);
-        vt.setProperty("pinnedInfluenceY",static_cast<double>(pinnedInfluenceY_),   nullptr);
-        vt.setProperty("pinTargetSlot",   static_cast<int>(pinTargetSlot_),         nullptr);
+        vt.setProperty("isPinned", isPinned_, nullptr);
+        vt.setProperty("pinnedCircleX", static_cast<double>(pinnedCircleX_), nullptr);
+        vt.setProperty("pinnedInfluenceY", static_cast<double>(pinnedInfluenceY_), nullptr);
+        vt.setProperty("pinTargetSlot", static_cast<int>(pinTargetSlot_), nullptr);
         for (int i = 0; i < kNumCaptureSlots; ++i)
             vt.appendChild(slots_[static_cast<std::size_t>(i)].toValueTree(), nullptr);
         return vt;
@@ -270,14 +280,14 @@ public:
     {
         if (!vt.isValid() || !vt.hasType("XouijaPinStore"))
             return;
-        isPinned_          = static_cast<bool>(vt.getProperty("isPinned", false));
-        pinnedCircleX_     = juce::jlimit(0.0f, 1.0f,
-                                static_cast<float>(static_cast<double>(vt.getProperty("pinnedCircleX", 0.5))));
-        pinnedInfluenceY_  = juce::jlimit(0.0f, 1.0f,
-                                static_cast<float>(static_cast<double>(vt.getProperty("pinnedInfluenceY", 0.0))));
+        isPinned_ = static_cast<bool>(vt.getProperty("isPinned", false));
+        pinnedCircleX_ =
+            juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(vt.getProperty("pinnedCircleX", 0.5))));
+        pinnedInfluenceY_ =
+            juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(vt.getProperty("pinnedInfluenceY", 0.0))));
         const int t = static_cast<int>(vt.getProperty("pinTargetSlot", 0));
         pinTargetSlot_ = (t >= 0 && t <= 4) ? static_cast<XouijaCaptureSlot::EngineTarget>(t)
-                                             : XouijaCaptureSlot::EngineTarget::Global;
+                                            : XouijaCaptureSlot::EngineTarget::Global;
         int slotIdx = 0;
         for (int c = 0; c < vt.getNumChildren() && slotIdx < kNumCaptureSlots; ++c)
         {
@@ -295,14 +305,19 @@ private:
     void notifyListeners()
     {
         broadcaster_.sendChangeMessage();
-        if (isPinned_ && onPinChanged)
-            onPinChanged(getPinnedCircleX(), getPinnedInfluenceY());
+        if (onPinChanged)
+        {
+            if (isPinned_)
+                onPinChanged(getPinnedCircleX(), getPinnedInfluenceY());
+            else
+                onPinChanged(0.0f, 0.0f);
+        }
     }
 
     // Live pin state
-    bool  isPinned_          = false;
-    float pinnedCircleX_     = 0.5f;
-    float pinnedInfluenceY_  = 0.0f;
+    bool isPinned_ = false;
+    float pinnedCircleX_ = 0.5f;
+    float pinnedInfluenceY_ = 0.0f;
     XouijaCaptureSlot::EngineTarget pinTargetSlot_ = XouijaCaptureSlot::EngineTarget::Global;
 
     // Named capture slots
@@ -347,15 +362,14 @@ struct XouijaPinContextMenu
     //  50-99     = inner sub-items for per-slot target (50+slotIdx*5 + targetEnum)
     //  100-103   = clear slot 0-3
     //
-    static constexpr int kTogglePin    = 1;
-    static constexpr int kPinTargetBase= 10;  // +0=Global +1=Slot0 +2=Slot1 +3=Slot2 +4=Slot3
-    static constexpr int kCaptureBase  = 20;  // +slotIdx
-    static constexpr int kRecallBase   = 30;  // +slotIdx
-    static constexpr int kSlotTgtBase  = 50;  // +slotIdx*5 + targetEnum
-    static constexpr int kClearBase    = 100; // +slotIdx
+    static constexpr int kTogglePin = 1;
+    static constexpr int kPinTargetBase = 10; // +0=Global +1=Slot0 +2=Slot1 +3=Slot2 +4=Slot3
+    static constexpr int kCaptureBase = 20;   // +slotIdx
+    static constexpr int kRecallBase = 30;    // +slotIdx
+    static constexpr int kSlotTgtBase = 50;   // +slotIdx*5 + targetEnum
+    static constexpr int kClearBase = 100;    // +slotIdx
 
-    static void show(XouijaPinStore& store, float curCircleX, float curInfluenceY,
-                     juce::Component* relativeTo,
+    static void show(XouijaPinStore& store, float curCircleX, float curInfluenceY, juce::Component* relativeTo,
                      std::function<void(float x, float y)> onRecall)
     {
         juce::PopupMenu menu;
@@ -374,9 +388,7 @@ struct XouijaPinContextMenu
             {
                 auto et = static_cast<XouijaCaptureSlot::EngineTarget>(t);
                 bool active = (store.getPinTargetSlot() == et);
-                pinTargetMenu.addItem(kPinTargetBase + t,
-                                      XouijaCaptureSlot::engineTargetName(et),
-                                      true, active);
+                pinTargetMenu.addItem(kPinTargetBase + t, XouijaCaptureSlot::engineTargetName(et), true, active);
             }
             menu.addSubMenu("Route pin to engine...", pinTargetMenu);
         }
@@ -404,9 +416,9 @@ struct XouijaPinContextMenu
             juce::String label = "Recall Slot " + juce::String(i + 1);
             if (s.hasCapture)
             {
-                if (s.name.isNotEmpty()) label += "  \"" + s.name + "\"";
-                label += "  [X:" + juce::String(s.circleX, 2)
-                       + " Y:" + juce::String(s.influenceY, 2) + "]";
+                if (s.name.isNotEmpty())
+                    label += "  \"" + s.name + "\"";
+                label += "  [X:" + juce::String(s.circleX, 2) + " Y:" + juce::String(s.influenceY, 2) + "]";
             }
 
             // Recall submenu for occupied slots includes "Route to..."
@@ -420,9 +432,7 @@ struct XouijaPinContextMenu
                 {
                     auto et = static_cast<XouijaCaptureSlot::EngineTarget>(t);
                     bool active = (s.targetSlot == et);
-                    tgtSub.addItem(kSlotTgtBase + i * 5 + t,
-                                   XouijaCaptureSlot::engineTargetName(et),
-                                   true, active);
+                    tgtSub.addItem(kSlotTgtBase + i * 5 + t, XouijaCaptureSlot::engineTargetName(et), true, active);
                 }
                 recallSub.addSubMenu("Route to engine...", tgtSub);
                 recallSub.addItem(kClearBase + i, "Clear slot");
@@ -434,59 +444,60 @@ struct XouijaPinContextMenu
             }
         }
 
-        menu.showMenuAsync(
-            juce::PopupMenu::Options{}.withTargetComponent(relativeTo),
-            [&store, curCircleX, curInfluenceY, onRecall](int result)
-            {
-                if (result <= 0) return;
+        menu.showMenuAsync(juce::PopupMenu::Options{}.withTargetComponent(relativeTo),
+                           [&store, curCircleX, curInfluenceY, onRecall](int result)
+                           {
+                               if (result <= 0)
+                                   return;
 
-                if (result == kTogglePin)
-                {
-                    if (store.hasPinnedValue())
-                        store.unpin();
-                    else
-                        store.pin(curCircleX, curInfluenceY);
-                    return;
-                }
+                               if (result == kTogglePin)
+                               {
+                                   if (store.hasPinnedValue())
+                                       store.unpin();
+                                   else
+                                       store.pin(curCircleX, curInfluenceY);
+                                   return;
+                               }
 
-                if (result >= kPinTargetBase && result < kPinTargetBase + 5)
-                {
-                    auto et = static_cast<XouijaCaptureSlot::EngineTarget>(result - kPinTargetBase);
-                    store.setPinTargetSlot(et);
-                    return;
-                }
+                               if (result >= kPinTargetBase && result < kPinTargetBase + 5)
+                               {
+                                   auto et = static_cast<XouijaCaptureSlot::EngineTarget>(result - kPinTargetBase);
+                                   store.setPinTargetSlot(et);
+                                   return;
+                               }
 
-                if (result >= kCaptureBase && result < kCaptureBase + XouijaPinStore::kNumCaptureSlots)
-                {
-                    int idx = result - kCaptureBase;
-                    store.captureToSlot(idx, curCircleX, curInfluenceY);
-                    return;
-                }
+                               if (result >= kCaptureBase && result < kCaptureBase + XouijaPinStore::kNumCaptureSlots)
+                               {
+                                   int idx = result - kCaptureBase;
+                                   store.captureToSlot(idx, curCircleX, curInfluenceY);
+                                   return;
+                               }
 
-                if (result >= kRecallBase && result < kRecallBase + XouijaPinStore::kNumCaptureSlots)
-                {
-                    int idx = result - kRecallBase;
-                    const auto& s = store.getSlot(idx);
-                    if (s.hasCapture && onRecall)
-                        onRecall(s.circleX, s.influenceY);
-                    return;
-                }
+                               if (result >= kRecallBase && result < kRecallBase + XouijaPinStore::kNumCaptureSlots)
+                               {
+                                   int idx = result - kRecallBase;
+                                   const auto& s = store.getSlot(idx);
+                                   if (s.hasCapture && onRecall)
+                                       onRecall(s.circleX, s.influenceY);
+                                   return;
+                               }
 
-                if (result >= kSlotTgtBase && result < kSlotTgtBase + XouijaPinStore::kNumCaptureSlots * 5)
-                {
-                    int raw  = result - kSlotTgtBase;
-                    int si   = raw / 5;
-                    int ti   = raw % 5;
-                    store.setTargetSlot(si, static_cast<XouijaCaptureSlot::EngineTarget>(ti));
-                    return;
-                }
+                               if (result >= kSlotTgtBase &&
+                                   result < kSlotTgtBase + XouijaPinStore::kNumCaptureSlots * 5)
+                               {
+                                   int raw = result - kSlotTgtBase;
+                                   int si = raw / 5;
+                                   int ti = raw % 5;
+                                   store.setTargetSlot(si, static_cast<XouijaCaptureSlot::EngineTarget>(ti));
+                                   return;
+                               }
 
-                if (result >= kClearBase && result < kClearBase + XouijaPinStore::kNumCaptureSlots)
-                {
-                    store.clearSlot(result - kClearBase);
-                    return;
-                }
-            });
+                               if (result >= kClearBase && result < kClearBase + XouijaPinStore::kNumCaptureSlots)
+                               {
+                                   store.clearSlot(result - kClearBase);
+                                   return;
+                               }
+                           });
     }
 };
 

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -115,7 +115,7 @@
 #include "DSP/Effects/AquaticFXSuite.h"
 #include "Core/EpicChainSlotController.h"
 #include "Core/DNAProximity.h"
-#include "Core/PresetMorphEngine.h"  // feat/preset-morph-foundation — #9 + #2
+#include "Core/PresetMorphEngine.h" // feat/preset-morph-foundation — #9 + #2
 #include "DSP/ThreadInit.h"
 #include <cstring> // std::strncmp — used in Wave 5 A1 global mod route evaluation
 
@@ -156,33 +156,25 @@ static bool registered_Obsidian =
 static bool registered_Observandum =
     xoceanus::EngineRegistry::instance().registerEngine("Observandum", []() -> std::unique_ptr<xoceanus::SynthEngine>
                                                         { return std::make_unique<xoceanus::ObservandumEngine>(); });
-static bool registered_Orrery =
-    xoceanus::EngineRegistry::instance().registerEngine("Orrery", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OrreryEngine>(); });
-static bool registered_Opsin =
-    xoceanus::EngineRegistry::instance().registerEngine("Opsin", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OpsinEngine>(); });
-static bool registered_Oort =
-    xoceanus::EngineRegistry::instance().registerEngine("Oort", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OortEngine>(); });
-static bool registered_Ondine =
-    xoceanus::EngineRegistry::instance().registerEngine("Ondine", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OndineEngine>(); });
-static bool registered_Ortolan =
-    xoceanus::EngineRegistry::instance().registerEngine("Ortolan", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OrtolanEngine>(); });
-static bool registered_Octant =
-    xoceanus::EngineRegistry::instance().registerEngine("Octant", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OctantEngine>(); });
+static bool registered_Orrery = xoceanus::EngineRegistry::instance().registerEngine(
+    "Orrery", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OrreryEngine>(); });
+static bool registered_Opsin = xoceanus::EngineRegistry::instance().registerEngine(
+    "Opsin", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OpsinEngine>(); });
+static bool registered_Oort = xoceanus::EngineRegistry::instance().registerEngine(
+    "Oort", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OortEngine>(); });
+static bool registered_Ondine = xoceanus::EngineRegistry::instance().registerEngine(
+    "Ondine", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OndineEngine>(); });
+static bool registered_Ortolan = xoceanus::EngineRegistry::instance().registerEngine(
+    "Ortolan", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OrtolanEngine>(); });
+static bool registered_Octant = xoceanus::EngineRegistry::instance().registerEngine(
+    "Octant", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OctantEngine>(); });
 static bool registered_Overtide =
     xoceanus::EngineRegistry::instance().registerEngine("Overtide", []() -> std::unique_ptr<xoceanus::SynthEngine>
                                                         { return std::make_unique<xoceanus::OvertideEngine>(); });
-static bool registered_Oobleck =
-    xoceanus::EngineRegistry::instance().registerEngine("Oobleck", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OobleckEngine>(); });
-static bool registered_Ooze =
-    xoceanus::EngineRegistry::instance().registerEngine("Ooze", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OozeEngine>(); });
+static bool registered_Oobleck = xoceanus::EngineRegistry::instance().registerEngine(
+    "Oobleck", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OobleckEngine>(); });
+static bool registered_Ooze = xoceanus::EngineRegistry::instance().registerEngine(
+    "Ooze", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OozeEngine>(); });
 static bool registered_Origami = xoceanus::EngineRegistry::instance().registerEngine(
     "Origami", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OrigamiEngine>(); });
 static bool registered_Oracle = xoceanus::EngineRegistry::instance().registerEngine(
@@ -367,13 +359,11 @@ static bool registered_Obiont = xoceanus::EngineRegistry::instance().registerEng
 static bool registered_Oxidize = xoceanus::EngineRegistry::instance().registerEngine(
     "Oxidize", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OxidizeAdapter>(); });
 // OGIVE — scanned glass synthesis (engine #86)
-static bool registered_Ogive =
-    xoceanus::EngineRegistry::instance().registerEngine("Ogive", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OgiveEngine>(); });
+static bool registered_Ogive = xoceanus::EngineRegistry::instance().registerEngine(
+    "Ogive", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OgiveEngine>(); });
 // OLVIDO — spectral erosion synthesis (engine #87)
-static bool registered_Olvido =
-    xoceanus::EngineRegistry::instance().registerEngine("Olvido", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OlvidoEngine>(); });
+static bool registered_Olvido = xoceanus::EngineRegistry::instance().registerEngine(
+    "Olvido", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OlvidoEngine>(); });
 
 // OSTRACON — corpus-buffer synthesis (engine #88)
 static bool registered_Ostracon =
@@ -381,14 +371,12 @@ static bool registered_Ostracon =
                                                         { return std::make_unique<xoceanus::OstraconEngine>(); });
 
 // OUTCROP — wave-terrain synthesis (engine #89)
-static bool registered_Outcrop =
-    xoceanus::EngineRegistry::instance().registerEngine("Outcrop", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OutcropEngine>(); });
+static bool registered_Outcrop = xoceanus::EngineRegistry::instance().registerEngine(
+    "Outcrop", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OutcropEngine>(); });
 
 // ONDA — NLS soliton synthesis (engine #90; formerly Oneiric)
-static bool registered_Onda =
-    xoceanus::EngineRegistry::instance().registerEngine("Onda", []() -> std::unique_ptr<xoceanus::SynthEngine>
-                                                        { return std::make_unique<xoceanus::OndaEngine>(); });
+static bool registered_Onda = xoceanus::EngineRegistry::instance().registerEngine(
+    "Onda", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OndaEngine>(); });
 
 // OLLOTRON — tape-chamber keyboard synthesis (engine #91)
 static bool registered_Ollotron =
@@ -415,8 +403,10 @@ XOceanusProcessor::XOceanusProcessor()
     // #1357 W8B: initialise XY surface position atomics to 0.5 (centre).
     // std::atomic is not copy/move-constructible, so we cannot use brace-init
     // in the member declaration — store initial values here instead.
-    for (auto& a : xyX_) a.store(0.5f, std::memory_order_relaxed);
-    for (auto& a : xyY_) a.store(0.5f, std::memory_order_relaxed);
+    for (auto& a : xyX_)
+        a.store(0.5f, std::memory_order_relaxed);
+    for (auto& a : xyY_)
+        a.store(0.5f, std::memory_order_relaxed);
 
     // Wire MIDI learn manager to the APVTS and install default CC mappings.
     midiLearnManager.setAPVTS(&apvts);
@@ -459,18 +449,18 @@ void XOceanusProcessor::cacheParameterPointers()
         cachedParams.cmSlotRoute[slot] = apvts.getRawParameterValue("cm_slot_route_" + juce::String(slot));
 
     // B2: input mode + global key/scale + 48 pad chord params
-    cachedParams.cmInputMode   = apvts.getRawParameterValue("chord_input_mode");
-    cachedParams.cmGlobalRoot  = apvts.getRawParameterValue("cm_global_root");
+    cachedParams.cmInputMode = apvts.getRawParameterValue("chord_input_mode");
+    cachedParams.cmGlobalRoot = apvts.getRawParameterValue("cm_global_root");
     cachedParams.cmGlobalScale = apvts.getRawParameterValue("cm_global_scale");
     for (int i = 0; i < 16; ++i)
     {
         const juce::String prefix = "chord_pad_" + juce::String(i) + "_";
-        cachedParams.padChords[i].root    = apvts.getRawParameterValue(prefix + "root");
+        cachedParams.padChords[i].root = apvts.getRawParameterValue(prefix + "root");
         cachedParams.padChords[i].voicing = apvts.getRawParameterValue(prefix + "voicing");
-        cachedParams.padChords[i].inv     = apvts.getRawParameterValue(prefix + "inv");
-        jassert(cachedParams.padChords[i].root    != nullptr);
+        cachedParams.padChords[i].inv = apvts.getRawParameterValue(prefix + "inv");
+        jassert(cachedParams.padChords[i].root != nullptr);
         jassert(cachedParams.padChords[i].voicing != nullptr);
-        jassert(cachedParams.padChords[i].inv     != nullptr);
+        jassert(cachedParams.padChords[i].inv != nullptr);
     }
 
     cachedParams.ohmCommune = apvts.getRawParameterValue("ohm_macroCommune");
@@ -503,10 +493,10 @@ void XOceanusProcessor::cacheParameterPointers()
     cachedParams.mpeSlideTarget = apvts.getRawParameterValue("mpe_slideTarget");
 
     // Wave 5 D1: XOuija walk engine mood/tendency — cache once, read per-block
-    cachedParams.ouijaCalmWild           = apvts.getRawParameterValue("ouija_calm_wild");
+    cachedParams.ouijaCalmWild = apvts.getRawParameterValue("ouija_calm_wild");
     cachedParams.ouijaConsonantDissonant = apvts.getRawParameterValue("ouija_consonant_dissonant");
-    cachedParams.ouijaTendencyCol        = apvts.getRawParameterValue("ouija_tendency_col");
-    cachedParams.ouijaTendencyRow        = apvts.getRawParameterValue("ouija_tendency_row");
+    cachedParams.ouijaTendencyCol = apvts.getRawParameterValue("ouija_tendency_col");
+    cachedParams.ouijaTendencyRow = apvts.getRawParameterValue("ouija_tendency_row");
 
     // B1: Pre-resolve the Orrery cutoff parameter pointer used for isOrryCutoff detection
     // in flushModRoutesSnapshot().  If the Orrery engine is not registered, this stays
@@ -517,8 +507,8 @@ void XOceanusProcessor::cacheParameterPointers()
     // nullptr when Onset parameters are not registered (safe — corresponding isPercXxx stays false).
     percLevelParam_ = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter("perc_level"));
     percPunchParam_ = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter("perc_macro_punch"));
-    percToneParam_  = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter("perc_masterTone"));
-    percGritParam_  = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter("perc_char_grit"));
+    percToneParam_ = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter("perc_masterTone"));
+    percGritParam_ = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter("perc_char_grit"));
 }
 
 juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createParameterLayout()
@@ -717,18 +707,17 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
         juce::StringArray{"WARM", "BRIGHT", "TENSION", "OPEN", "DARK", "SWEET", "COMPLEX", "RAW"}, 0));
     params.push_back(std::make_unique<juce::AudioParameterChoice>(
         juce::ParameterID("cm_voicing", 1), "CM Voicing",
-        juce::StringArray{
-            // Tertian (0-4) — indices fixed for preset backward compat
-            "ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON",
-            // Quartal family (5-6)
-            "QUARTAL-3", "QUARTAL-4",
-            // Quintal family (7-8)
-            "QUINTAL-3", "QUINTAL-4",
-            // Modal-world family (9-13)
-            "HIJAZ", "BHAIRAVI", "YO", "IN", "PHRYG-DOM",
-            // Drone family (14-19)
-            "DRONE-P5", "DRONE-P4", "DRONE-M3", "DRONE-m3", "DRONE-M2", "DRONE-m2"
-        }, 0));
+        juce::StringArray{// Tertian (0-4) — indices fixed for preset backward compat
+                          "ROOT-SPREAD", "DROP-2", "QUARTAL", "UPPER STRUCT", "UNISON",
+                          // Quartal family (5-6)
+                          "QUARTAL-3", "QUARTAL-4",
+                          // Quintal family (7-8)
+                          "QUINTAL-3", "QUINTAL-4",
+                          // Modal-world family (9-13)
+                          "HIJAZ", "BHAIRAVI", "YO", "IN", "PHRYG-DOM",
+                          // Drone family (14-19)
+                          "DRONE-P5", "DRONE-P4", "DRONE-M3", "DRONE-m3", "DRONE-M2", "DRONE-m2"},
+        0));
     params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("cm_spread", 1), "CM Spread",
                                                                  juce::NormalisableRange<float>(0.0f, 1.0f), 0.75f));
     params.push_back(
@@ -758,11 +747,10 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     // Values: 0=CHORD→SEQ, 1=SEQ→CHORD, 2=PARALLEL. Default: CHORD→SEQ.
     for (int slot = 0; slot < 4; ++slot)
     {
-        const juce::String paramId  = "cm_slot_route_" + juce::String(slot);
+        const juce::String paramId = "cm_slot_route_" + juce::String(slot);
         const juce::String paramName = "CM Slot " + juce::String(slot + 1) + " Routing";
         params.push_back(std::make_unique<juce::AudioParameterChoice>(
-            juce::ParameterID(paramId, 1), paramName,
-            juce::StringArray{"CHORD→SEQ", "SEQ→CHORD", "PARALLEL"}, 0));
+            juce::ParameterID(paramId, 1), paramName, juce::StringArray{"CHORD→SEQ", "SEQ→CHORD", "PARALLEL"}, 0));
     }
 
     // ── B3: Per-slot chord input mode (Wave 5 B3 mount) ──────────────────────
@@ -770,7 +758,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     // Values: 0=AUTO-HARMONIZE, 1=PAD-PER-CHORD, 2=SCALE-DEGREE. Default: AUTO-HARMONIZE.
     for (int slot = 0; slot < 4; ++slot)
     {
-        const juce::String paramId  = "cm_slot_input_mode_" + juce::String(slot);
+        const juce::String paramId = "cm_slot_input_mode_" + juce::String(slot);
         const juce::String paramName = "CM Slot " + juce::String(slot + 1) + " Input Mode";
         params.push_back(std::make_unique<juce::AudioParameterChoice>(
             juce::ParameterID(paramId, 1), paramName,
@@ -779,53 +767,49 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
 
     // ── B2: Chord input mode + global key/scale ───────────────────────────────
     params.push_back(std::make_unique<juce::AudioParameterChoice>(
-        juce::ParameterID("chord_input_mode", 1), "Chord Input Mode",
-        juce::StringArray{"AUTO", "PAD", "DEG"}, 0)); // default = AutoHarmonize
+        juce::ParameterID("chord_input_mode", 1), "Chord Input Mode", juce::StringArray{"AUTO", "PAD", "DEG"},
+        0)); // default = AutoHarmonize
 
     params.push_back(std::make_unique<juce::AudioParameterChoice>(
         juce::ParameterID("cm_global_root", 1), "CM Global Root",
-        juce::StringArray{"C","C#","D","D#","E","F","F#","G","G#","A","A#","B"}, 0)); // C
+        juce::StringArray{"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}, 0)); // C
 
     params.push_back(std::make_unique<juce::AudioParameterChoice>(
         juce::ParameterID("cm_global_scale", 1), "CM Global Scale",
-        juce::StringArray{"Chromatic","Major","Minor","Dorian","Mixolydian",
-                          "Pent Min","Pent Maj","Blues","Harm Min"}, 1)); // Major
+        juce::StringArray{"Chromatic", "Major", "Minor", "Dorian", "Mixolydian", "Pent Min", "Pent Maj", "Blues",
+                          "Harm Min"},
+        1)); // Major
 
     // ── B2: Pad chord slots — 16 pads × 3 params = 48 params ─────────────────
     // Build the voicing string array once (reused for all 16 pads)
     {
-        juce::StringArray voicingChoices{
-            "ROOT-SPREAD","DROP-2","QUARTAL","UPPER-STRUCT","UNISON",
-            "QUARTAL-3","QUARTAL-4","QUINTAL-3","QUINTAL-4",
-            "HIJAZ","BHAIRAVI","YO","IN","PHRYG-DOM",
-            "DRONE-P5","DRONE-P4","DRONE-M3","DRONE-m3","DRONE-M2","DRONE-m2"
-        };
+        juce::StringArray voicingChoices{"ROOT-SPREAD", "DROP-2",    "QUARTAL",   "UPPER-STRUCT", "UNISON",
+                                         "QUARTAL-3",   "QUARTAL-4", "QUINTAL-3", "QUINTAL-4",    "HIJAZ",
+                                         "BHAIRAVI",    "YO",        "IN",        "PHRYG-DOM",    "DRONE-P5",
+                                         "DRONE-P4",    "DRONE-M3",  "DRONE-m3",  "DRONE-M2",     "DRONE-m2"};
 
         // Default roots follow the C major scale degrees for pads 0-7:
         // C D E F G A B C (pads 0-7), then repeat for pads 8-15
         static constexpr int kDefaultRoots[16] = {
-            60, 62, 64, 65, 67, 69, 71, 72,  // C4 D4 E4 F4 G4 A4 B4 C5
-            60, 62, 64, 65, 67, 69, 71, 72   // repeat (pads 8-15)
+            60, 62, 64, 65, 67, 69, 71, 72, // C4 D4 E4 F4 G4 A4 B4 C5
+            60, 62, 64, 65, 67, 69, 71, 72  // repeat (pads 8-15)
         };
 
         for (int i = 0; i < 16; ++i)
         {
             const juce::String prefix = "chord_pad_" + juce::String(i) + "_";
 
-            params.push_back(std::make_unique<juce::AudioParameterInt>(
-                juce::ParameterID(prefix + "root", 1),
-                "Chord Pad " + juce::String(i + 1) + " Root",
-                0, 127, kDefaultRoots[i]));
+            params.push_back(std::make_unique<juce::AudioParameterInt>(juce::ParameterID(prefix + "root", 1),
+                                                                       "Chord Pad " + juce::String(i + 1) + " Root", 0,
+                                                                       127, kDefaultRoots[i]));
 
             params.push_back(std::make_unique<juce::AudioParameterChoice>(
-                juce::ParameterID(prefix + "voicing", 1),
-                "Chord Pad " + juce::String(i + 1) + " Voicing",
+                juce::ParameterID(prefix + "voicing", 1), "Chord Pad " + juce::String(i + 1) + " Voicing",
                 voicingChoices, 0)); // default = RootSpread
 
             params.push_back(std::make_unique<juce::AudioParameterInt>(
-                juce::ParameterID(prefix + "inv", 1),
-                "Chord Pad " + juce::String(i + 1) + " Inversion",
-                0, 3, 0)); // default = root position
+                juce::ParameterID(prefix + "inv", 1), "Chord Pad " + juce::String(i + 1) + " Inversion", 0, 3,
+                0)); // default = root position
         }
     }
 
@@ -1218,9 +1202,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     // pitchBendRange: non-MPE pitch-bend range in semitones (1..24, default 2).
     //                 Engines read this to convert normalised wheel value to cents.
     // Both IDs are frozen — do not rename or add version suffixes.
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("masterTune", 1), "Master Tune (Hz)",
-        juce::NormalisableRange<float>(415.0f, 466.0f), 440.0f));
+    params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("masterTune", 1), "Master Tune (Hz)",
+                                                                 juce::NormalisableRange<float>(415.0f, 466.0f),
+                                                                 440.0f));
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         juce::ParameterID("pitchBendRange", 1), "Pitch Bend Range (semitones)",
         juce::NormalisableRange<float>(1.0f, 24.0f, 1.0f), 2.0f));
@@ -1258,15 +1242,13 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     // PlaySurface wires onParameterChanged for these three IDs to call
     // xouijaPanel_.setMoodState() so the heatmap repaint happens on the message
     // thread without touching the audio thread.
+    params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("xouija_brightness", 1),
+                                                                 "XOuija Brightness",
+                                                                 juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("xouija_brightness", 1), "XOuija Brightness",
-        juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+        juce::ParameterID("xouija_tension", 1), "XOuija Tension", juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("xouija_tension", 1), "XOuija Tension",
-        juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("xouija_density", 1), "XOuija Density",
-        juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+        juce::ParameterID("xouija_density", 1), "XOuija Density", juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
 
     // ── Wave 5 D1: XOuija multi-layer cell parameters ────────────────────────
     // Mood sliders and tendency are automatable APVTS params (per spec section 6).
@@ -1274,22 +1256,20 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     // values for APVTS, and editorial state is not automatable.
     // Output routing (one per primary slot) is an int choice param 0-4 (Off…ModSource).
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("ouija_calm_wild", 1), "XOuija Calm/Wild",
-        juce::NormalisableRange<float>(0.0f, 1.0f), 0.3f));
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("ouija_consonant_dissonant", 1), "XOuija Consonant/Dissonant",
-        juce::NormalisableRange<float>(0.0f, 1.0f), 0.2f));
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("ouija_tendency_col", 1), "XOuija Tendency Col",
-        juce::NormalisableRange<float>(-1.0f, 1.0f), 0.0f));
-    params.push_back(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("ouija_tendency_row", 1), "XOuija Tendency Row",
-        juce::NormalisableRange<float>(-1.0f, 1.0f), 0.0f));
+        juce::ParameterID("ouija_calm_wild", 1), "XOuija Calm/Wild", juce::NormalisableRange<float>(0.0f, 1.0f), 0.3f));
+    params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("ouija_consonant_dissonant", 1),
+                                                                 "XOuija Consonant/Dissonant",
+                                                                 juce::NormalisableRange<float>(0.0f, 1.0f), 0.2f));
+    params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("ouija_tendency_col", 1),
+                                                                 "XOuija Tendency Col",
+                                                                 juce::NormalisableRange<float>(-1.0f, 1.0f), 0.0f));
+    params.push_back(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("ouija_tendency_row", 1),
+                                                                 "XOuija Tendency Row",
+                                                                 juce::NormalisableRange<float>(-1.0f, 1.0f), 0.0f));
     for (int s = 0; s < kNumPrimarySlots; ++s)
         params.push_back(std::make_unique<juce::AudioParameterChoice>(
-            juce::ParameterID("ouija_route_" + juce::String(s), 1),
-            "XOuija Route Slot " + juce::String(s + 1),
-            juce::StringArray{ "Off", "Drive Notes", "Drive Sequencer", "Drive Chord", "Mod Source" },
+            juce::ParameterID("ouija_route_" + juce::String(s), 1), "XOuija Route Slot " + juce::String(s + 1),
+            juce::StringArray{"Off", "Drive Notes", "Drive Sequencer", "Drive Chord", "Mod Source"},
             0 /* default: Off */));
 
     // AquaticFXSuite::addParameters() uses ParameterLayout::add() (JUCE 7+ API)
@@ -1304,10 +1284,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
 
     // Wave 5 C1: Per-slot pattern sequencer parameters (primary slots 0–3 only).
     for (int s = 0; s < kNumPrimarySlots; ++s)
-        XOceanus::PerEnginePatternSequencer::addParameters(
-            layout,
-            "slot" + juce::String(s) + "_seq_",
-            "Slot " + juce::String(s + 1) + " Seq ");
+        XOceanus::PerEnginePatternSequencer::addParameters(layout, "slot" + juce::String(s) + "_seq_",
+                                                           "Slot " + juce::String(s + 1) + " Seq ");
 
     // Wave 6: Per-slot play surface layout mode (primary slots 0–3 only).
     // 0 = PlaySurface (KEYS/PADS/XY/OUIJA full window, default)
@@ -1317,10 +1295,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     for (int s = 0; s < kNumPrimarySlots; ++s)
     {
         layout.add(std::make_unique<juce::AudioParameterChoice>(
-            juce::ParameterID("slot" + juce::String(s) + "_layout_mode", 1),
-            "Slot " + juce::String(s + 1) + " Layout",
-            juce::StringArray{ "PlaySurface", "PadGrid" },
-            0 /* default = PlaySurface */));
+            juce::ParameterID("slot" + juce::String(s) + "_layout_mode", 1), "Slot " + juce::String(s + 1) + " Layout",
+            juce::StringArray{"PlaySurface", "PadGrid"}, 0 /* default = PlaySurface */));
     }
 
     // ── Wave 8: XY Surface parameters (8 params × 4 slots = 32 params) ─────────
@@ -1334,45 +1310,35 @@ juce::AudioProcessorValueTreeState::ParameterLayout XOceanusProcessor::createPar
     //   5=EnvAttack, 6=EnvRelease, 7=Drive, 8=Macro1, 9=Macro2, 10=Macro3,
     //   11=Macro4, 12=FX1WetDry, 13=FX2WetDry, 14=FX3WetDry
     {
-        const juce::StringArray kXYPatterns {"None","PULSE","DRIFT","TIDE","RIPPLE","CHAOS"};
-        const juce::StringArray kXYSync     {"Free","1bar/4","1bar/2","1bar","2bar","4bar"};
-        const juce::StringArray kXYAssign   {
-            "None","Filter Cutoff","Filter Res","LFO Rate","LFO Depth",
-            "Env Attack","Env Release","Drive",
-            "Macro1","Macro2","Macro3","Macro4",
-            "FX1 Wet","FX2 Wet","FX3 Wet"
-        };
+        const juce::StringArray kXYPatterns{"None", "PULSE", "DRIFT", "TIDE", "RIPPLE", "CHAOS"};
+        const juce::StringArray kXYSync{"Free", "1bar/4", "1bar/2", "1bar", "2bar", "4bar"};
+        const juce::StringArray kXYAssign{"None",       "Filter Cutoff", "Filter Res", "LFO Rate", "LFO Depth",
+                                          "Env Attack", "Env Release",   "Drive",      "Macro1",   "Macro2",
+                                          "Macro3",     "Macro4",        "FX1 Wet",    "FX2 Wet",  "FX3 Wet"};
         for (int s = 0; s < kNumPrimarySlots; ++s)
         {
             const juce::String sfx = "_slot" + juce::String(s);
             layout.add(std::make_unique<juce::AudioParameterChoice>(
-                juce::ParameterID("xy_pattern" + sfx, 1),
-                "XY Pattern Slot " + juce::String(s + 1), kXYPatterns, 0));
-            layout.add(std::make_unique<juce::AudioParameterFloat>(
-                juce::ParameterID("xy_speed" + sfx, 1),
-                "XY Speed Slot "   + juce::String(s + 1),
-                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
-            layout.add(std::make_unique<juce::AudioParameterFloat>(
-                juce::ParameterID("xy_depth" + sfx, 1),
-                "XY Depth Slot "   + juce::String(s + 1),
-                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+                juce::ParameterID("xy_pattern" + sfx, 1), "XY Pattern Slot " + juce::String(s + 1), kXYPatterns, 0));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("xy_speed" + sfx, 1),
+                                                                   "XY Speed Slot " + juce::String(s + 1),
+                                                                   juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("xy_depth" + sfx, 1),
+                                                                   "XY Depth Slot " + juce::String(s + 1),
+                                                                   juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+            layout.add(std::make_unique<juce::AudioParameterChoice>(juce::ParameterID("xy_sync" + sfx, 1),
+                                                                    "XY Sync Slot " + juce::String(s + 1), kXYSync,
+                                                                    3)); // default: 1bar
             layout.add(std::make_unique<juce::AudioParameterChoice>(
-                juce::ParameterID("xy_sync" + sfx, 1),
-                "XY Sync Slot "    + juce::String(s + 1), kXYSync, 3)); // default: 1bar
+                juce::ParameterID("xy_assignX" + sfx, 1), "XY Assign X Slot " + juce::String(s + 1), kXYAssign, 0));
             layout.add(std::make_unique<juce::AudioParameterChoice>(
-                juce::ParameterID("xy_assignX" + sfx, 1),
-                "XY Assign X Slot "+ juce::String(s + 1), kXYAssign, 0));
-            layout.add(std::make_unique<juce::AudioParameterChoice>(
-                juce::ParameterID("xy_assignY" + sfx, 1),
-                "XY Assign Y Slot "+ juce::String(s + 1), kXYAssign, 0));
-            layout.add(std::make_unique<juce::AudioParameterFloat>(
-                juce::ParameterID("xy_pos_x" + sfx, 1),
-                "XY Pos X Slot "   + juce::String(s + 1),
-                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
-            layout.add(std::make_unique<juce::AudioParameterFloat>(
-                juce::ParameterID("xy_pos_y" + sfx, 1),
-                "XY Pos Y Slot "   + juce::String(s + 1),
-                juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+                juce::ParameterID("xy_assignY" + sfx, 1), "XY Assign Y Slot " + juce::String(s + 1), kXYAssign, 0));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("xy_pos_x" + sfx, 1),
+                                                                   "XY Pos X Slot " + juce::String(s + 1),
+                                                                   juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
+            layout.add(std::make_unique<juce::AudioParameterFloat>(juce::ParameterID("xy_pos_y" + sfx, 1),
+                                                                   "XY Pos Y Slot " + juce::String(s + 1),
+                                                                   juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
         }
     }
 
@@ -1493,10 +1459,8 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
             // T6: Wire Onset global mod offset pointers for any already-loaded Onset engine.
             if (auto* onset = dynamic_cast<OnsetEngine*>(eng.get()))
             {
-                onset->setPercModOffsetPtrs(&globalPercLevelModOffset_,
-                                            &globalPercPunchModOffset_,
-                                            &globalPercToneModOffset_,
-                                            &globalPercGritModOffset_);
+                onset->setPercModOffsetPtrs(&globalPercLevelModOffset_, &globalPercPunchModOffset_,
+                                            &globalPercToneModOffset_, &globalPercGritModOffset_);
             }
         }
     }
@@ -1537,10 +1501,8 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
     // Preset parameter application: we apply "Oxbow_Breath_Mist" parameters inline
     // (no disk I/O) using APVTS setValueNotifyingHost(), which is message-thread-safe.
     // Parameters match Presets/XOceanus/Organic/Oxbow/Oxbow_Breath_Mist.xometa verbatim.
-    if (!hasRestoredState.load(std::memory_order_acquire) &&
-        !hasLaunchedBefore_.load(std::memory_order_acquire) &&
-        !firstBreathActive_ &&
-        !firstBreathPending_.load(std::memory_order_relaxed))
+    if (!hasRestoredState.load(std::memory_order_acquire) && !hasLaunchedBefore_.load(std::memory_order_acquire) &&
+        !firstBreathActive_ && !firstBreathPending_.load(std::memory_order_relaxed))
     {
         // Swap slot 0 from Obrix → Oxbow for the First Breath experience.
         // This replaces the just-loaded Obrix (above) with the atmospheric pad engine.
@@ -1550,22 +1512,17 @@ void XOceanusProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
         // Values taken verbatim from Oxbow_Breath_Mist.xometa (Organic mood).
         // Uses setValueNotifyingHost so the UI reflects the initial state.
         // Parameters are normalized via convertTo0to1 to respect APVTS range contracts.
-        struct BreathMistParam { const char* id; float value; };
+        struct BreathMistParam
+        {
+            const char* id;
+            float value;
+        };
         static const BreathMistParam kBreathMistParams[] = {
-            {"oxb_size",         0.1f},
-            {"oxb_decay",        0.5f},
-            {"oxb_entangle",     0.06f},
-            {"oxb_erosionRate",  0.05f},
-            {"oxb_erosionDepth", 0.08f},
-            {"oxb_convergence",  4.0f},
-            {"oxb_resonanceQ",   3.5f},
-            {"oxb_resonanceMix", 0.15f},
-            {"oxb_cantilever",   0.12f},
-            {"oxb_damping",      7000.0f},
-            {"oxb_predelay",     0.0f},
-            {"oxb_dryWet",       0.15f},
-            {"oxb_exciterDecay", 0.05f},
-            {"oxb_exciterBright",0.5f},
+            {"oxb_size", 0.1f},          {"oxb_decay", 0.5f},         {"oxb_entangle", 0.06f},
+            {"oxb_erosionRate", 0.05f},  {"oxb_erosionDepth", 0.08f}, {"oxb_convergence", 4.0f},
+            {"oxb_resonanceQ", 3.5f},    {"oxb_resonanceMix", 0.15f}, {"oxb_cantilever", 0.12f},
+            {"oxb_damping", 7000.0f},    {"oxb_predelay", 0.0f},      {"oxb_dryWet", 0.15f},
+            {"oxb_exciterDecay", 0.05f}, {"oxb_exciterBright", 0.5f},
         };
         for (const auto& p : kBreathMistParams)
         {
@@ -1730,8 +1687,9 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         if (cachedParams.cmSlotRoute[slot] != nullptr)
         {
             const int modeIdx = static_cast<int>(cachedParams.cmSlotRoute[slot]->load(std::memory_order_relaxed));
-            chordMachine.setSlotRoutingMode(slot, static_cast<ChordSeqRoutingMode>(
-                std::max(0, std::min(modeIdx, static_cast<int>(ChordSeqRoutingMode::NumModes) - 1))));
+            chordMachine.setSlotRoutingMode(
+                slot, static_cast<ChordSeqRoutingMode>(
+                          std::max(0, std::min(modeIdx, static_cast<int>(ChordSeqRoutingMode::NumModes) - 1))));
         }
     }
     // W12 fix: sync pattern from APVTS on every block.  applyPattern() is safe to
@@ -1747,8 +1705,7 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
 
     // ── B2: Sync chord input mode + global key/scale + pad chord slots ─────────
     if (cachedParams.cmInputMode)
-        chordMachine.setInputMode(static_cast<ChordInputMode>(
-            static_cast<int>(cachedParams.cmInputMode->load())));
+        chordMachine.setInputMode(static_cast<ChordInputMode>(static_cast<int>(cachedParams.cmInputMode->load())));
     if (cachedParams.cmGlobalRoot)
         chordMachine.setGlobalRootKey(static_cast<int>(cachedParams.cmGlobalRoot->load()));
     if (cachedParams.cmGlobalScale)
@@ -1759,8 +1716,7 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         if (cachedParams.padChords[i].root != nullptr)
         {
             chordMachine.setPadChord(
-                i,
-                static_cast<int>(cachedParams.padChords[i].root->load()),
+                i, static_cast<int>(cachedParams.padChords[i].root->load()),
                 static_cast<VoicingMode>(static_cast<int>(cachedParams.padChords[i].voicing->load())),
                 static_cast<int>(cachedParams.padChords[i].inv->load()));
         }
@@ -1864,9 +1820,7 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                 posPtr = &posSnapshot;
             }
         }
-        hostTransport.processBlock(numSamples,
-                                   currentSampleRate.load(std::memory_order_relaxed),
-                                   posPtr);
+        hostTransport.processBlock(numSamples, currentSampleRate.load(std::memory_order_relaxed), posPtr);
         if (posPtr != nullptr && posPtr->getPpqPosition().hasValue())
         {
             const double ppq = *posPtr->getPpqPosition();
@@ -2095,14 +2049,14 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
             firstBreathPending_.store(false, std::memory_order_release);
             if (enginePtrs[0] != nullptr) // engine must be ready
             {
-                firstBreathActive_         = true;
-                firstBreathFading_         = false; // reset any in-progress fade from a prior replay
-                firstBreathFadeCountdown_  = 0;
-                firstBreathGeneration_     = engineGeneration_.load(std::memory_order_acquire); // snapshot generation at arm time
-                firstBreathCountdown_      = static_cast<int>(
-                    currentSampleRate.load(std::memory_order_relaxed) * kFirstBreathTimeoutMs / 1000.0);
-                slotMidi[0].addEvent(
-                    juce::MidiMessage::noteOn(1, kFirstBreathNote, kFirstBreathVelocity), 0);
+                firstBreathActive_ = true;
+                firstBreathFading_ = false; // reset any in-progress fade from a prior replay
+                firstBreathFadeCountdown_ = 0;
+                firstBreathGeneration_ =
+                    engineGeneration_.load(std::memory_order_acquire); // snapshot generation at arm time
+                firstBreathCountdown_ = static_cast<int>(currentSampleRate.load(std::memory_order_relaxed) *
+                                                         kFirstBreathTimeoutMs / 1000.0);
+                slotMidi[0].addEvent(juce::MidiMessage::noteOn(1, kFirstBreathNote, kFirstBreathVelocity), 0);
             }
         }
 
@@ -2116,10 +2070,10 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
             // mechanism, so we simply disarm without an extra note-off here.
             if (engineGeneration_.load(std::memory_order_relaxed) != firstBreathGeneration_)
             {
-                firstBreathActive_        = false;
-                firstBreathFading_        = false;
+                firstBreathActive_ = false;
+                firstBreathFading_ = false;
                 firstBreathFadeCountdown_ = 0;
-                firstBreathCountdown_     = 0;
+                firstBreathCountdown_ = 0;
             }
             else
             {
@@ -2143,9 +2097,9 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     // §1300: user interaction — start the 200 ms fade window instead of
                     // killing the note immediately.  The note-off fires after the fade
                     // expires so there is no abrupt cut when the user first plays.
-                    firstBreathFading_         = true;
-                    firstBreathFadeCountdown_  = static_cast<int>(
-                        currentSampleRate.load(std::memory_order_relaxed) * kFirstBreathFadeMs / 1000.0);
+                    firstBreathFading_ = true;
+                    firstBreathFadeCountdown_ = static_cast<int>(currentSampleRate.load(std::memory_order_relaxed) *
+                                                                 kFirstBreathFadeMs / 1000.0);
                 }
 
                 if (firstBreathFading_)
@@ -2155,10 +2109,10 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     {
                         // Fade complete — send note-off and disarm.
                         slotMidi[0].addEvent(juce::MidiMessage::noteOff(1, kFirstBreathNote, (uint8_t)0), 0);
-                        firstBreathActive_         = false;
-                        firstBreathFading_         = false;
-                        firstBreathCountdown_      = 0;
-                        firstBreathFadeCountdown_  = 0;
+                        firstBreathActive_ = false;
+                        firstBreathFading_ = false;
+                        firstBreathCountdown_ = 0;
+                        firstBreathFadeCountdown_ = 0;
                     }
                 }
                 else
@@ -2168,7 +2122,7 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     if (firstBreathCountdown_ <= 0)
                     {
                         slotMidi[0].addEvent(juce::MidiMessage::noteOff(1, kFirstBreathNote, (uint8_t)0), 0);
-                        firstBreathActive_    = false;
+                        firstBreathActive_ = false;
                         firstBreathCountdown_ = 0;
                     }
                 }
@@ -2188,13 +2142,12 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         // I4: Pre-computed slot APVTS prefix strings — avoids juce::String allocation
         // every block.  "slot0_seq_" … "slot3_seq_" match the IDs registered in
         // createParameterLayout via PerEnginePatternSequencer::addParameters().
-        static const juce::String kSlotSeqPrefix[kNumPrimarySlots] = {
-            "slot0_seq_", "slot1_seq_", "slot2_seq_", "slot3_seq_"
-        };
+        static const juce::String kSlotSeqPrefix[kNumPrimarySlots] = {"slot0_seq_", "slot1_seq_", "slot2_seq_",
+                                                                      "slot3_seq_"};
 
-        const double seqBpm      = hostTransport.getBPM();
-        const double seqPpq      = hostTransport.getBeatPosition();
-        const bool   seqPlaying  = hostTransport.isPlaying();
+        const double seqBpm = hostTransport.getBPM();
+        const double seqPpq = hostTransport.getBeatPosition();
+        const bool seqPlaying = hostTransport.isPlaying();
         for (int s = 0; s < kNumPrimarySlots; ++s)
         {
             slotSequencers_[s].syncFromApvts(apvts, kSlotSeqPrefix[s]);
@@ -2213,15 +2166,14 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         if (cachedParams.ouijaCalmWild)
             ouijaWalkEngine_.setCalmWild(cachedParams.ouijaCalmWild->load(std::memory_order_relaxed));
         if (cachedParams.ouijaConsonantDissonant)
-            ouijaWalkEngine_.setConsonantDissonant(cachedParams.ouijaConsonantDissonant->load(std::memory_order_relaxed));
+            ouijaWalkEngine_.setConsonantDissonant(
+                cachedParams.ouijaConsonantDissonant->load(std::memory_order_relaxed));
         if (cachedParams.ouijaTendencyCol)
             ouijaWalkEngine_.setTendencyCol(cachedParams.ouijaTendencyCol->load(std::memory_order_relaxed));
         if (cachedParams.ouijaTendencyRow)
             ouijaWalkEngine_.setTendencyRow(cachedParams.ouijaTendencyRow->load(std::memory_order_relaxed));
 
-        ouijaWalkEngine_.processBlock(numSamples,
-                                      hostTransport.getBPM(),
-                                      hostTransport.getBeatPosition(),
+        ouijaWalkEngine_.processBlock(numSamples, hostTransport.getBPM(), hostTransport.getBeatPosition(),
                                       hostTransport.isPlaying());
     }
     // ── end Wave 5 D1 ─────────────────────────────────────────────────────────
@@ -2295,10 +2247,7 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
         // Publish mono mix to the partner audio bus for Pack 1 FX chains
         // (Otrium triangular ducking). Done here so consumers see this slot's
         // most recent renderBlock() output for the current block.
-        partnerAudioBus_.publish(i,
-                                 engineBuffers[i].getReadPointer(0),
-                                 engineBuffers[i].getReadPointer(1),
-                                 numSamples);
+        partnerAudioBus_.publish(i, engineBuffers[i].getReadPointer(0), engineBuffers[i].getReadPointer(1), numSamples);
     }
 
     // ── Wave 5 A1: Evaluate global mod routes ────────────────────────────────
@@ -2349,8 +2298,8 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
             // by lastTriggerVelocity at consumption to satisfy D001 (Strategy 2).
             float percLevelMod = 0.0f;
             float percPunchMod = 0.0f;
-            float percToneMod  = 0.0f;
-            float percGritMod  = 0.0f;
+            float percToneMod = 0.0f;
+            float percGritMod = 0.0f;
 
             for (int ri = 0; ri < nRoutes; ++ri)
             {
@@ -2372,11 +2321,18 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                 }
                 else if (snap.sourceId == static_cast<int>(ModSourceId::XouijaCell))
                 {
-                    // C5 (#1360): pinned XOuija position read from SlotModSourceRegistry.
-                    // X axis is the primary value (circle-of-fifths, bipolar [-1, +1]).
-                    // Y axis (influence depth) accessible via getModSourceRegistry().getXouijaCellY()
-                    // when a per-parameter axis discriminator is added in a future PR.
+                    // Legacy (ID=18, back-compat): X axis.
                     srcVal = modSourceRegistry_.getXouijaCellX();
+                }
+                else if (snap.sourceId == static_cast<int>(ModSourceId::XouijaX))
+                {
+                    // #1383 A4: per-axis planchette X (circle-of-fifths, bipolar).
+                    srcVal = modSourceRegistry_.getXouijaX();
+                }
+                else if (snap.sourceId == static_cast<int>(ModSourceId::XouijaY))
+                {
+                    // #1383 A4: per-axis planchette Y (influence depth, bipolar).
+                    srcVal = modSourceRegistry_.getXouijaY();
                 }
                 else if (snap.sourceId >= static_cast<int>(ModSourceId::XYX0) &&
                          snap.sourceId <= static_cast<int>(ModSourceId::XYY3))
@@ -2385,9 +2341,8 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     // XYX0..XYX3 = IDs 20..23 (slot 0..3, X axis)
                     // XYY0..XYY3 = IDs 24..27 (slot 0..3, Y axis)
                     const bool isX = snap.sourceId < static_cast<int>(ModSourceId::XYY0);
-                    const int xySlot = isX
-                        ? snap.sourceId - static_cast<int>(ModSourceId::XYX0)
-                        : snap.sourceId - static_cast<int>(ModSourceId::XYY0);
+                    const int xySlot = isX ? snap.sourceId - static_cast<int>(ModSourceId::XYX0)
+                                           : snap.sourceId - static_cast<int>(ModSourceId::XYY0);
                     if (xySlot < 0 || xySlot >= kNumPrimarySlots)
                         continue;
                     // Map [0, 1] → [-1, +1] so centre position produces zero modulation.
@@ -2395,8 +2350,8 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     srcVal = raw * 2.0f - 1.0f;
                 }
                 else if (snap.sourceId == static_cast<int>(ModSourceId::SeqStepValue) ||
-                         snap.sourceId == static_cast<int>(ModSourceId::BeatPhase)    ||
-                         snap.sourceId == static_cast<int>(ModSourceId::LiveGate)     ||
+                         snap.sourceId == static_cast<int>(ModSourceId::BeatPhase) ||
+                         snap.sourceId == static_cast<int>(ModSourceId::LiveGate) ||
                          snap.sourceId == static_cast<int>(ModSourceId::SeqStepPitch))
                 {
                     // Validate slot index — guard against stale or bad snapshots.
@@ -2438,10 +2393,14 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                     routeModAccum_[static_cast<size_t>(ri)] = snap.depth;
                     // T6: Onset global params: accumulate depth so OnsetEngine can multiply
                     // by lastTriggerVelocity at consumption.  Strategy 2 — engine-side multiply.
-                    if (snap.isPercLevel) percLevelMod += snap.depth;
-                    if (snap.isPercPunch) percPunchMod += snap.depth;
-                    if (snap.isPercTone)  percToneMod  += snap.depth;
-                    if (snap.isPercGrit)  percGritMod  += snap.depth;
+                    if (snap.isPercLevel)
+                        percLevelMod += snap.depth;
+                    if (snap.isPercPunch)
+                        percPunchMod += snap.depth;
+                    if (snap.isPercTone)
+                        percToneMod += snap.depth;
+                    if (snap.isPercGrit)
+                        percGritMod += snap.depth;
                     continue; // skip the generic srcVal * depth path below
                 }
                 else if (snap.sourceId == static_cast<int>(ModSourceId::ModWheel))
@@ -2486,10 +2445,14 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
                 }
                 // T6: Onset global-parameter dispatch — non-velocity sources (LFO, XOuija, etc).
                 // modOffset = srcVal * depth, already normalised.  OnsetEngine clamps on use.
-                if (snap.isPercLevel) percLevelMod += modOffset;
-                if (snap.isPercPunch) percPunchMod += modOffset;
-                if (snap.isPercTone)  percToneMod  += modOffset;
-                if (snap.isPercGrit)  percGritMod  += modOffset;
+                if (snap.isPercLevel)
+                    percLevelMod += modOffset;
+                if (snap.isPercPunch)
+                    percPunchMod += modOffset;
+                if (snap.isPercTone)
+                    percToneMod += modOffset;
+                if (snap.isPercGrit)
+                    percGritMod += modOffset;
                 // else: destination is available via routeModAccum_[ri] for engines to read.
                 // When an engine opt-in API is added (Phase A2+), it will call
                 // getModRouteAccum(ri) with the route index it cached at load time.
@@ -2507,8 +2470,8 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
             // multiplies by lastTriggerVelocity at consumption (D001, Strategy 2).
             globalPercLevelModOffset_.store(percLevelMod, std::memory_order_relaxed);
             globalPercPunchModOffset_.store(percPunchMod, std::memory_order_relaxed);
-            globalPercToneModOffset_.store(percToneMod,  std::memory_order_relaxed);
-            globalPercGritModOffset_.store(percGritMod,  std::memory_order_relaxed);
+            globalPercToneModOffset_.store(percToneMod, std::memory_order_relaxed);
+            globalPercGritModOffset_.store(percGritMod, std::memory_order_relaxed);
         }
         else
         {
@@ -2793,8 +2756,7 @@ void XOceanusProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::Mid
     // Drain the graveyard on the message thread if anything was deposited this block.
     // Using MessageManager::callAsync (not juce::Timer) — some iOS AUv3 hosts run
     // Timer callbacks on the audio thread, which would defeat the purpose.
-    if (graveyardWritePos_.load(std::memory_order_relaxed) !=
-        graveyardReadPos_.load(std::memory_order_relaxed))
+    if (graveyardWritePos_.load(std::memory_order_relaxed) != graveyardReadPos_.load(std::memory_order_relaxed))
     {
         juce::MessageManager::callAsync([this] { drainGraveyard(); });
     }
@@ -2985,8 +2947,8 @@ void XOceanusProcessor::depositInGraveyard(std::shared_ptr<SynthEngine> engine) 
 {
     // Called ONLY from the audio thread — no blocking, no allocation.
     int write = graveyardWritePos_.load(std::memory_order_relaxed);
-    int read  = graveyardReadPos_.load(std::memory_order_acquire);
-    int next  = (write + 1) % kGraveyardSize;
+    int read = graveyardReadPos_.load(std::memory_order_acquire);
+    int next = (write + 1) % kGraveyardSize;
 
     if (next == read)
     {
@@ -3007,7 +2969,7 @@ void XOceanusProcessor::drainGraveyard()
 {
     // Called ONLY from the message thread (via MessageManager::callAsync).
     // ~SynthEngine() runs here — vector deallocations are safe off the RT thread.
-    int read  = graveyardReadPos_.load(std::memory_order_relaxed);
+    int read = graveyardReadPos_.load(std::memory_order_relaxed);
     int write = graveyardWritePos_.load(std::memory_order_acquire);
 
     while (read != write)
@@ -3070,10 +3032,8 @@ void XOceanusProcessor::loadEngine(int slot, const std::string& engineId)
         // T6: Wire Onset global mod offset pointers into OnsetEngine at load time.
         if (auto* onset = dynamic_cast<OnsetEngine*>(newEngine.get()))
         {
-            onset->setPercModOffsetPtrs(&globalPercLevelModOffset_,
-                                        &globalPercPunchModOffset_,
-                                        &globalPercToneModOffset_,
-                                        &globalPercGritModOffset_);
+            onset->setPercModOffsetPtrs(&globalPercLevelModOffset_, &globalPercPunchModOffset_,
+                                        &globalPercToneModOffset_, &globalPercGritModOffset_);
         }
 
         // T6: Wire OpalEngine into the global mod-route opt-in path.
@@ -3208,10 +3168,10 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
         if (count >= kMaxGlobalRoutes)
             break;
         auto& snap = routesSnapshot_[static_cast<size_t>(count)];
-        snap.sourceId  = r.sourceId;
-        snap.depth     = r.depth;
-        snap.bipolar   = r.bipolar;
-        snap.valid     = true;
+        snap.sourceId = r.sourceId;
+        snap.depth = r.depth;
+        snap.bipolar = r.bipolar;
+        snap.valid = true;
         snap.slotIndex = r.slotIndex; // C5: per-route slot index (-1 = N/A)
         // Copy dest param ID into fixed-length char array — no std::string on audio thread.
         // juce::String::copyToUTF8 writes at most maxBytes chars (inc. null terminator).
@@ -3221,8 +3181,7 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
         // audio thread never calls apvts.getParameter() (a hash-map lookup, not RT-safe).
         // Lifetime of juce::RangedAudioParameter* == lifetime of apvts == lifetime of
         // this processor, so the pointer stays valid for the duration of the snapshot.
-        snap.destParam = dynamic_cast<juce::RangedAudioParameter*>(
-            apvts.getParameter(r.destParamId));
+        snap.destParam = dynamic_cast<juce::RangedAudioParameter*>(apvts.getParameter(r.destParamId));
 
         // Pre-cache the range span (end - start) so the audio thread can scale
         // normalised modOffset to param units without calling any juce:: method.
@@ -3244,8 +3203,8 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
         // percXxxParam_ pointers are nullptr when Onset is not loaded — safe default.
         snap.isPercLevel = (percLevelParam_ != nullptr && snap.destParam == percLevelParam_);
         snap.isPercPunch = (percPunchParam_ != nullptr && snap.destParam == percPunchParam_);
-        snap.isPercTone  = (percToneParam_  != nullptr && snap.destParam == percToneParam_);
-        snap.isPercGrit  = (percGritParam_  != nullptr && snap.destParam == percGritParam_);
+        snap.isPercTone = (percToneParam_ != nullptr && snap.destParam == percToneParam_);
+        snap.isPercGrit = (percGritParam_ != nullptr && snap.destParam == percGritParam_);
 
         // T5: Mark routes whose source is Velocity so engines can apply per-voice
         // multiplication (D001).  routeModAccum_[ri] will hold depth, not depth*srcVal.
@@ -3256,16 +3215,16 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
     // Zero out trailing slots so stale entries are not evaluated.
     for (int i = count; i < kMaxGlobalRoutes; ++i)
     {
-        routesSnapshot_[static_cast<size_t>(i)].valid              = false;
-        routesSnapshot_[static_cast<size_t>(i)].destParam          = nullptr;
+        routesSnapshot_[static_cast<size_t>(i)].valid = false;
+        routesSnapshot_[static_cast<size_t>(i)].destParam = nullptr;
         routesSnapshot_[static_cast<size_t>(i)].destParamRangeSpan = 0.0f;
-        routesSnapshot_[static_cast<size_t>(i)].isOrryCutoff       = false;
-        routesSnapshot_[static_cast<size_t>(i)].velocityScaled     = false;
+        routesSnapshot_[static_cast<size_t>(i)].isOrryCutoff = false;
+        routesSnapshot_[static_cast<size_t>(i)].velocityScaled = false;
         // T6: clear Onset flags on trailing (inactive) slots.
-        routesSnapshot_[static_cast<size_t>(i)].isPercLevel        = false;
-        routesSnapshot_[static_cast<size_t>(i)].isPercPunch        = false;
-        routesSnapshot_[static_cast<size_t>(i)].isPercTone         = false;
-        routesSnapshot_[static_cast<size_t>(i)].isPercGrit         = false;
+        routesSnapshot_[static_cast<size_t>(i)].isPercLevel = false;
+        routesSnapshot_[static_cast<size_t>(i)].isPercPunch = false;
+        routesSnapshot_[static_cast<size_t>(i)].isPercTone = false;
+        routesSnapshot_[static_cast<size_t>(i)].isPercGrit = false;
     }
 
     routesSnapshotCount_.store(count, std::memory_order_relaxed);
@@ -3283,7 +3242,8 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
     for (int i = 0; i < MaxSlots; ++i)
     {
         auto eng = std::atomic_load(&engines[i]);
-        if (!eng) continue;
+        if (!eng)
+            continue;
         if (auto* opal = dynamic_cast<OpalEngine*>(eng.get()))
             opal->cacheGlobalModRoutes();
     }
@@ -3420,25 +3380,25 @@ void XOceanusProcessor::getStateInformation(juce::MemoryBlock& destData)
         // F2-002: Persist atomic settings so session recall restores them correctly.
         // Without this, polyphony/voiceMode/midiChannel/oversampling reset to defaults
         // on every DAW session reload.
-        xml->setAttribute("polyphony",    polyphonyCap_.load());
-        xml->setAttribute("voiceMode",    voiceMode_.load());
-        xml->setAttribute("midiChannel",  midiChannel_.load());
+        xml->setAttribute("polyphony", polyphonyCap_.load());
+        xml->setAttribute("voiceMode", voiceMode_.load());
+        xml->setAttribute("midiChannel", midiChannel_.load());
         xml->setAttribute("oversampling", oversamplingFactor_.load());
 
         // F2-006: Persist OceanView ViewState + zoomed slot so DAW session recall
         // restores the user's last navigation state.
         xml->setAttribute("oceanViewState", persistedOceanViewState_);
-        xml->setAttribute("oceanViewSlot",  persistedOceanViewSlot_);
+        xml->setAttribute("oceanViewSlot", persistedOceanViewSlot_);
 
         // F3-006: Persist REACT dial level so it survives DAW session reload.
         xml->setAttribute("reactLevel", static_cast<double>(persistedReactLevel_));
 
         // F3-011/F3-017: Persist breakout panel open states.
-        xml->setAttribute("seqBreakoutOpen",   persistedSeqBreakoutOpen_   ? 1 : 0);
+        xml->setAttribute("seqBreakoutOpen", persistedSeqBreakoutOpen_ ? 1 : 0);
         xml->setAttribute("chordBreakoutOpen", persistedChordBreakoutOpen_ ? 1 : 0);
 
         // D4 — Save register lock + current register (per-instance, per-session).
-        xml->setAttribute("registerLocked",  persistedRegisterLocked  ? 1 : 0);
+        xml->setAttribute("registerLocked", persistedRegisterLocked ? 1 : 0);
         xml->setAttribute("registerCurrent", persistedRegisterCurrent);
 
         // §1.1.1 Principle 4 — Persist first-launch flag so Sound on First Launch
@@ -3452,8 +3412,7 @@ void XOceanusProcessor::getStateInformation(juce::MemoryBlock& destData)
         // values are already captured by the APVTS state above.
         // Keys: slot0_presetName … slot3_presetName  (frozen identifiers).
         for (int i = 0; i < kNumPrimarySlots; ++i)
-            xml->setAttribute("slot" + juce::String(i) + "_presetName",
-                               slotPresets_[static_cast<size_t>(i)].name);
+            xml->setAttribute("slot" + juce::String(i) + "_presetName", slotPresets_[static_cast<size_t>(i)].name);
 
         copyXmlToBinary(*xml, destData);
     }
@@ -3655,7 +3614,7 @@ void XOceanusProcessor::setStateInformation(const void* data, int sizeInBytes)
 
         // D4 — Restore register lock + current register.
         // Defaults: unlocked, Gallery (0) — graceful for sessions predating D4.
-        persistedRegisterLocked  = xml->getIntAttribute("registerLocked",  0) != 0;
+        persistedRegisterLocked = xml->getIntAttribute("registerLocked", 0) != 0;
         persistedRegisterCurrent = xml->getIntAttribute("registerCurrent", 0);
         // Clamp to valid range (0=Gallery, 1=Performance, 2=Coupling).
         if (persistedRegisterCurrent < 0 || persistedRegisterCurrent > 2)
@@ -3663,23 +3622,23 @@ void XOceanusProcessor::setStateInformation(const void* data, int sizeInBytes)
 
         // F2-002: Restore atomic settings.  Defaults match init values so old sessions
         // (predating F2-002) are safe — they simply reload as defaults.
-        polyphonyCap_.store(xml->getIntAttribute("polyphony",    16));
-        voiceMode_.store(xml->getIntAttribute("voiceMode",       0));
-        midiChannel_.store(xml->getIntAttribute("midiChannel",   0));
+        polyphonyCap_.store(xml->getIntAttribute("polyphony", 16));
+        voiceMode_.store(xml->getIntAttribute("voiceMode", 0));
+        midiChannel_.store(xml->getIntAttribute("midiChannel", 0));
         oversamplingFactor_.store(xml->getIntAttribute("oversampling", 0));
 
         // F2-006: Restore OceanView ViewState + slot.
         // Default 0 (Orbital) and -1 (no slot) match OceanView's initial state.
         persistedOceanViewState_ = xml->getIntAttribute("oceanViewState", 0);
-        persistedOceanViewSlot_  = xml->getIntAttribute("oceanViewSlot",  -1);
+        persistedOceanViewSlot_ = xml->getIntAttribute("oceanViewSlot", -1);
 
         // F3-006: Restore REACT dial level.  Default 0.80 matches kDefaultReactLevel in OceanView.
-        persistedReactLevel_ = juce::jlimit(0.0f, 1.0f,
-            static_cast<float>(xml->getDoubleAttribute("reactLevel", 0.80)));
+        persistedReactLevel_ =
+            juce::jlimit(0.0f, 1.0f, static_cast<float>(xml->getDoubleAttribute("reactLevel", 0.80)));
 
         // F3-011/F3-017: Restore breakout panel open states.
         // Defaults to false (closed) for sessions predating this feature.
-        persistedSeqBreakoutOpen_   = xml->getIntAttribute("seqBreakoutOpen",   0) != 0;
+        persistedSeqBreakoutOpen_ = xml->getIntAttribute("seqBreakoutOpen", 0) != 0;
         persistedChordBreakoutOpen_ = xml->getIntAttribute("chordBreakoutOpen", 0) != 0;
 
         // #1378 — Restore per-slot preset names.
@@ -4088,10 +4047,10 @@ void XOceanusProcessor::applyPreset(const PresetData& preset)
             for (const auto& pmt : slotTargets)
             {
                 MacroTarget mt;
-                mt.engineId    = pmt.engineName;
+                mt.engineId = pmt.engineName;
                 mt.parameterId = pmt.paramId;
-                mt.minValue    = pmt.depthMin;
-                mt.maxValue    = pmt.depthMax;
+                mt.minValue = pmt.depthMin;
+                mt.maxValue = pmt.depthMax;
                 // isCouplingTarget / couplingRouteSlot remain false/-1:
                 // engine parameter targets are resolved via parameterId lookup.
                 liveTargets.push_back(std::move(mt));
@@ -4113,10 +4072,8 @@ void XOceanusProcessor::applyPreset(const PresetData& preset)
     // as the same baseline. Future enhancement: per-engine DNA in preset schema would
     // call setBaseDNA per slot with different values.
     {
-        std::array<float, 6> dnaArr = {
-            preset.dna.brightness, preset.dna.warmth,    preset.dna.movement,
-            preset.dna.density,    preset.dna.space,     preset.dna.aggression
-        };
+        std::array<float, 6> dnaArr = {preset.dna.brightness, preset.dna.warmth, preset.dna.movement,
+                                       preset.dna.density,    preset.dna.space,  preset.dna.aggression};
         for (int slot = 0; slot < xoceanus::DNAModulationBus::MaxEngineSlots; ++slot)
             dnaBus_.setBaseDNA(slot, dnaArr);
     }

--- a/Source/XOceanusProcessor.h
+++ b/Source/XOceanusProcessor.h
@@ -168,10 +168,7 @@ public:
     // Read the global cutoff mod offset computed from global mod routes.
     // Called by OrreryEngine::renderBlock on the audio thread.
     // Zero when no global route targets orry_fltCutoff.
-    float getGlobalCutoffModOffset() const noexcept
-    {
-        return globalCutoffModOffset_.load(std::memory_order_relaxed);
-    }
+    float getGlobalCutoffModOffset() const noexcept { return globalCutoffModOffset_.load(std::memory_order_relaxed); }
 
     // B1: Read the accumulated modOffset for a given route slot (audio-thread only).
     // Returns 0.0f for out-of-range indices.  Engines that opt into generic global
@@ -181,7 +178,8 @@ public:
     // range span to convert to parameter units.
     float getModRouteAccum(int routeIdx) const noexcept
     {
-        if (routeIdx < 0 || routeIdx >= kMaxGlobalRoutes) return 0.0f;
+        if (routeIdx < 0 || routeIdx >= kMaxGlobalRoutes)
+            return 0.0f;
         return routeModAccum_[static_cast<size_t>(routeIdx)];
     }
 
@@ -193,10 +191,7 @@ public:
     const float* getModRouteAccumPtr() const noexcept { return routeModAccum_.data(); }
 
     // B1: Read the number of active routes in the snapshot (audio-thread or message-thread).
-    int getModRouteCount() const noexcept
-    {
-        return routesSnapshotCount_.load(std::memory_order_relaxed);
-    }
+    int getModRouteCount() const noexcept { return routesSnapshotCount_.load(std::memory_order_relaxed); }
 
     // T6: Per-route snapshot accessors for engines that opt into generic global
     // mod routing.  Engines call these in their attachParameters() / onModRoutesChanged()
@@ -210,17 +205,20 @@ public:
     //   Multiply getModRouteAccum(ri) by this to convert normalised offset to param units.
     const char* getModRouteDestParamId(int ri) const noexcept
     {
-        if (ri < 0 || ri >= kMaxGlobalRoutes) return "";
+        if (ri < 0 || ri >= kMaxGlobalRoutes)
+            return "";
         return routesSnapshot_[static_cast<size_t>(ri)].destParamId;
     }
     bool isModRouteVelocityScaled(int ri) const noexcept
     {
-        if (ri < 0 || ri >= kMaxGlobalRoutes) return false;
+        if (ri < 0 || ri >= kMaxGlobalRoutes)
+            return false;
         return routesSnapshot_[static_cast<size_t>(ri)].velocityScaled;
     }
     float getModRouteRangeSpan(int ri) const noexcept
     {
-        if (ri < 0 || ri >= kMaxGlobalRoutes) return 0.0f;
+        if (ri < 0 || ri >= kMaxGlobalRoutes)
+            return 0.0f;
         return routesSnapshot_[static_cast<size_t>(ri)].destParamRangeSpan;
     }
 
@@ -261,9 +259,8 @@ public:
     }
     void removeSlotPresetListener(SlotPresetListener* l)
     {
-        slotPresetListeners_.erase(
-            std::remove(slotPresetListeners_.begin(), slotPresetListeners_.end(), l),
-            slotPresetListeners_.end());
+        slotPresetListeners_.erase(std::remove(slotPresetListeners_.begin(), slotPresetListeners_.end(), l),
+                                   slotPresetListeners_.end());
     }
 
     // Engine slot management (message thread only)
@@ -362,7 +359,7 @@ public:
     // The UI oscilloscope component calls getWaveformFifo(slot).readLatest()
     // at its ~30Hz repaint timer to grab the latest window of samples.
     std::array<WaveformFifo, MaxSlots> waveformFifos;
-    WaveformFifo masterOutputFifo;  // master bus output (post-FX) for ocean wave surface
+    WaveformFifo masterOutputFifo; // master bus output (post-FX) for ocean wave surface
 
     // UI-thread accessor — returns a const reference; safe to call at any time.
     const WaveformFifo& getWaveformFifo(int slot) const noexcept
@@ -483,22 +480,17 @@ public:
         // Re-load Oxbow in slot 0 so the engine is ready for the note.
         loadEngine(0, "Oxbow");
         // Re-apply the Breath Mist preset parameters inline (same values as first launch).
-        struct BreathMistParam { const char* id; float value; };
+        struct BreathMistParam
+        {
+            const char* id;
+            float value;
+        };
         static const BreathMistParam kBreathMistParams[] = {
-            {"oxb_size",          0.1f},
-            {"oxb_decay",         0.5f},
-            {"oxb_entangle",      0.06f},
-            {"oxb_erosionRate",   0.05f},
-            {"oxb_erosionDepth",  0.08f},
-            {"oxb_convergence",   4.0f},
-            {"oxb_resonanceQ",    3.5f},
-            {"oxb_resonanceMix",  0.15f},
-            {"oxb_cantilever",    0.12f},
-            {"oxb_damping",       7000.0f},
-            {"oxb_predelay",      0.0f},
-            {"oxb_dryWet",        0.15f},
-            {"oxb_exciterDecay",  0.05f},
-            {"oxb_exciterBright", 0.5f},
+            {"oxb_size", 0.1f},          {"oxb_decay", 0.5f},         {"oxb_entangle", 0.06f},
+            {"oxb_erosionRate", 0.05f},  {"oxb_erosionDepth", 0.08f}, {"oxb_convergence", 4.0f},
+            {"oxb_resonanceQ", 3.5f},    {"oxb_resonanceMix", 0.15f}, {"oxb_cantilever", 0.12f},
+            {"oxb_damping", 7000.0f},    {"oxb_predelay", 0.0f},      {"oxb_dryWet", 0.15f},
+            {"oxb_exciterDecay", 0.05f}, {"oxb_exciterBright", 0.5f},
         };
         for (const auto& p : kBreathMistParams)
         {
@@ -518,24 +510,22 @@ public:
     // atomic updated each processBlock tick.  The message thread uses this to gate
     // the FirstHourWalkthrough prompt so the tour bubble does not appear while the
     // greeting note is still playing (race fix per Wave 9c spec §1303).
-    bool isFirstBreathActive() const noexcept
-    {
-        return firstBreathActiveMirror_.load(std::memory_order_relaxed);
-    }
+    bool isFirstBreathActive() const noexcept { return firstBreathActiveMirror_.load(std::memory_order_relaxed); }
 
     // Dark Cockpit B041: note activity level (0.0 = silent, 1.0 = max activity).
     // Computed from output RMS in processBlock() with ~100ms attack / ~500ms release.
     // Safe to call from any thread.
     float getNoteActivity() const noexcept { return noteActivity_.load(std::memory_order_relaxed); }
 
-    // ── Wave5-C5: SlotModSourceRegistry — message-thread-origin ModSources ──────
-    // Exposes live bipolar values for ModSources whose origin is the message thread
-    // (UI gestures, pin callbacks).  Audio thread reads them lock-free from
-    // processBlock().  Currently hosts XouijaCell; extend for future UI-origin sources.
+    // ── Wave5-C5 + #1383 A4: SlotModSourceRegistry ───────────────────────────
+    // Hosts XouijaCell (ID=18, back-compat) + XouijaX/Y (IDs=28/29, A4).
     //
-    // Wire-up (in PlaySurface::setProcessor or equivalent):
+    // Wire-up (PlaySurface::setProcessor, #1383 A4):
     //   xouijaPanel_.getPinStore().onPinChanged = [this](float bx, float by) {
-    //       modSourceRegistry_.updateSourceValue(ModSourceId::XouijaCell, bx, by);
+    //       auto& r = modSourceRegistry_;
+    //       r.updateSourceValue(ModSourceId::XouijaX, bx);
+    //       r.updateSourceValue(ModSourceId::XouijaY, by);
+    //       r.updateSourceValue(ModSourceId::XouijaCell, bx, by);
     //   };
     SlotModSourceRegistry& getModSourceRegistry() noexcept { return modSourceRegistry_; }
     const SlotModSourceRegistry& getModSourceRegistry() const noexcept { return modSourceRegistry_; }
@@ -552,18 +542,21 @@ public:
     // getXYPosition: call from audio thread inside processBlock.
     void setXYPosition(int slot, float x, float y) noexcept
     {
-        if (slot < 0 || slot >= kNumPrimarySlots) return;
+        if (slot < 0 || slot >= kNumPrimarySlots)
+            return;
         xyX_[static_cast<size_t>(slot)].store(x, std::memory_order_relaxed);
         xyY_[static_cast<size_t>(slot)].store(y, std::memory_order_relaxed);
     }
     float getXYX(int slot) const noexcept
     {
-        if (slot < 0 || slot >= kNumPrimarySlots) return 0.5f;
+        if (slot < 0 || slot >= kNumPrimarySlots)
+            return 0.5f;
         return xyX_[static_cast<size_t>(slot)].load(std::memory_order_relaxed);
     }
     float getXYY(int slot) const noexcept
     {
-        if (slot < 0 || slot >= kNumPrimarySlots) return 0.5f;
+        if (slot < 0 || slot >= kNumPrimarySlots)
+            return 0.5f;
         return xyY_[static_cast<size_t>(slot)].load(std::memory_order_relaxed);
     }
 
@@ -594,38 +587,32 @@ public:
     void setPersistedRegisterLocked(bool v) noexcept { persistedRegisterLocked = v; }
     bool getPersistedRegisterLocked() const noexcept { return persistedRegisterLocked; }
     void setPersistedRegisterCurrent(int r) noexcept { persistedRegisterCurrent = r; }
-    int  getPersistedRegisterCurrent() const noexcept { return persistedRegisterCurrent; }
+    int getPersistedRegisterCurrent() const noexcept { return persistedRegisterCurrent; }
 
     // F2-006: OceanView ViewState + zoomed slot persistence.
     // Written by OceanView's onStateEntered callback (message thread only).
     void setPersistedOceanViewState(int state) noexcept { persistedOceanViewState_ = state; }
-    int  getPersistedOceanViewState() const noexcept    { return persistedOceanViewState_; }
-    void setPersistedOceanViewSlot(int slot)  noexcept  { persistedOceanViewSlot_  = slot;  }
-    int  getPersistedOceanViewSlot()  const noexcept    { return persistedOceanViewSlot_;  }
+    int getPersistedOceanViewState() const noexcept { return persistedOceanViewState_; }
+    void setPersistedOceanViewSlot(int slot) noexcept { persistedOceanViewSlot_ = slot; }
+    int getPersistedOceanViewSlot() const noexcept { return persistedOceanViewSlot_; }
 
     // F3-006: REACT dial level persistence (0.0–1.0; default 0.80).
     // Written by OceanView HUD dial callback; read back in initHudCallbacks().
-    void  setPersistedReactLevel(float v) noexcept  { persistedReactLevel_ = juce::jlimit(0.0f, 1.0f, v); }
-    float getPersistedReactLevel() const noexcept   { return persistedReactLevel_; }
+    void setPersistedReactLevel(float v) noexcept { persistedReactLevel_ = juce::jlimit(0.0f, 1.0f, v); }
+    float getPersistedReactLevel() const noexcept { return persistedReactLevel_; }
 
     // F3-011/F3-017: Sequencer and Chord breakout panel open-state persistence.
     // Written by OceanView when panels open/close; read back after session restore.
-    void setPersistedSeqBreakoutOpen(bool v)   noexcept { persistedSeqBreakoutOpen_   = v; }
-    bool getPersistedSeqBreakoutOpen()  const noexcept  { return persistedSeqBreakoutOpen_;   }
+    void setPersistedSeqBreakoutOpen(bool v) noexcept { persistedSeqBreakoutOpen_ = v; }
+    bool getPersistedSeqBreakoutOpen() const noexcept { return persistedSeqBreakoutOpen_; }
     void setPersistedChordBreakoutOpen(bool v) noexcept { persistedChordBreakoutOpen_ = v; }
     bool getPersistedChordBreakoutOpen() const noexcept { return persistedChordBreakoutOpen_; }
 
     // #1179 — TideWaterline deferred state pickup.
     // OceanView calls this in initWaterline() to apply state that arrived via
     // setStateInformation() before the editor window was first opened.
-    juce::ValueTree getPersistedTideWaterlineState() const noexcept
-    {
-        return persistedTideWaterlineState_;
-    }
-    void clearPersistedTideWaterlineState() noexcept
-    {
-        persistedTideWaterlineState_ = juce::ValueTree{};
-    }
+    juce::ValueTree getPersistedTideWaterlineState() const noexcept { return persistedTideWaterlineState_; }
+    void clearPersistedTideWaterlineState() noexcept { persistedTideWaterlineState_ = juce::ValueTree{}; }
 
     // ── Settings-drawer session controls (#1359) ─────────────────────────────
     // All setters are message-thread-only; atomics are read by the audio thread.
@@ -644,10 +631,7 @@ public:
     // Global voice mode: 0=Poly, 1=Mono, 2=Legato, 3=Unison.  Default 0.
     // Engines that expose their own voiceMode param continue to honour that param;
     // this is the session-level override applied at the processor layer.
-    void setVoiceMode(int mode) noexcept
-    {
-        voiceMode_.store(juce::jlimit(0, 3, mode), std::memory_order_relaxed);
-    }
+    void setVoiceMode(int mode) noexcept { voiceMode_.store(juce::jlimit(0, 3, mode), std::memory_order_relaxed); }
     int getVoiceMode() const noexcept { return voiceMode_.load(std::memory_order_relaxed); }
 
     // Master tune in Hz.  Range 415.0..466.0 (±1 semitone around A=440).
@@ -723,7 +707,7 @@ private:
     std::shared_ptr<std::vector<MegaCouplingMatrix::CouplingRoute>> mergedRoutePtr;
 
     MasterFXChain masterFX;
-    xoceanus::EpicChainSlotController epicSlots;  // 3-slot Epic Chains FX router
+    xoceanus::EpicChainSlotController epicSlots; // 3-slot Epic Chains FX router
     ChordMachine chordMachine;
 
     // Unified host transport — the processor updates this from the PlayHead
@@ -847,16 +831,16 @@ private:
         std::array<std::atomic<float>*, 4> cmSlotRoute = {nullptr, nullptr, nullptr, nullptr};
 
         // B2: input mode + global key/scale
-        std::atomic<float>* cmInputMode   = nullptr; // chord_input_mode (0=AUTO, 1=PAD, 2=DEG)
-        std::atomic<float>* cmGlobalRoot  = nullptr; // cm_global_root (0-11)
+        std::atomic<float>* cmInputMode = nullptr;   // chord_input_mode (0=AUTO, 1=PAD, 2=DEG)
+        std::atomic<float>* cmGlobalRoot = nullptr;  // cm_global_root (0-11)
         std::atomic<float>* cmGlobalScale = nullptr; // cm_global_scale (0-8)
 
         // B2: pad chord slots (16 × 3 params)
         struct PadChordParams
         {
-            std::atomic<float>* root    = nullptr; // chord_pad_N_root   [0,127]
+            std::atomic<float>* root = nullptr;    // chord_pad_N_root   [0,127]
             std::atomic<float>* voicing = nullptr; // chord_pad_N_voicing [0,NumModes-1]
-            std::atomic<float>* inv     = nullptr; // chord_pad_N_inv    [0,3]
+            std::atomic<float>* inv = nullptr;     // chord_pad_N_inv    [0,3]
         };
         std::array<PadChordParams, 16> padChords;
 
@@ -886,10 +870,10 @@ private:
 
         // Wave 5 D1: XOuija walk engine mood/tendency — cached raw pointers
         // so processBlock reads them without string lookups.
-        std::atomic<float>* ouijaCalmWild          = nullptr;
+        std::atomic<float>* ouijaCalmWild = nullptr;
         std::atomic<float>* ouijaConsonantDissonant = nullptr;
-        std::atomic<float>* ouijaTendencyCol        = nullptr;
-        std::atomic<float>* ouijaTendencyRow        = nullptr;
+        std::atomic<float>* ouijaTendencyCol = nullptr;
+        std::atomic<float>* ouijaTendencyRow = nullptr;
     } cachedParams;
 
     juce::MidiBuffer mpeMidiBuffer; // MPE-processed MIDI (expression stripped)
@@ -947,15 +931,15 @@ private:
     // Written by processBlock (audio thread), read by message thread.
     std::atomic<bool> firstBreathActiveMirror_{false};
     // Audio-thread-only state (no atomics needed):
-    bool         firstBreathActive_{false};
-    int          firstBreathCountdown_{0};
-    bool         firstBreathFading_{false};     // true during the 200 ms interaction fade
-    int          firstBreathFadeCountdown_{0};  // samples remaining in fade window
-    uint64_t     firstBreathGeneration_{0}; // engineGeneration_ value at arm time; if it changes, breath is cancelled
-    static constexpr int  kFirstBreathNote       = 48;     // C3
-    static constexpr float kFirstBreathVelocity  = 60.0f / 127.0f;
-    static constexpr int  kFirstBreathTimeoutMs  = 30000;  // 30-second failsafe
-    static constexpr int  kFirstBreathFadeMs     = 200;    // §1300: fade window before note-off on user interaction
+    bool firstBreathActive_{false};
+    int firstBreathCountdown_{0};
+    bool firstBreathFading_{false};     // true during the 200 ms interaction fade
+    int firstBreathFadeCountdown_{0};   // samples remaining in fade window
+    uint64_t firstBreathGeneration_{0}; // engineGeneration_ value at arm time; if it changes, breath is cancelled
+    static constexpr int kFirstBreathNote = 48; // C3
+    static constexpr float kFirstBreathVelocity = 60.0f / 127.0f;
+    static constexpr int kFirstBreathTimeoutMs = 30000; // 30-second failsafe
+    static constexpr int kFirstBreathFadeMs = 200;      // §1300: fade window before note-off on user interaction
 
     // ── Per-slot mute state ───────────────────────────────────────────────────
     // Written by message thread (setSlotMuted), read by audio thread per block.
@@ -1065,7 +1049,7 @@ private:
     // and store 0.5f in the XOceanusProcessor constructor body (see XOceanusProcessor.cpp).
     std::array<std::atomic<float>, kNumPrimarySlots> xyX_;
     std::array<std::atomic<float>, kNumPrimarySlots> xyY_;
-    // Wave5-C5: message-thread-origin ModSource live values (XouijaCell, etc.)
+    // Wave5-C5 + #1383 A4: message-thread-origin ModSources (XouijaCell=18, XouijaX=28, XouijaY=29)
     SlotModSourceRegistry modSourceRegistry_;
     // Timestamp of the start of the current processBlock call (high-res ticks).
     juce::int64 processBlockStartTick{0};
@@ -1120,17 +1104,17 @@ private:
 
     // ── Editor UI state storage (closes #314, #357) ──────────────────────────
     // Written on the message thread only.  No audio-thread access — plain ints.
-    int persistedPlayScaleIndex = 0;     // #314: PlayControlPanel scale selector
-    int persistedSelectedSlot = -1;      // #357: editor tile focus (-1 = overview)
-    int persistedSignalFlowSection = 0;  // #357: signal flow active section
-    bool persistedCockpitBypass = false; // #357: Dark Cockpit bypass state
-    bool persistedRegisterLocked = false; // D4: register lock toggle
-    int  persistedRegisterCurrent = 0;   // D4: current register index (0=Gallery, 1=Performance, 2=Coupling)
-    int  persistedOceanViewState_ = 0;   // F2-006: OceanView ViewState (0=Orbital,1=ZoomIn,2=Split,3=Browser)
-    int  persistedOceanViewSlot_  = -1;  // F2-006: slot index when ViewState is ZoomIn/Split
-    float persistedReactLevel_    = 0.80f; // F3-006: REACT dial visual reactivity level
-    bool  persistedSeqBreakoutOpen_   = false; // F3-011: sequencer breakout panel open state
-    bool  persistedChordBreakoutOpen_ = false; // F3-017: chord breakout panel open state
+    int persistedPlayScaleIndex = 0;          // #314: PlayControlPanel scale selector
+    int persistedSelectedSlot = -1;           // #357: editor tile focus (-1 = overview)
+    int persistedSignalFlowSection = 0;       // #357: signal flow active section
+    bool persistedCockpitBypass = false;      // #357: Dark Cockpit bypass state
+    bool persistedRegisterLocked = false;     // D4: register lock toggle
+    int persistedRegisterCurrent = 0;         // D4: current register index (0=Gallery, 1=Performance, 2=Coupling)
+    int persistedOceanViewState_ = 0;         // F2-006: OceanView ViewState (0=Orbital,1=ZoomIn,2=Split,3=Browser)
+    int persistedOceanViewSlot_ = -1;         // F2-006: slot index when ViewState is ZoomIn/Split
+    float persistedReactLevel_ = 0.80f;       // F3-006: REACT dial visual reactivity level
+    bool persistedSeqBreakoutOpen_ = false;   // F3-011: sequencer breakout panel open state
+    bool persistedChordBreakoutOpen_ = false; // F3-017: chord breakout panel open state
 
     // ── #1178: TideWaterline deferred step-sequence state ────────────────────
     // Holds the "TideWaterlineSteps" tree from setStateInformation() when the
@@ -1180,14 +1164,14 @@ private:
     // Max 32 routes; fixed-size array avoids any audio-thread allocation.
     struct GlobalModRouteSnapshot
     {
-        int     sourceId{0};
-        float   depth{0.0f};
-        bool    bipolar{false};
-        bool    valid{false};
-        char    destParamId[64]{};  // fixed-length to avoid std::string on audio thread
+        int sourceId{0};
+        float depth{0.0f};
+        bool bipolar{false};
+        bool valid{false};
+        char destParamId[64]{}; // fixed-length to avoid std::string on audio thread
         // Wave 5 C5: per-route slot index for sequencer-scoped sources.
         // -1 = not slot-scoped (backward-compat default).  0–3 = slot to query.
-        int     slotIndex{-1};
+        int slotIndex{-1};
 
         // B1: Pre-resolved destination parameter pointer (resolved on message thread in
         // flushModRoutesSnapshot).  Lifetime: as long as the APVTS (i.e., the processor).
@@ -1226,9 +1210,9 @@ private:
     };
     static constexpr int kMaxGlobalRoutes = ModRoutingModel::MaxRoutes;
     std::array<GlobalModRouteSnapshot, kMaxGlobalRoutes> routesSnapshot_{};
-    std::atomic<int> routesSnapshotCount_{0};   // written by message thread, read by audio thread
-    std::atomic<int> snapshotVersion_{0};        // generation counter
-    int audioSnapshotVersion_{-1};               // audio thread: last consumed version (audio-thread-only)
+    std::atomic<int> routesSnapshotCount_{0}; // written by message thread, read by audio thread
+    std::atomic<int> snapshotVersion_{0};     // generation counter
+    int audioSnapshotVersion_{-1};            // audio thread: last consumed version (audio-thread-only)
 
     // Cached pointer to the orry_fltCutoff parameter — resolved once in cacheParameterPointers()
     // and used in flushModRoutesSnapshot() to set isOrryCutoff by pointer identity (no strncmp).


### PR DESCRIPTION
## Problem: Dead-wiring across A1/A2/A3 parallel split

Three PRs implementing #1383 were developed in parallel and split across different territories:

- **A1 (#1479)** — `XouijaPinStore.notifyListeners()` fix + `setProcessor()` wiring scaffold
- **A2 (#1481)** — `PlaySurface.setProcessor()` lambda that calls `updateSourceValue(ModSourceId::XouijaCell, bx, by)` — wired to **old ID=18**
- **A3 (#1480)** — Picker UI: added `XouijaX=28`, `XouijaY=29`, `XouijaDepth=30` to `ModSourceId` enum **with no backing atomics**

Result: the picker exposes `XouijaX` and `XouijaY` in the menu but no code writes to them. Users who route a parameter to those sources hear nothing because the registry atomics don't exist. Additionally, `XouijaDepth=30` was semantically wrong — A1 confirmed that `influenceY` IS the depth axis.

## Changes in this PR (A4)

### Drop
- `XouijaDepth` (proposed ID=30) — removed from enum, names, colours, glyphs, picker table, strip colour table. `Count` stays at 30 (IDs 28+29 fill that space cleanly).

### Add to `SlotModSourceRegistry.h`
- `ouijaLiveX_` / `ouijaLiveY_` `std::atomic<float>` members
- Single-float `updateSourceValue(ModSourceId, float)` overload for the two new IDs
- `getXouijaX()` / `getXouijaY()` audio-thread read accessors
- `reset()` and constructor updated to zero-init the new atomics

### Fix `PlaySurface.h` (reconciled A1+A2 lambda — supersedes #1481)
- Null out `onPinChanged` before processor swap (A1 pattern)
- New lambda fan-writes three atomics on each pin change:
  ```cpp
  reg.updateSourceValue(ModSourceId::XouijaX, bx);    // ID=28 — new
  reg.updateSourceValue(ModSourceId::XouijaY, by);    // ID=29 — new
  reg.updateSourceValue(ModSourceId::XouijaCell, bx, by); // ID=18 — back-compat
  ```

### Fix `XouijaPinStore.h` (A1 bug)
- `notifyListeners()` was gated on `isPinned_` — unpin never fired callback, leaving stale values in registry. Fixed to always call with `(0, 0)` on unpin.

### Extend `XOceanusProcessor.cpp`
- Added `else-if` branches for `XouijaX` and `XouijaY` in the processBlock mod-routing accumulation loop.

### Legacy `XouijaCell=18` decision: **KEPT**
Searching `grep -rn "XouijaCell" Source/` finds the ID referenced in `XOceanusProcessor.cpp` (processBlock branch reading `getXouijaCellX()`), multiple comment sites, and the registry itself. Removing it would require a preset migration to remap saved routes with `sourceId=18`. The three-write fan-out in the lambda is free (`std::atomic::store` relaxed, 3 × 4 bytes). Legacy routes on ID=18 continue to work unchanged.

## Final XOuija ModSource ID table

| ID | Enum | Atomic | Accessor | Notes |
|----|------|--------|----------|-------|
| 18 | `XouijaCell` | `ouijaCellX_` / `ouijaCellY_` | `getXouijaCellX()` / `getXouijaCellY()` | Legacy, back-compat, preset-frozen |
| 28 | `XouijaX` | `ouijaLiveX_` | `getXouijaX()` | New in A4 — planchette X (circle-of-fifths) |
| 29 | `XouijaY` | `ouijaLiveY_` | `getXouijaY()` | New in A4 — planchette Y (influence depth) |

## Audio-thread safety guarantees (carried over from #1481)

| Guarantee | Mechanism |
|-----------|-----------|
| No alloc on message thread | `onPinChanged` lambda captures `this` only; no heap ops |
| No alloc on audio thread | `getXouijaCellX/Y()`, `getXouijaX/Y()` read `std::atomic<float>` only |
| No mutex / lock | `std::atomic<float>` with `memory_order_relaxed` — one-block-late is acceptable for a continuous mod source |
| No dangling processor reference | Detach path (`processor_ == nullptr`) nulls `onPinChanged` before returning |
| No firing after editor destroy | `PlaySurface` destructor path hits `setProcessor(nullptr)` which nulls the callback |
| `onPinChanged` fires on message thread | `XouijaPinStore::notifyListeners()` is message-thread-only per store contract |
| Write-read ordering | Relaxed atomic store (message thread) / relaxed atomic load (audio thread) — safe because a one-block-late value is musically acceptable |

## Merge order

**Required: A3 (#1480) must merge before this PR.** A4 conflicts with A3 on `ModSourceHandle.h` (both touch the enum and `Count`). The conflict is intentional — A4 is the reconciliation. After A3 merges, rebase this branch onto updated main before merging A4.

Final sequence: **A1 (#1479) → A3 (#1480) → A4 (this PR)**. #1481 closed as superseded — A4's lambda is a strict superset.

## Test plan (carried over from #1481, expanded for A4)

- [ ] Pin XOuija planchette (right-click → "Pin as ModSource") — verify `onPinChanged` fires and `SlotModSourceRegistry` receives bipolar values
- [ ] Unpin — verify registry receives (0, 0) via `notifyListeners()` path
- [ ] Close editor window — verify no crash (detach callback is null before processor outlives editor)
- [ ] Re-open editor with saved state — verify pin store restores correctly and callback re-installs
- [ ] Wire a mod route to `ModSourceId::XouijaCell` (ID 18) and confirm mod target moves when pin changes (back-compat)
- [ ] Wire a mod route to `ModSourceId::XouijaX` (ID 28) and confirm mod target moves when planchette drags horizontally
- [ ] Wire a mod route to `ModSourceId::XouijaY` (ID 29) and confirm mod target moves when planchette drags vertically
- [ ] Confirm `XouijaDepth=30` no longer appears in picker

## Files touched

- `Source/Core/SlotModSourceRegistry.h` — new atomics, overloads, accessors, reset
- `Source/Future/UI/ModRouting/ModSourceHandle.h` — enum (XouijaX/Y added, Depth dropped, Count=30), names, colours, glyphs
- `Source/Future/UI/ModRouting/ModulateFromMenu.h` — kAllModSources: XouijaX/Y rows added, comment updated
- `Source/Future/UI/ModRouting/ModMatrixBreakout.h` — kAllModSourcesForStrip: violet entries for 28/29
- `Source/UI/PlaySurface/PlaySurface.h` — setProcessor() fan-out lambda + null-out on swap
- `Source/UI/PlaySurface/XOuijaPanel.h` — comment updated to reflect live wiring
- `Source/UI/PlaySurface/XouijaPinStore.h` — notifyListeners() fix + callback doc updated
- `Source/XOceanusProcessor.cpp` — processBlock: XouijaX/Y branches added
- `Source/XOceanusProcessor.h` — comment updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
