### PR TITLE
feat: T6 Oxbow engine opt-in to mod matrix (Path B Phase 2.6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,8 @@ target_sources(XOceanus PRIVATE
     Source/Engines/Organism/OrganismEngine.cpp
     Source/Engines/Oxbow/OxbowEngine.h
     Source/Engines/Oxbow/OxbowEngine.cpp
+    Source/Engines/Oxbow/OxbowAdapter.h
+    Source/Engines/Oxbow/OxbowAdapter.cpp
     Source/Engines/Oware/OwareEngine.h
     Source/Engines/Oware/OwareEngine.cpp
 

--- a/Source/Engines/Oxbow/OxbowAdapter.cpp
+++ b/Source/Engines/Oxbow/OxbowAdapter.cpp
@@ -1,0 +1,62 @@
+#include "OxbowAdapter.h"
+// T6: full processor type needed for getModRouteCount / getModRouteDestParamId etc.
+// XOceanusProcessor.h includes OxbowAdapter.h (transitively via OxbowEngine.h), so
+// this include is safe — the header guard prevents double-inclusion; by the time
+// we get here OxbowAdapter.h is done.
+#include "../../XOceanusProcessor.h"
+
+namespace xoceanus
+{
+
+// T6: cacheGlobalModRoutes — scan the current global-mod-route snapshot for routes
+// that target any of Oxbow's 5 modulated parameters.  Stores the route index (or -1)
+// per target so renderBlock() can read getModRouteAccum() in O(1) without strncmp.
+//
+// Thread-safety: called on the message thread (from setProcessorPtr() and from any
+// future flushModRoutesSnapshot() callback).  The audio thread reads the cached
+// arrays read-only.  A one-block lag is acceptable — worst case is a missed
+// mod-offset for a single block when a route is added or removed.
+//
+// DSP safety: no allocation, no locks, no logging.
+void OxbowAdapter::cacheGlobalModRoutes() noexcept
+{
+    // Reset all targets to "no active route"
+    for (int t = 0; t < kOxbowGlobalModTargets; ++t)
+    {
+        globalModRouteIdx_[t]  = -1;
+        globalModVelScaled_[t] = false;
+        globalModRangeSpan_[t] = 0.0f;
+    }
+
+    if (processorPtr_ == nullptr)
+    {
+        modAccumPtr_ = nullptr;
+        return;
+    }
+
+    // Cache the raw accumulator pointer — used by applyGlobalModRoutes() without
+    // needing to call through the full XOceanusProcessor type in the header.
+    modAccumPtr_ = processorPtr_->getModRouteAccumPtr();
+
+    int numRoutes = processorPtr_->getModRouteCount();
+    for (int ri = 0; ri < numRoutes; ++ri)
+    {
+        const char* destId = processorPtr_->getModRouteDestParamId(ri);
+        if (destId == nullptr || destId[0] == '\0')
+            continue;
+
+        for (int t = 0; t < kOxbowGlobalModTargets; ++t)
+        {
+            if (std::strcmp(destId, kGlobalModTargetIds[t]) == 0)
+            {
+                // Last matching route wins if multiple routes target the same param.
+                globalModRouteIdx_[t]  = ri;
+                globalModVelScaled_[t] = processorPtr_->isModRouteVelocityScaled(ri);
+                globalModRangeSpan_[t] = processorPtr_->getModRouteRangeSpan(ri);
+                break;
+            }
+        }
+    }
+}
+
+} // namespace xoceanus

--- a/Source/Engines/Oxbow/OxbowAdapter.h
+++ b/Source/Engines/Oxbow/OxbowAdapter.h
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+//==============================================================================
+// OxbowAdapter.h — XOceanus mod-matrix opt-in adapter for OxbowEngine
+//
+// Engine: Oxbow (Entangled Reverb) — Engine #43
+// Concept: Chiasmus FDN reverb. Sound enters as rushing water; the Oxbow cuts
+//          the current, leaving a suspended pool of resonance that slowly erases
+//          itself. Golden standing waves remain.
+// Accent: Oxbow Teal #1A6B5A | Prefix: oxb_ | Voices: 1 (monophonic reverb)
+//
+// T6: Pattern B mod-matrix opt-in.
+// Wraps OxbowEngine and adds the global-mod-route consumption path so the mod
+// matrix can target Oxbow's 5 most performance-expressive parameters without any
+// per-sample strcmp on the audio thread.
+//
+// Silence gate: managed by OxbowEngine internally. This adapter calls
+// engine_.prepareSilenceGate() in prepare() so the engine's gate is ready, and
+// delegates all SRO gate queries to the engine via analyzeForSilenceGate() at
+// the end of renderBlock(). The adapter's own gate (inherited from SynthEngine)
+// is kept in sync so the processor's isSilenceGateBypassed() check works correctly.
+//
+// Targets (5):
+//   0 = oxb_decay       — Decay Time (0.1..60s). Velocity → longer tail.
+//   1 = oxb_damping     — Damping Hz (200..16000). D001: velocity → brighter timbre.
+//   2 = oxb_entangle    — Entanglement (0..1). Velocity → denser L/R cross-coupling.
+//   3 = oxb_dryWet      — Dry/Wet (0..1). Velocity → deeper immersion.
+//   4 = oxb_size        — Space Size (0..1). Velocity → larger virtual room.
+//
+// Threading: setProcessorPtr() called once on message thread from loadEngine();
+// cacheGlobalModRoutes() refreshed from flushModRoutesSnapshot(). Audio thread
+// reads cached indices read-only with one-block lag tolerance.
+//==============================================================================
+
+#include "../../Core/SynthEngine.h"
+#include "OxbowEngine.h"
+#include <array>
+#include <cstring>
+
+namespace xoceanus
+{
+
+// T6: Forward-declare so OxbowAdapter can cache a processor pointer for the
+// global mod-route path. Full type is included in OxbowAdapter.cpp only.
+class XOceanusProcessor;
+
+// Number of global mod-route slots cached at load time.
+static constexpr int kOxbowGlobalModTargets = 5;
+
+class OxbowAdapter : public SynthEngine
+{
+public:
+    OxbowAdapter() = default;
+
+    //-- Identity ---------------------------------------------------------------
+
+    juce::String getEngineId()    const override { return engine_.getEngineId(); }
+    juce::Colour getAccentColour() const override { return engine_.getAccentColour(); }
+    int          getMaxVoices()   const override { return engine_.getMaxVoices(); }
+
+    //-- Lifecycle ---------------------------------------------------------------
+
+    void prepare(double sampleRate, int maxBlockSize) override
+    {
+        engine_.prepare(sampleRate, maxBlockSize);
+        // Prepare the adapter's own silence gate so isSilenceGateBypassed() returns
+        // a valid result when called by the processor. The engine's internal gate is
+        // also set up here (engine_.prepareSilenceGate) so OxbowEngine's renderBlock()
+        // internal bypass check works correctly.
+        // Note: the processor calls prepareSilenceGate() separately after prepare() —
+        // that second call sets the hold time from silenceGateHoldMs(). Both calls are
+        // needed: this one ensures the engine's gate is prepared before the first
+        // renderBlock(), the processor's call overrides hold time on both gates.
+        const float holdMs = 500.0f; // Chiasmus FDN + pre-delay reverb tail
+        prepareSilenceGate(sampleRate, maxBlockSize, holdMs);
+        engine_.prepareSilenceGate(sampleRate, maxBlockSize, holdMs);
+    }
+
+    void releaseResources() override { engine_.releaseResources(); }
+
+    void reset() override { engine_.reset(); }
+
+    //-- Audio ------------------------------------------------------------------
+
+    void renderBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi, int numSamples) override
+    {
+        juce::ScopedNoDenormals noDenormals;
+
+        // Wake both gates on note-on so neither gate silences the reverb tail.
+        for (const auto& metadata : midi)
+        {
+            if (metadata.getMessage().isNoteOn())
+            {
+                wakeSilenceGate();          // adapter's gate
+                engine_.wakeSilenceGate();  // engine's internal gate
+                break;
+            }
+        }
+
+        // Zero-idle bypass: check adapter's gate (kept in sync via analyzeForSilenceGate).
+        if (isSilenceGateBypassed() && midi.isEmpty())
+            return;
+
+        // T6: Apply accumulated global mod-route offsets to the 5 target param
+        // atomics BEFORE the engine reads them in its renderBlock().
+        // avgVelocity = 1.0f (monophonic reverb; OxbowEngine stores currentVelocity
+        // internally but does not expose it). Velocity-scaled routes therefore
+        // express at full depth — use non-velocity-scaled routes for fixed offsets.
+        applyGlobalModRoutes(1.0f);
+
+        // Delegate all DSP, MIDI parsing, and internal gate management to engine.
+        engine_.renderBlock(buffer, midi, numSamples);
+
+        // Keep the adapter's gate in sync with the engine's rendered output.
+        analyzeForSilenceGate(buffer, numSamples);
+    }
+
+    //-- Coupling ---------------------------------------------------------------
+
+    float getSampleForCoupling(int channel, int sampleIndex) const override
+    {
+        return engine_.getSampleForCoupling(channel, sampleIndex);
+    }
+
+    void applyCouplingInput(CouplingType type, float amount, const float* sourceBuffer, int numSamples) override
+    {
+        engine_.applyCouplingInput(type, amount, sourceBuffer, numSamples);
+    }
+
+    //-- Parameters -------------------------------------------------------------
+
+    static void addParameters(std::vector<std::unique_ptr<juce::RangedAudioParameter>>& params)
+    {
+        OxbowEngine::addParameters(params);
+    }
+
+    void attachParameters(juce::AudioProcessorValueTreeState& apvts) override
+    {
+        engine_.attachParameters(apvts);
+
+        // Cache pointers for the 5 mod-target params so applyGlobalModRoutes()
+        // can add offsets to the live atomic values without string lookups.
+        pDecaySnap_    = apvts.getRawParameterValue("oxb_decay");
+        pDampingSnap_  = apvts.getRawParameterValue("oxb_damping");
+        pEntangleSnap_ = apvts.getRawParameterValue("oxb_entangle");
+        pDryWetSnap_   = apvts.getRawParameterValue("oxb_dryWet");
+        pSizeSnap_     = apvts.getRawParameterValue("oxb_size");
+    }
+
+    //-- T6: Global mod-route opt-in -------------------------------------------
+    //
+    // setProcessorPtr() — called once from XOceanusProcessor::loadEngine() on the
+    // message thread after attachParameters(). Stores the processor pointer and
+    // runs an initial cacheGlobalModRoutes() scan so cached indices are ready
+    // before the first renderBlock().
+    //
+    // cacheGlobalModRoutes() — scans the current global-mod-route snapshot for
+    // routes targeting any of Oxbow's 5 modulated parameters and stores matching
+    // route indices in globalModRouteIdx_[]. -1 = no active route for that target.
+    // Called whenever the snapshot changes (on load + on route model flush).
+
+    void setProcessorPtr(XOceanusProcessor* proc) noexcept
+    {
+        processorPtr_ = proc;
+        cacheGlobalModRoutes();
+    }
+
+    void cacheGlobalModRoutes() noexcept; // implemented in OxbowAdapter.cpp
+
+private:
+    //-- T6: Apply accumulated global mod offsets to engine param snaps ---------
+    //
+    // Called at the top of renderBlock() after macro/coupling, before DSP.
+    // Adds range_span * accum * (velScaled ? avgVel : 1.0f) to each target's
+    // live parameter value. OxbowEngine reads these atomics in its renderBlock().
+    // juce::jlimit used to clamp the result within each parameter's valid range.
+
+    void applyGlobalModRoutes(float avgVelocity) noexcept
+    {
+        if (modAccumPtr_ == nullptr)
+            return;
+
+        // Target 0: oxb_decay (0.1..60.0 s)
+        {
+            int ri = globalModRouteIdx_[0];
+            if (ri >= 0 && pDecaySnap_ != nullptr)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[0] ? raw * avgVelocity : raw;
+                float span  = globalModRangeSpan_[0]; // 59.9f
+                float cur   = pDecaySnap_->load(std::memory_order_relaxed);
+                pDecaySnap_->store(juce::jlimit(0.1f, 60.0f, cur + depth * span),
+                                   std::memory_order_relaxed);
+            }
+        }
+
+        // Target 1: oxb_damping (200..16000 Hz) — D001: velocity → brighter timbre
+        {
+            int ri = globalModRouteIdx_[1];
+            if (ri >= 0 && pDampingSnap_ != nullptr)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[1] ? raw * avgVelocity : raw;
+                float span  = globalModRangeSpan_[1]; // 15800.0f
+                float cur   = pDampingSnap_->load(std::memory_order_relaxed);
+                pDampingSnap_->store(juce::jlimit(200.0f, 16000.0f, cur + depth * span),
+                                     std::memory_order_relaxed);
+            }
+        }
+
+        // Target 2: oxb_entangle (0..1)
+        {
+            int ri = globalModRouteIdx_[2];
+            if (ri >= 0 && pEntangleSnap_ != nullptr)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[2] ? raw * avgVelocity : raw;
+                float span  = globalModRangeSpan_[2]; // 1.0f
+                float cur   = pEntangleSnap_->load(std::memory_order_relaxed);
+                pEntangleSnap_->store(juce::jlimit(0.0f, 1.0f, cur + depth * span),
+                                      std::memory_order_relaxed);
+            }
+        }
+
+        // Target 3: oxb_dryWet (0..1)
+        {
+            int ri = globalModRouteIdx_[3];
+            if (ri >= 0 && pDryWetSnap_ != nullptr)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[3] ? raw * avgVelocity : raw;
+                float span  = globalModRangeSpan_[3]; // 1.0f
+                float cur   = pDryWetSnap_->load(std::memory_order_relaxed);
+                pDryWetSnap_->store(juce::jlimit(0.0f, 1.0f, cur + depth * span),
+                                    std::memory_order_relaxed);
+            }
+        }
+
+        // Target 4: oxb_size (0..1)
+        {
+            int ri = globalModRouteIdx_[4];
+            if (ri >= 0 && pSizeSnap_ != nullptr)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[4] ? raw * avgVelocity : raw;
+                float span  = globalModRangeSpan_[4]; // 1.0f
+                float cur   = pSizeSnap_->load(std::memory_order_relaxed);
+                pSizeSnap_->store(juce::jlimit(0.0f, 1.0f, cur + depth * span),
+                                  std::memory_order_relaxed);
+            }
+        }
+    }
+
+    //-- Members ----------------------------------------------------------------
+
+    OxbowEngine engine_;
+
+    // Live parameter pointers for the 5 mod targets (set in attachParameters).
+    std::atomic<float>* pDecaySnap_    = nullptr;
+    std::atomic<float>* pDampingSnap_  = nullptr;
+    std::atomic<float>* pEntangleSnap_ = nullptr;
+    std::atomic<float>* pDryWetSnap_   = nullptr;
+    std::atomic<float>* pSizeSnap_     = nullptr;
+
+    // T6: Global mod-route opt-in state
+    // processorPtr_: set by setProcessorPtr() on the message thread; read-only
+    //   on the audio thread after that. Plain pointer — no atomic needed because
+    //   assignment happens before the first renderBlock() call.
+    XOceanusProcessor* processorPtr_ = nullptr;
+
+    // Cached route indices for the 5 target params.
+    // -1 = no active global route for that target.
+    // Written by cacheGlobalModRoutes() (message thread), read by renderBlock()
+    // (audio thread). One-block lag is safe.
+    std::array<int,   kOxbowGlobalModTargets> globalModRouteIdx_{-1, -1, -1, -1, -1};
+    std::array<bool,  kOxbowGlobalModTargets> globalModVelScaled_{};
+    std::array<float, kOxbowGlobalModTargets> globalModRangeSpan_{};
+
+    // Raw pointer to the processor's routeModAccum_ array.
+    const float* modAccumPtr_ = nullptr;
+
+    // Param IDs for the 5 modulated targets (index-matched to globalModRouteIdx_).
+    static constexpr const char* kGlobalModTargetIds[kOxbowGlobalModTargets] = {
+        "oxb_decay",
+        "oxb_damping",
+        "oxb_entangle",
+        "oxb_dryWet",
+        "oxb_size",
+    };
+};
+
+// T6: cacheGlobalModRoutes() is implemented in OxbowAdapter.cpp where
+// XOceanusProcessor.h can be included for the full type without a circular
+// dependency (OxbowAdapter.h only forward-declares XOceanusProcessor).
+
+} // namespace xoceanus

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -56,6 +56,7 @@
 #include "Engines/Overtone/OvertoneEngine.h"
 #include "Engines/Organism/OrganismEngine.h"
 #include "Engines/Oxbow/OxbowEngine.h"
