### PR TITLE
feat: T6 Opera engine opt-in to mod matrix (Path B Phase 3.3)

### DIFF
--- a/Source/Engines/Opera/OperaAdapter.cpp
+++ b/Source/Engines/Opera/OperaAdapter.cpp
@@ -1,1 +1,64 @@
 #include "OperaAdapter.h"
+// T6: full processor type needed for getModRouteCount / getModRouteDestParamId etc.
+// OperaAdapter.h only forward-declares XOceanusProcessor; the full definition
+// is included here where it is safe — no circular include because XOceanusProcessor.h
+// includes OperaAdapter.h transitively through OperaEngine.h, but by the time
+// this .cpp TU is compiled that chain is already complete.
+#include "../../XOceanusProcessor.h"
+
+namespace xoceanus
+{
+
+// T6: cacheGlobalModRoutes — scan the current global-mod-route snapshot for routes
+// that target any of Opera's 5 modulated parameters.  Stores the route index
+// (or -1) per target so applyGlobalModRoutes() can read getModRouteAccum() in O(1)
+// without std::strcmp on the audio thread.
+//
+// Thread-safety: called on the message thread (from setProcessorPtr() and from
+// flushModRoutesSnapshot() after the release fence).  The audio thread reads the
+// cached arrays read-only.  A one-block lag is acceptable — worst case is a missed
+// mod offset for a single block when a route is added or removed.
+//
+// DSP safety: no allocation, no locks, no logging.
+void OperaAdapter::cacheGlobalModRoutes() noexcept
+{
+    // Reset all targets to "no active route"
+    for (int t = 0; t < kOperaGlobalModTargets; ++t)
+    {
+        globalModRouteIdx_[t]  = -1;
+        globalModVelScaled_[t] = false;
+        globalModRangeSpan_[t] = 0.0f;
+    }
+
+    if (processorPtr_ == nullptr)
+    {
+        modAccumPtr_ = nullptr;
+        return;
+    }
+
+    // Cache the raw accumulator pointer — used by applyGlobalModRoutes() without
+    // needing to call through the full XOceanusProcessor type in the header.
+    modAccumPtr_ = processorPtr_->getModRouteAccumPtr();
+
+    int numRoutes = processorPtr_->getModRouteCount();
+    for (int ri = 0; ri < numRoutes; ++ri)
+    {
+        const char* destId = processorPtr_->getModRouteDestParamId(ri);
+        if (destId == nullptr || destId[0] == '\0')
+            continue;
+
+        for (int t = 0; t < kOperaGlobalModTargets; ++t)
+        {
+            if (std::strcmp(destId, kGlobalModTargetIds[t]) == 0)
+            {
+                // Last matching route wins if multiple routes target the same param.
+                globalModRouteIdx_[t]  = ri;
+                globalModVelScaled_[t] = processorPtr_->isModRouteVelocityScaled(ri);
+                globalModRangeSpan_[t] = processorPtr_->getModRouteRangeSpan(ri);
+                break;
+            }
+        }
+    }
+}
+
+} // namespace xoceanus

--- a/Source/Engines/Opera/OperaAdapter.h
+++ b/Source/Engines/Opera/OperaAdapter.h
@@ -12,6 +12,14 @@
 #include "../../Core/SynthEngine.h"
 #include "OperaEngine.h"
 
+#include <array>
+#include <cstring>
+
+// Forward-declare processor so setProcessorPtr() can store the pointer without
+// pulling in the full XOceanusProcessor.h here (that would create a circular
+// include because XOceanusProcessor.h includes OperaAdapter.h transitively).
+class XOceanusProcessor;
+
 namespace xoceanus
 {
 
@@ -37,19 +45,33 @@ public:
     void renderBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi, int numSamples) override
     {
         juce::ScopedNoDenormals noDenormals;
-        for (const auto& metadata : midi)
+
+        // Compute average voice velocity once per block for velocity-scaled routes.
+        float avgVel = 0.0f;
         {
-            if (metadata.getMessage().isNoteOn())
+            int count = 0;
+            for (const auto& metadata : midi)
             {
-                wakeSilenceGate();
-                break;
+                auto msg = metadata.getMessage();
+                if (msg.isNoteOn())
+                {
+                    avgVel += static_cast<float>(msg.getVelocity()) / 127.0f;
+                    ++count;
+                    wakeSilenceGate();
+                }
             }
+            if (count > 0)
+                avgVel /= static_cast<float>(count);
         }
 
         if (isSilenceGateBypassed() && midi.isEmpty())
-        {
             return;
-        }
+
+        // T6: Apply global mod-route offsets BEFORE delegating to the inner
+        // OperaEngine.  The engine reads these via its own ModOffsets path;
+        // we inject them directly into the engine's external-mod-offsets
+        // API so they accumulate on top of LFO/MW/AT modulation.
+        applyGlobalModRoutes(avgVel);
 
         engine_.renderBlock(buffer, midi, numSamples);
         analyzeForSilenceGate(buffer, numSamples);
@@ -77,8 +99,148 @@ public:
         engine_.setMPEManager(m);
     }
 
