### PR TITLE
fix(ci): release.yml tag-deletion race in downstream jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,10 @@ jobs:
       - name: Checkout tagged commit
         uses: actions/checkout@v6
         with:
+          # Pin to the immutable commit SHA rather than the tag name so this
+          # job does not fail if the tag is deleted or moved between the time
+          # the build job ran and this job starts (tag-deletion race).
+          ref: ${{ github.sha }}
           fetch-depth: 1
 
       # ── Retrieve unsigned artefacts ──────────────────────────────────────
@@ -467,6 +471,10 @@ jobs:
       - name: Checkout tagged commit
         uses: actions/checkout@v6
         with:
+          # Pin to the immutable commit SHA rather than the tag name so this
+          # job does not fail if the tag is deleted or moved between the time
+          # the build job ran and this job starts (tag-deletion race).
+          ref: ${{ github.sha }}
           fetch-depth: 1
 
       # ── Download notarized artefacts ─────────────────────────────────────
@@ -633,6 +641,10 @@ jobs:
       - name: Checkout tagged commit
         uses: actions/checkout@v6
         with:
+          # Pin to the immutable commit SHA rather than the tag name so this
+          # job does not fail if the tag is deleted or moved between the time
+          # the build job ran and this job starts (tag-deletion race).
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       # ── Download DMG ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Each post-build job (`sign`, `package`, `release`) called `actions/checkout@v6` without a `ref:`, causing Actions to re-resolve the triggering tag at checkout time.
- If the tag is deleted or moved on origin between the `build` job finishing and any downstream job starting, the checkout fails with `fatal: couldn't find remote ref refs/tags/<tag>`.
- Fix: add `ref: ${{ github.sha }}` to all three downstream checkouts. The commit SHA is immutable for the life of the workflow run regardless of tag state.
- The `build` job checkout is unchanged — it runs first while the tag is still live, and its `fetch-depth: 0` is required for `git-describe`/release note generation.

This is **part 1 of 3** for release.yml repair. Parts 2 (signing secrets: MACOS_CERTIFICATE, APPLE_*) and 3 (VST3 target coverage) are separate tasks requiring user action / separate PRs.

## Test plan

- [ ] Confirm PR CI checks pass (workflow YAML lint).
- [ ] Merge alongside rest of merge train.
- [ ] Full end-to-end test: push a `v*` tag and verify all 5 jobs complete without `couldn't find remote ref` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)