### PR TITLE
feat: T6 Offering engine opt-in to mod matrix (Path B Phase 4.1)

### DIFF
--- a/Source/Engines/Offering/OfferingEngine.cpp
+++ b/Source/Engines/Offering/OfferingEngine.cpp
@@ -1,2 +1,62 @@
 // OfferingEngine.cpp — XOffering | All DSP inline in OfferingEngine.h
 #include "OfferingEngine.h"
+// T6: full processor type needed for getModRouteCount / getModRouteDestParamId etc.
+// XOceanusProcessor.h includes OfferingEngine.h, so this include is safe — the header
+// guard prevents double-inclusion; by the time we get here OfferingEngine.h is done.
+#include "../../XOceanusProcessor.h"
+
+namespace xoceanus
+{
+
+// T6: cacheGlobalModRoutes — scan the current global-mod-route snapshot for routes
+// that target any of Offering's 5 modulated parameters.  Stores the route index (or -1)
+// per target so renderBlock() can read accumulators in O(1) without strcmp.
+//
+// Thread-safety: called on the message thread (from setProcessorPtr() and from any
+// future flushModRoutesSnapshot() callback).  The audio thread reads the cached arrays
+// read-only.  A one-block lag is acceptable — worst case is a missed mod-offset for
+// a single block when a route is added or removed.
+//
+// DSP safety: no allocation, no locks, no logging.
+void OfferingEngine::cacheGlobalModRoutes() noexcept
+{
+    // Reset all targets to "no active route"
+    for (int t = 0; t < kOfferingGlobalModTargets; ++t)
+    {
+        globalModRouteIdx_[t]  = -1;
+        globalModVelScaled_[t] = false;
+        globalModRangeSpan_[t] = 0.0f;
+    }
+
+    if (processorPtr_ == nullptr)
+    {
+        modAccumPtr_ = nullptr;
+        return;
+    }
+
+    // Cache the raw accumulator pointer — used by renderBlock() without
+    // needing to call through the full XOceanusProcessor type in the header.
+    modAccumPtr_ = processorPtr_->getModRouteAccumPtr();
+
+    int numRoutes = processorPtr_->getModRouteCount();
+    for (int ri = 0; ri < numRoutes; ++ri)
+    {
+        const char* destId = processorPtr_->getModRouteDestParamId(ri);
+        if (destId == nullptr || destId[0] == '\0')
+            continue;
+
+        for (int t = 0; t < kOfferingGlobalModTargets; ++t)
+        {
+            if (std::strcmp(destId, kGlobalModTargetIds[t]) == 0)
+            {
+                // Last matching route wins if multiple routes target the same param.
+                globalModRouteIdx_[t]  = ri;
+                globalModVelScaled_[t] = processorPtr_->isModRouteVelocityScaled(ri);
+                globalModRangeSpan_[t] = processorPtr_->getModRouteRangeSpan(ri);
+                break;
+            }
+        }
+    }
+}
+
+} // namespace xoceanus

--- a/Source/Engines/Offering/OfferingEngine.h
+++ b/Source/Engines/Offering/OfferingEngine.h
@@ -38,6 +38,10 @@
 //
 //==============================================================================
 
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <algorithm>
 #include "../../Core/SynthEngine.h"
 #include "../../Core/PolyAftertouch.h"
 #include "../../DSP/FastMath.h"
@@ -49,13 +53,15 @@
 #include "OfferingCollage.h"
 #include "OfferingCity.h"
 #include "OfferingCuriosity.h"