+    //-- T6: Global mod-route opt-in (Pattern B) --------------------------------
+    //
+    // setProcessorPtr() — called once from XOceanusProcessor::loadEngine() on the
+    // message thread after attachParameters().  Stores the processor pointer so
+    // cacheGlobalModRoutes() can call the public route accessors.
+    //
+    // cacheGlobalModRoutes() — scans the current snapshot for routes that target
+    // any of Opera's 5 modulated parameters and stores the matching route indices
+    // in globalModRouteIdx_[].  -1 means no active route for that target.
+    // Called whenever the snapshot changes (on load + on route model flush).
+    //
+    // Target → index mapping (fixed):
+    //   0 = opera_drama       (Kuramoto coupling strength / timbral intensity — D001)
+    //   1 = opera_filterCutoff (filter brightness — D001: velocity→timbre)
+    //   2 = opera_breath      (breath noise level — expressiveness via mod wheel)
+    //   3 = opera_vibDepth    (vibrato depth — aftertouch expressiveness)
+    //   4 = opera_ampR        (amp release — tail length extension via aftertouch)
+
+    static constexpr int kOperaGlobalModTargets = 5;
+
+    void setProcessorPtr(XOceanusProcessor* p) noexcept
+    {
+        processorPtr_ = p;
+        cacheGlobalModRoutes();
+    }
+
+    void cacheGlobalModRoutes() noexcept; // implemented in OperaAdapter.cpp (needs full XOceanusProcessor type)
+
 private:
     opera::OperaEngine engine_;