+#include "Engines/Oxbow/OxbowAdapter.h"
 #include "Engines/Oware/OwareEngine.h"
 #include "Engines/Opera/OperaAdapter.h"
 #include "Engines/Offering/OfferingEngine.h"
@@ -255,7 +256,7 @@ static bool registered_Organism =
                                                         { return std::make_unique<xoceanus::OrganismEngine>(); });
 // Singularity Collection — OXBOW (entangled reverb synth engine)
 static bool registered_Oxbow = xoceanus::EngineRegistry::instance().registerEngine(
-    "Oxbow", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OxbowEngine>(); });
+    "Oxbow", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OxbowAdapter>(); });
 // OWARE — tuned percussion synthesizer (wood/metal material continuum)
 static bool registered_Oware = xoceanus::EngineRegistry::instance().registerEngine(
     "Oware", []() -> std::unique_ptr<xoceanus::SynthEngine> { return std::make_unique<xoceanus::OwareEngine>(); });
@@ -3094,6 +3095,12 @@ void XOceanusProcessor::loadEngine(int slot, const std::string& engineId)
         // so the engine's cached route indices are ready before the first renderBlock().
         if (auto* organ = dynamic_cast<OrganonEngine*>(newEngine.get()))
             organ->setProcessorPtr(this);
+        // T6: Wire OxbowAdapter into the global mod-route opt-in path (Pattern B).
+        // Identical protocol to OpalEngine above: setProcessorPtr() stores the pointer
+        // and immediately calls cacheGlobalModRoutes() so indices are ready before the
+        // first renderBlock().
+        if (auto* oxb = dynamic_cast<OxbowAdapter*>(newEngine.get()))
+            oxb->setProcessorPtr(this);
     }
 
     // Wake the silence gate so the new engine renders its first block immediately.