-#include <array>
-#include <cmath>
-#include <cstring>
-#include <algorithm>
+
+// T6: Forward declaration — full type included in OfferingEngine.cpp to avoid circular dependency.
+class XOceanusProcessor;
 
 namespace xoceanus
 {
+
+// T6: Number of global mod-route targets for OfferingEngine (Path B).
+static constexpr int kOfferingGlobalModTargets = 5;
 
 //==============================================================================
 // Voice slot MIDI note mapping — GM drum map standard positions.
@@ -349,6 +355,77 @@ public:
         // D006: mod wheel → curiosity drive
         snap.digCuriosity = std::clamp(snap.digCuriosity + modWheelValue_ * snap.modWheel * 0.3f, 0.0f, 1.0f);
 
+        // ── 4b. T6: Apply global mod-route offsets ────────────────────
+        // Compute avgVelocity once per block (one-block-lag approximation, identical
+        // to Opal/Oxytocin precedent).  No active voices → unity so depth is fully
+        // expressed with no held notes (consistent with rest of fleet).
+        if (modAccumPtr_ != nullptr)
+        {
+            float avgVel = 0.0f;
+            int activeCount = 0;
+            for (int v = 0; v < 8; ++v)
+            {
+                if (voices_[v].active)
+                {
+                    avgVel += voices_[v].lastSample != 0.0f ? 1.0f : 0.0f; // proxy: active voice
+                    ++activeCount;
+                }
+            }
+            avgVel = (activeCount > 0) ? 1.0f : 1.0f; // drum engine: no per-voice velocity on audio thread; use unity
+
+            // Target 0: ofr_transientSnap (0..1, span=1.0) — attack hardness
+            {
+                int ri = globalModRouteIdx_[0];
+                if (ri >= 0)
+                {
+                    float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                    float depth = globalModVelScaled_[0] ? raw * avgVel : raw;
+                    snap.transientSnap = juce::jlimit(0.0f, 1.0f, snap.transientSnap + depth * globalModRangeSpan_[0]);
+                }
+            }
+            // Target 1: ofr_cityIntensity (0..1, span=1.0) — city processing depth
+            {
+                int ri = globalModRouteIdx_[1];
+                if (ri >= 0)
+                {
+                    float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                    float depth = globalModVelScaled_[1] ? raw * avgVel : raw;
+                    snap.cityIntensity = juce::jlimit(0.0f, 1.0f, snap.cityIntensity + depth * globalModRangeSpan_[1]);
+                }
+            }
+            // Target 2: ofr_digCuriosity (0..1, span=1.0) — curiosity engine drive
+            {
+                int ri = globalModRouteIdx_[2];
+                if (ri >= 0)
+                {
+                    float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                    float depth = globalModVelScaled_[2] ? raw * avgVel : raw;
+                    snap.digCuriosity = juce::jlimit(0.0f, 1.0f, snap.digCuriosity + depth * globalModRangeSpan_[2]);
+                }
+            }
+            // Target 3: ofr_dustVinyl (0..1, span=1.0) — vinyl texture amount
+            {
+                int ri = globalModRouteIdx_[3];
+                if (ri >= 0)
+                {
+                    float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                    float depth = globalModVelScaled_[3] ? raw * avgVel : raw;
+                    snap.dustVinyl = juce::jlimit(0.0f, 1.0f, snap.dustVinyl + depth * globalModRangeSpan_[3]);
+                }
+            }
+            // Target 4: ofr_flipStretch (0.5..2.0, span=1.5) — time-stretch factor
+            {
+                int ri = globalModRouteIdx_[4];
+                if (ri >= 0)
+                {
+                    float raw   = modAccumPtr_[static_cast<size_t>(ri)];
+                    float depth = globalModVelScaled_[4] ? raw * avgVel : raw;
+                    snap.flipStretch = juce::jlimit(0.5f, 2.0f, snap.flipStretch + depth * globalModRangeSpan_[4]);
+                }
+            }
+        }
+        // ── end T6 global mod routes ─────────────────────────────────
+
         // D006: aftertouch → texture intensity
         float atMod = aftertouchValue_ * snap.aftertouch;
 
@@ -600,6 +677,31 @@ public:
             break;
         }
     }
+
+    //-- T6: Global mod-route opt-in ---------------------------------------------
+    //
+    // setProcessorPtr() — called once from XOceanusProcessor::loadEngine() on the
+    // message thread after attachParameters().  Stores the processor pointer so
+    // cacheGlobalModRoutes() can call the public route accessors.
+    //
+    // cacheGlobalModRoutes() — scans the current snapshot for routes that target
+    // any of Offering's 5 modulated parameters.  -1 means no active route.
+    // Called on load and on every flushModRoutesSnapshot().
+    //
+    // Target → index mapping (fixed):
+    //   0 = ofr_transientSnap    (transient attack hardness — D001 timbre)
+    //   1 = ofr_cityIntensity    (city processing depth — character shaper)
+    //   2 = ofr_digCuriosity     (curiosity engine drive — groove feel)
+    //   3 = ofr_dustVinyl        (vinyl texture amount — lo-fi character)
+    //   4 = ofr_flipStretch      (time-stretch factor — rhythmic texture)
+
+    void setProcessorPtr(XOceanusProcessor* p) noexcept
+    {
+        processorPtr_ = p;
+        cacheGlobalModRoutes();
+    }
+
+    void cacheGlobalModRoutes() noexcept;  // implemented in OfferingEngine.cpp
 
     //-- Parameters ---------------------------------------------------------------
 
@@ -1040,6 +1142,35 @@ private:
     std::atomic<float>* paramMacroCity_ = nullptr;
     std::atomic<float>* paramMacroFlip_ = nullptr;
     std::atomic<float>* paramMacroDust_ = nullptr;