+
+    // T6: Global mod-route opt-in state.
+    // processorPtr_: set by setProcessorPtr() on the message thread; read-only on
+    //   the audio thread after that.  Plain pointer — no atomic needed because
+    //   assignment happens before the first renderBlock() call.
+    XOceanusProcessor* processorPtr_ = nullptr;
+
+    // Cached route indices for the 5 target params (kOperaGlobalModTargets).
+    // -1 = no active global route for that target.
+    // Written by cacheGlobalModRoutes() (message thread), read by renderBlock()
+    // (audio thread).  One-block lag on route add/remove is safe.
+    std::array<int, kOperaGlobalModTargets> globalModRouteIdx_{ -1, -1, -1, -1, -1 };
+
+    // velocityScaled flag for each cached route slot.
+    std::array<bool, kOperaGlobalModTargets> globalModVelScaled_{};
+
+    // Pre-cached range span for each target param so applyGlobalModRoutes() can
+    // scale the normalised accumulator to param units without calling juce:: methods.
+    std::array<float, kOperaGlobalModTargets> globalModRangeSpan_{};
+
+    // Raw pointer to the processor's routeModAccum_ array.  Set by setProcessorPtr()
+    // alongside processorPtr_.  Stored separately so applyGlobalModRoutes() can read
+    // accumulators without needing the full XOceanusProcessor type (forward-decl safe).
+    const float* modAccumPtr_ = nullptr;
+
+    // Param IDs for the 5 modulated targets (index-matched to globalModRouteIdx_).
+    static constexpr const char* kGlobalModTargetIds[kOperaGlobalModTargets] = {
+        "opera_drama",        // 0: Kuramoto coupling / timbral intensity (D001)
+        "opera_filterCutoff", // 1: filter brightness (D001 velocity→timbre)
+        "opera_breath",       // 2: breath noise level (expressiveness)
+        "opera_vibDepth",     // 3: vibrato depth (aftertouch expressiveness)
+        "opera_ampR",         // 4: amp release (tail length)
+    };
+
+    // T6: Apply accumulated global mod-route offsets to the 5 target params via
+    // the engine's external mod-offset API.  Implemented inline here (all data
+    // comes from cached arrays — no full processor type needed).
+    // Must be called BEFORE engine_.renderBlock() each block.
+    void applyGlobalModRoutes(float avgVel) noexcept
+    {
+        if (modAccumPtr_ == nullptr)
+            return;
+
+        // Target 0: opera_drama (0..1)
+        // High drama = stronger Kuramoto coupling → richer harmonic blend.
+        {
+            int ri = globalModRouteIdx_[0];
+            if (ri >= 0)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[0] ? raw * avgVel : raw;
+                float span  = globalModRangeSpan_[0]; // 1.0f
+                engine_.setExternalModOffset_Drama(depth * span);
+            }
+        }
+
+        // Target 1: opera_filterCutoff (20..20000 Hz) — D001 compliance.
+        // Velocity route: high velocity → brighter filter.
+        {
+            int ri = globalModRouteIdx_[1];
+            if (ri >= 0)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[1] ? raw * avgVel : raw;
+                float span  = globalModRangeSpan_[1]; // 19980.0f
+                engine_.setExternalModOffset_FilterCutoff(depth * span);
+            }
+        }
+
+        // Target 2: opera_breath (0..1)
+        // Mod-wheel→breath brings in breath noise for organic, live feel.
+        {
+            int ri = globalModRouteIdx_[2];
+            if (ri >= 0)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[2] ? raw * avgVel : raw;
+                float span  = globalModRangeSpan_[2]; // 1.0f
+                engine_.setExternalModOffset_Breath(depth * span);
+            }
+        }
+
+        // Target 3: opera_vibDepth (0..1)
+        // Aftertouch→vibrato depth for expressive pitch modulation.
+        {
+            int ri = globalModRouteIdx_[3];
+            if (ri >= 0)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[3] ? raw * avgVel : raw;
+                float span  = globalModRangeSpan_[3]; // 1.0f
+                engine_.setExternalModOffset_VibDepth(depth * span);
+            }
+        }
+
+        // Target 4: opera_ampR (0..2 s normalised 0..1 in snap_)
+        // Aftertouch extends release tails for sustained, evolving chords.
+        {
+            int ri = globalModRouteIdx_[4];
+            if (ri >= 0)
+            {
+                float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                float depth = globalModVelScaled_[4] ? raw * avgVel : raw;
+                float span  = globalModRangeSpan_[4]; // 1.0f (snap_.ampR is 0..1)
+                engine_.setExternalModOffset_AmpR(depth * span);
+            }
+        }
+    }
 };
+
+// T6: cacheGlobalModRoutes() is implemented in OperaAdapter.cpp where
+// XOceanusProcessor.h can be included for the full type without a circular
+// dependency (OperaAdapter.h only forward-declares XOceanusProcessor).
 
 } // namespace xoceanus

--- a/Source/Engines/Opera/OperaAdapter.h
+++ b/Source/Engines/Opera/OperaAdapter.h
@@ -18,7 +18,8 @@
 // Forward-declare processor so setProcessorPtr() can store the pointer without
 // pulling in the full XOceanusProcessor.h here (that would create a circular
 // include because XOceanusProcessor.h includes OperaAdapter.h transitively).