@@ -3303,6 +3310,8 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
             oxy->cacheGlobalModRoutes();
         if (auto* organ = dynamic_cast<OrganonEngine*>(eng.get()))
             organ->cacheGlobalModRoutes();
+        if (auto* oxb = dynamic_cast<OxbowAdapter*>(eng.get()))
+            oxb->cacheGlobalModRoutes();
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `OxbowAdapter` wrapping `OxbowEngine` with T6 Pattern B mod-matrix opt-in (identical protocol to `OxytocinAdapter` #1482 and `OpalEngine` #1458)
- Replaces `OxbowEngine` factory instantiation with `OxbowAdapter` in the engine registry
- Wires two `dynamic_cast<OxbowAdapter*>` hooks in `XOceanusProcessor`: `setProcessorPtr()` in `loadEngine()` and `cacheGlobalModRoutes()` in `flushModRoutesSnapshot()`

**Targets (5):** `oxb_decay`, `oxb_damping`, `oxb_entangle`, `oxb_dryWet`, `oxb_size`

**Threading:** `setProcessorPtr()` called once on message thread; `cacheGlobalModRoutes()` refreshed on snapshot flush. Audio thread reads cached indices read-only with one-block lag tolerance.

## Test plan

- [ ] Load Oxbow in any slot — verify no crash, preset loads correctly
- [ ] Add a global mod route targeting `oxb_decay` or `oxb_dryWet` — verify modulation applies
- [ ] Hot-swap Oxbow out and back in — verify cached indices reset and re-populated correctly
- [ ] Confirm `flushModRoutesSnapshot()` updates Oxbow's cached indices when routes change

🤖 Generated with [Claude Code](https://claude.com/claude-code)