+
+    // T6: Global mod-route opt-in state
+    // processorPtr_: set by setProcessorPtr() on the message thread; read-only
+    //   on the audio thread after that.
+    XOceanusProcessor* processorPtr_ = nullptr;
+
+    // Cached route indices for the 5 target params (kOfferingGlobalModTargets).
+    // -1 = no active global route for that target.
+    // Written by cacheGlobalModRoutes() (message thread), read by renderBlock()
+    // (audio thread).  One-block lag tolerance identical to Opal/Oxytocin precedent.
+    std::array<int,   kOfferingGlobalModTargets> globalModRouteIdx_{-1,-1,-1,-1,-1};
+    std::array<bool,  kOfferingGlobalModTargets> globalModVelScaled_{};
+    std::array<float, kOfferingGlobalModTargets> globalModRangeSpan_{};
+
+    // Raw pointer to the processor's routeModAccum_ array — set by cacheGlobalModRoutes().
+    const float* modAccumPtr_ = nullptr;
+
+    // Param IDs for the 5 modulated targets (index-matched to globalModRouteIdx_).
+    static constexpr const char* kGlobalModTargetIds[kOfferingGlobalModTargets] = {
+        "ofr_transientSnap",  // 0: attack hardness (0..1, span=1.0)
+        "ofr_cityIntensity",  // 1: city depth      (0..1, span=1.0)
+        "ofr_digCuriosity",   // 2: curiosity drive  (0..1, span=1.0)
+        "ofr_dustVinyl",      // 3: vinyl texture    (0..1, span=1.0)
+        "ofr_flipStretch",    // 4: time-stretch     (0.5..2.0, span=1.5)
+    };
 };
+
+// T6: cacheGlobalModRoutes() is implemented in OfferingEngine.cpp where
+// XOceanusProcessor.h can be included for the full type without a circular
+// dependency (OfferingEngine.h only forward-declares XOceanusProcessor).
 
 } // namespace xoceanus

--- a/Source/Engines/Offering/OfferingEngine.h
+++ b/Source/Engines/Offering/OfferingEngine.h
@@ -55,7 +55,8 @@
 #include "OfferingCuriosity.h"
 
 // T6: Forward declaration — full type included in OfferingEngine.cpp to avoid circular dependency.
-class XOceanusProcessor;
+// Must be in namespace xoceanus — XOceanusProcessor is defined in that namespace.
+namespace xoceanus { class XOceanusProcessor; }
 
 namespace xoceanus
 {

--- a/Source/XOceanusProcessor.cpp
+++ b/Source/XOceanusProcessor.cpp
@@ -3101,6 +3101,10 @@ void XOceanusProcessor::loadEngine(int slot, const std::string& engineId)
         // first renderBlock().
         if (auto* oxb = dynamic_cast<OxbowAdapter*>(newEngine.get()))
             oxb->setProcessorPtr(this);
+
+        // T6: Wire OfferingEngine into the global mod-route opt-in path (Path B Phase 4.1).
+        if (auto* offering = dynamic_cast<OfferingEngine*>(newEngine.get()))
+            offering->setProcessorPtr(this);
     }
 
     // Wake the silence gate so the new engine renders its first block immediately.
@@ -3312,6 +3316,8 @@ void XOceanusProcessor::flushModRoutesSnapshot() noexcept
             organ->cacheGlobalModRoutes();
         if (auto* oxb = dynamic_cast<OxbowAdapter*>(eng.get()))
             oxb->cacheGlobalModRoutes();
+        if (auto* offering = dynamic_cast<OfferingEngine*>(eng.get()))
+            offering->cacheGlobalModRoutes();
     }
 }
 


### PR DESCRIPTION
## Summary

- Wires `OfferingEngine` into the global mod-route opt-in path (Pattern B, Direct-Edit).
- Identical protocol to Opal (#1458), Oxytocin (#1482), Organon (#1487): `setProcessorPtr()` + `cacheGlobalModRoutes()` + cached index reads in `renderBlock()`.
- 5 targets chosen for maximum performance expression on a boom-bap drum engine.

## Targets

| Idx | Param ID | Description | Range | Span |
|-----|----------|-------------|-------|------|
| 0 | `ofr_transientSnap` | Transient attack hardness (D001 timbre) | 0..1 | 1.0 |
| 1 | `ofr_cityIntensity` | City processing depth (character) | 0..1 | 1.0 |
| 2 | `ofr_digCuriosity` | Curiosity engine drive (groove feel) | 0..1 | 1.0 |
| 3 | `ofr_dustVinyl` | Vinyl texture amount (lo-fi) | 0..1 | 1.0 |
| 4 | `ofr_flipStretch` | Time-stretch factor (rhythmic texture) | 0.5..2.0 | 1.5 |

## Threading

- `setProcessorPtr()` called once on message thread from `loadEngine()`.
- `cacheGlobalModRoutes()` refreshed from `flushModRoutesSnapshot()`.
- Audio thread reads `globalModRouteIdx_[]` / `modAccumPtr_[]` read-only with one-block lag tolerance.

## Scope

Strictly Path B mod-matrix scope. The known OOB-at-96kHz DSP CRIT is untouched.

## Files changed (3)

- `Source/Engines/Offering/OfferingEngine.h` — forward decl, constexpr, public methods, private members, renderBlock application
- `Source/Engines/Offering/OfferingEngine.cpp` — `cacheGlobalModRoutes()` implementation (includes full processor type)
- `Source/XOceanusProcessor.cpp` — `loadEngine()` hook + `flushModRoutesSnapshot()` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)