-class XOceanusProcessor;
+// Must be in namespace xoceanus — XOceanusProcessor is defined in that namespace.
+namespace xoceanus { class XOceanusProcessor; }
 
 namespace xoceanus
 {

--- a/Source/Engines/Opera/OperaEngine.h
+++ b/Source/Engines/Opera/OperaEngine.h
@@ -503,6 +503,22 @@ public:
     // mpeManager_ in renderBlock() to get per-voice pitch bend / pressure / slide.
     void setMPEManager(xoceanus::MPEManager* m) noexcept { mpeManager_ = m; }
 
+    //-- T6: External mod-route offset API (Path B, Pattern B) ------------------
+    // Called by OperaAdapter::applyGlobalModRoutes() immediately before renderBlock().
+    // Offsets are merged into the per-sample mods accumulator (drama/filterCutoff/
+    // breath/vibDepth) or applied to snap_.ampR after macro expansion.
+    // No allocation; all values stored in pre-allocated members.
+    void setExternalModOffset_Drama(float off) noexcept       { externalModOffsets_.drama       = off; }
+    void setExternalModOffset_FilterCutoff(float off) noexcept{ externalModOffsets_.filterCutoff = off; }
+    void setExternalModOffset_Breath(float off) noexcept      { externalModOffsets_.breath       = off; }
+    void setExternalModOffset_VibDepth(float off) noexcept    { externalModOffsets_.vibDepth     = off; }
+    void setExternalModOffset_AmpR(float off) noexcept        { externalAmpROff_                 = off; }
+    void clearExternalModOffsets() noexcept
+    {
+        externalModOffsets_.clear();
+        externalAmpROff_ = 0.0f;
+    }
+
     //==========================================================================
     // Lifecycle
     //==========================================================================
@@ -892,6 +908,18 @@ public:
         // macroCoupling (M3) is used by the coupling output read path; no snap modification needed.
 
         // ------------------------------------------------------------------
+        // STEP 2c: T6 — Apply external mod-route offsets (Path B, Pattern B).
+        // These are set by OperaAdapter::applyGlobalModRoutes() before each
+        // renderBlock() call.  snap_.ampR offset applied here at block rate;
+        // drama/filterCutoff/breath/vibDepth are merged per-sample below.
+        // ------------------------------------------------------------------
+        if (externalAmpROff_ != 0.0f)
+            snap_.ampR = std::clamp(snap_.ampR + externalAmpROff_, 0.0f, 1.0f);
+        // Clear external offsets so they don't bleed into the next block if the
+        // adapter fails to set them (e.g., no active route).
+        externalAmpROff_ = 0.0f;
+
+        // ------------------------------------------------------------------
         // STEP 3: Configure LFOs for this block
         // ------------------------------------------------------------------
         lfo1_.setRate(snap_.lfo1Rate, sr_);
@@ -1011,7 +1039,11 @@ public:
         {
             // 6a. Accumulate modulation offsets for this sample
             ModOffsets mods;
-            mods.clear();
+            // Seed with block-constant external mod-route offsets (Path B T6).
+            // These were set by OperaAdapter::applyGlobalModRoutes() before this
+            // renderBlock() call.  drama/filterCutoff/breath/vibDepth targets flow
+            // through the normal mods path below; they are cleared at block end above.
+            mods = externalModOffsets_;
 
             float lfo1Val = lfo1_.process() * snap_.lfo1Depth;
             float lfo2Val = lfo2_.process() * snap_.lfo2Depth;
@@ -1398,6 +1430,11 @@ public:
         std::memset(couplingMorphBuffer_, 0, sizeof(float) * static_cast<size_t>(blockSize_));
         std::memset(couplingKBuffer_, 0, sizeof(float) * static_cast<size_t>(blockSize_));
         std::memset(couplingPhaseBuffer_, 0, sizeof(float) * static_cast<size_t>(blockSize_));
+
+        // T6: Clear external mod offsets after consumption so a missing
+        // setExternalMod*() call in the next block doesn't apply stale offsets.
+        externalModOffsets_.clear();
+        // externalAmpROff_ was already cleared in STEP 2c above.
 
         // ------------------------------------------------------------------
         // STEP 11: Update active voice count for thread-safe UI query
@@ -1842,6 +1879,16 @@ private:
 
     // Per-block parameter snapshot
     ParamSnapshot snap_;
+
+    // T6: External mod-route offsets (Path B, Pattern B).
+    // Set by OperaAdapter::applyGlobalModRoutes() BEFORE each renderBlock() call
+    // and consumed inside renderBlock() (merged into per-sample mods accumulator
+    // for drama/filterCutoff/breath/vibDepth, or applied to snap_.ampR directly).
+    // Written on the audio thread in OperaAdapter::renderBlock() before the inner
+    // engine call; read + cleared within the same renderBlock() invocation so there
+    // is no cross-block data race.
+    ModOffsets externalModOffsets_;
+    float      externalAmpROff_ = 0.0f; // additive offset for snap_.ampR (0..1 normalised)
 
     // FIX OP-01 (P14): delta-guard state for setADSR — avoid std::exp calls when params are stable
     float lastAmpAtkSec_ = -1.0f;

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -3109,6 +3109,13 @@ void XOceanusProcessor::loadEngine(int slot, const std::string& engineId)
         // Identical protocol to Opal / Oxytocin above.
         if (auto* ostracon = dynamic_cast<OstraconEngine*>(newEngine.get()))
             ostracon->setProcessorPtr(this);
+        // T6: Wire OperaAdapter into the global mod-route opt-in path (Path B Phase 3.3).
+        // Identical protocol to OxytocinAdapter (#1482): setProcessorPtr() stores the
+        // pointer and immediately calls cacheGlobalModRoutes() so indices are ready
+        // before the first renderBlock().  Adapter pattern is used here because Opera
+        // already wraps a Conductor + KuramotoField + BreathEngine sub-architecture.
+        if (auto* opera = dynamic_cast<OperaAdapter*>(newEngine.get()))
+            opera->setProcessorPtr(this);
     }
 
     // Wake the silence gate so the new engine renders its first block immediately.
@@ -3324,6 +3331,8 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
             offering->cacheGlobalModRoutes();
         if (auto* ostracon = dynamic_cast<OstraconEngine*>(eng.get()))
             ostracon->cacheGlobalModRoutes();
+        if (auto* opera = dynamic_cast<OperaAdapter*>(eng.get()))
+            opera->cacheGlobalModRoutes();
     }
 }
 


