### PR TITLE
fix(P34): hardcoded sample-rate fallback sweep — 3 engines

### DIFF
--- a/Source/Engines/Ostinato/OstinatoEngine.h
+++ b/Source/Engines/Ostinato/OstinatoEngine.h
@@ -663,8 +663,9 @@ private:
 class OstiWaveguideBody
 {
 public:
-    // 4096 samples: supports body delay up to ~93ms at 44.1kHz
-    static constexpr int kMaxDelay = 4096;
+    // 8192 samples: supports body delay up to ~85ms at 96kHz (was 4096 → ~43ms, half the 44.1kHz window).
+    // Power-of-2 preserved so the & (kMaxDelay - 1) bitmask at writePos wrap remains valid.
+    static constexpr int kMaxDelay = 8192;
 
     void prepare(double sampleRate) noexcept
     {

--- a/Source/Engines/Outcrop/OutcropEngine.h
+++ b/Source/Engines/Outcrop/OutcropEngine.h
@@ -285,7 +285,7 @@ private:
     //==========================================================================
     //  S T A T E
     //==========================================================================
-    float sampleRateF = 44100.0f;
+    float sampleRateF = 0.0f; // 0 = not yet prepared; sentinel for render guard
     int   blockCap    = 512;
 
     std::array<OutcropVoice, kOutcropMaxVoices> voices;
@@ -547,7 +547,12 @@ inline void OutcropEngine::releaseVoicesForNote(int noteNum)
 // -----------------------------------------------------------------------------
 inline void OutcropEngine::prepare(double sampleRate, int maxBlockSize)
 {
-    sampleRateF = (sampleRate > 0.0) ? (float) sampleRate : 44100.0f;
+    if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+    {
+        jassertfalse; // host passed invalid sample rate — skip prepare
+        return;
+    }
+    sampleRateF = static_cast<float>(sampleRate);
     blockCap    = std::max(1, maxBlockSize);
 
     for (auto& v : voices)

--- a/Source/Engines/Owlfish/ArmorBuffer.h
+++ b/Source/Engines/Owlfish/ArmorBuffer.h
@@ -13,7 +13,7 @@ namespace xowlfish
 //
 // The barreleye owlfish sacrifices its transparent cranial shield on impact,
 // releasing a burst of captured sonic material. On velocity trigger:
-//   1. Last 2048 samples of input history are frozen into a capture buffer
+//   1. Last 4096 samples of input history are frozen into a capture buffer
 //   2. 8 grains spawn at random positions with pitch scatter
 //   3. Grains feed through a feedback delay line
 //   4. The main signal is ducked to make room for the armor burst
@@ -189,7 +189,10 @@ public:
     bool isActive() const { return armed; }
 
 private:
-    static constexpr int kHistorySize = 2048;
+    // 4096 samples: covers ~42.7ms at 96kHz (was 2048 → ~21ms at 96kHz, halving
+    // the capture window). At 44.1kHz, 4096 samples = ~92.9ms. Power-of-2 preserved
+    // so all & (kHistorySize - 1) bitmasks remain valid.
+    static constexpr int kHistorySize = 4096;
     static constexpr int kMaxDelay = 22050;
     static constexpr int kNumGrains = 8;
 


### PR DESCRIPTION
## Summary

P34 sweep for the V1 ship campaign. Fixes 3 engines with true hardcoded sample-rate fallback patterns; clears 9 engines as false positives (SR scaling ratios, not fallbacks).

Note: originally targeted `release/integrated-v1` per session prompt, but PR #1511 (V1 baseline) has since merged to `main`, so targeting `main` directly.

## Engines fixed

| Engine | File | Change | Severity |
|--------|------|--------|----------|
| **Outcrop** | `OutcropEngine.h:288,550` | `sampleRateF = 44100.0f` member init → `0.0f` sentinel; ternary fallback `(sr>0)?sr:44100.0f` → validate-or-bail with `jassertfalse` | P34 true hit |
| **Ostinato** | `OstinatoEngine.h:667` | `OstiWaveguideBody::kMaxDelay 4096 → 8192`; at 96kHz old value clamped 200ms body delay (CONGA/DUNDUN) to 43ms — wrong instrument character. Power-of-2 preserved; `& (kMaxDelay-1)` bitmask valid. | CRIT buffer |
| **Owlfish/ArmorBuffer** | `ArmorBuffer.h:192` | `kHistorySize 2048 → 4096`; at 96kHz old value gave only 21ms capture window (half of 44.1kHz). Power-of-2 preserved; all `& (kHistorySize-1)` bitmasks valid. | HIGH buffer |

## False positives cleared (9 engines)

All use `sr / 44100.0f` as a *scaling ratio*, not as a fallback for `sr=0`:
Offering, Opal, Orbweave, OpenSky, Osprey, Outlook, Overbite, Overworn, Overtide.

Overtide already uses the fleet sentinel pattern (`sampleRateFloat = 0.0f` init + explicit `<= 0.0f` guard).

## Test plan

- [ ] Build AU target: `cmake --build build --target XOceanus_AU --config Release`
- [ ] At 96kHz, trigger Ostinato CONGA with sustain — verify body resonance tail matches 44.1kHz character (no longer 4.7× shorter)
- [ ] At 96kHz, trigger Owlfish armor burst with 50+ ms audio input — verify capture shows >40ms of pre-trigger material
- [ ] At 96kHz, trigger Outcrop note — verify engine does not silently fall back to 44.1kHz coefficient computation
- [ ] Sentinel: `strings <binary> | grep "44100" | wc -l` should drop by 3 vs previous build

## Reference

- Fleet report: `~/.claude/skills/fathom-workspace/iteration-2/fathom-fleet-report-2026-04-26.md`
- Sweep plan: `~/.claude/skills/fathom-workspace/iteration-2/sweep-p34-96khz-buffer-sizing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)