### PR DESCRIPTION
## Summary

- Wire `OperaAdapter` into the global mod-route opt-in path (Pattern B, Path B Phase 3.3), identical protocol to `OxytocinAdapter` (#1482) and `OxbowAdapter` (#1489)
- Adapter pattern is used because `OperaAdapter` already existed (registered at `XOceanusProcessor.cpp:264`) for Opera's Conductor + KuramotoField + BreathEngine sub-architecture — added mod-matrix methods to the existing adapter rather than creating a new one
- 4 files changed: `OperaAdapter.h`, `OperaAdapter.cpp`, `OperaEngine.h`, `XOceanusProcessor.cpp`

## Targets (5)

| Index | Param ID | Range | Rationale |
|-------|----------|-------|-----------|
| 0 | `opera_drama` | 0..1 | Kuramoto coupling strength / timbral intensity (D001) |
| 1 | `opera_filterCutoff` | 20..20000 Hz | Filter brightness — D001 velocity→timbre compliance |
| 2 | `opera_breath` | 0..1 | Breath noise level — mod-wheel expressiveness |
| 3 | `opera_vibDepth` | 0..1 | Vibrato depth — aftertouch expressiveness |
| 4 | `opera_ampR` | 0..1 (normalised) | Amp release tail length |

## Implementation details

`OperaEngine` gains `externalModOffsets_` (a `ModOffsets` struct) and `externalAmpROff_` with typed setters. drama/filterCutoff/breath/vibDepth offsets seed the per-sample `mods` accumulator at the top of the sample loop; `ampR` applies to `snap_.ampR` at block rate post-macro-expansion (step 2c). Both are cleared at end of `renderBlock` to prevent stale values bleeding into subsequent blocks.

`OperaAdapter::renderBlock()` computes `avgVel` from note-on messages, calls `applyGlobalModRoutes(avgVel)` before delegating to `engine_.renderBlock()`.

## Processor hooks

Two hooks mirror the OxytocinAdapter precedent:
1. `loadEngine()` — `dynamic_cast<OperaAdapter*>` → `setProcessorPtr(this)`
2. `flushModRoutesSnapshot()` — `dynamic_cast<OperaAdapter*>` → `cacheGlobalModRoutes()`

## Test plan

- [ ] Load Opera engine in a slot; add a mod route targeting `opera_drama` — confirm coupling strength responds
- [ ] Add velocity-scaled route to `opera_filterCutoff` — confirm brighter filter at higher velocities
- [ ] Add aftertouch route to `opera_vibDepth` — confirm vibrato increases with channel pressure
- [ ] Verify no audio artifacts when no routes are active (modAccumPtr_ == nullptr guard)
- [ ] Rapid engine hot-swap while routes active — verify no crash (one-block lag safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)