### PR TITLE
fix(P37): invSR NaN guard sweep — 5 engines

### DIFF
--- a/Docs/plans/2026-05-04-save-as-design.md
+++ b/Docs/plans/2026-05-04-save-as-design.md
@@ -1,0 +1,204 @@
+# Save As / Save Dialog — Design Spec
+
+**Date:** 2026-05-04
+**Tracking:** GitHub issue #1405 (`TODO(#1354)` placeholder in `XOceanusEditor.h:1130`)
+**Campaign:** V1 Ship Campaign Week 1 Lane B — Day 2 brainstorm #1
+**Status:** APPROVED — ready for implementation plan (writing-plans skill)
+
+## Problem
+
+The current Save flow (`Cmd+S` → `juce::AlertWindow` text input) silently overwrites existing presets and has no path to capture mood, category, or tags. Issue #1405: "Save preset has no overwrite protection or mood selector." Result: user-saved presets land uncategorized and invisible in `DnaMapBrowser`'s mood-pill filters.
+
+## Solution at a glance
+
+Split Save into two paths matching macOS conventions:
+- **`Cmd+S`** = quick save (silent overwrite of loaded preset; rich dialog only on first save of a fresh-state preset)
+- **`Cmd+Shift+S`** = explicit Save As (always opens rich dialog with name + mood + category + tags + description)
+
+## Locked decisions (5 questions resolved 2026-05-04)
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Architecture: **Split Save / Save As** (macOS standard) | Preserves quick-save power-user loop; matches user muscle memory |
+| 2 | `Cmd+S` matrix: rich dialog on fresh state, silent overwrite on modified loaded preset, no-op on unmodified | Captures rich fields at least once per preset; preserves fast iteration loop |
+| 3 | Required fields: **Name + Mood**; optional: Category, Tags, Description; auto/hidden: Timbre, Author, Version, Tier | Mood is the primary `DnaMapBrowser` filter; making it required directly fixes the "uncategorized presets" problem |
+| 4 | Name collision: **auto-number `(2)` at dialog open + confirm-overwrite if user manually creates collision** | Handles 99% case (sane default) without removing the explicit-overwrite path |
+| 5 | Form factor: **modal dialog** styled with existing submarine tokens; mood selector = compact dropdown with color swatches | Modal matches transactional intent; reuses locked Tokens.h palette (no new tokens introduced) |
+
+## Architecture
+
+**One new file, two modified:**
+- **NEW** `Source/UI/Ocean/SavePresetDialog.h` — modal dialog component, `juce::DialogWindow` wrapper
+- **MOD** `Source/UI/XOceanusEditor.h` — `Cmd+S` / `Cmd+Shift+S` handlers + state matrix in `keyPressed()`; the existing `onSavePreset` lambda at lines 1132–1186 is replaced
+- **MOD** `Source/Core/PresetManager.h` — add collision-check overload on `savePresetToFile()` (uses `juce::File::existsAsFile()` plus a confirm callback)
+
+## Components
+
+### SavePresetDialog
+- Inherits `juce::Component`; hosted inside a `juce::DialogWindow`
+- Constructor: `(PresetData initial, bool isFirstSave, std::function<void(PresetData)> onSave, std::function<void()> onCancel)`
+- Internal fields:
+  - `NameField` (`juce::TextEditor`) — single-line, `Save` button disabled while empty
+  - `MoodDropdown` (`juce::ComboBox`) with custom `MoodDropdownLookAndFeel` for color-swatch rendering — 16 alphabetical entries from `xoceanus::GalleryColors::Ocean::*`
+  - `CategoryDropdown` (`juce::ComboBox`) — 10 categories from `PresetTaxonomy.h`, optional ("— None —" first item)
+  - `TagsField` (`juce::TextEditor`) — comma-separated, free-form
+  - `DescriptionField` (`juce::TextEditor`) — multi-line, ~3 rows, optional
+  - `SaveButton` (`juce::TextButton`)
+  - `CancelButton` (`juce::TextButton`)
+- Layout: vertical stack, ~480×360px content area
+- Visual: depth-tone background from `Tokens.h` D1; type from D3 2-font stack; 200ms fade-in (D4); cursor changes per D5
+
+### MoodDropdownLookAndFeel
+- Custom `juce::LookAndFeel_V4` subclass overriding `drawComboBoxItem()`
+- Renders a 12×12px filled circle (mood color from `GalleryColors.h:576–621`) followed by mood name in standard type
+- Reused in any future place that needs mood selection (forward-compatible with #1428 ChainMatrix and #24 modulation viz mood filtering)
+
+### XOceanusEditor changes
+- Replace existing `Cmd+S` handler at line 1952
+- Add `Cmd+Shift+S` handler
+- New helper `getCurrentSaveState()` returning enum `{ NoPresetLoaded, LoadedModified, LoadedUnmodified }` based on `currentPresetData_` and `isDirty_` flags
+- Decision tree implementation:
+  ```
+  if (modifiers.isCommandDown() && !modifiers.isShiftDown() && key == 'S') {
+      switch (getCurrentSaveState()) {
+          case NoPresetLoaded:    openSavePresetDialog(/*isFirstSave=*/true); break;
+          case LoadedModified:    silentOverwriteCurrentPreset(); break;
+          case LoadedUnmodified:  /* no-op */ break;
+      }
+  }
+  if (modifiers.isCommandDown() && modifiers.isShiftDown() && key == 'S') {
+      openSavePresetDialog(/*isFirstSave=*/false);
+  }
+  ```
+
+### PresetManager additions
+- New overload `savePresetToFile(juce::File targetFile, const PresetData& data, std::function<bool(juce::File)> confirmOverwrite)` — calls `confirmOverwrite(targetFile)` if file exists; if it returns false, abort the save
+- Existing `savePresetToFile(file, data)` retained for the silent-overwrite path (no behavior change)
+- New helper `getNextAvailableName(const juce::String& base)` — appends `(2)`, `(3)`, etc. until a non-colliding name is found
+
+## Data flow
+
+### Cmd+S pressed
+```
+keyPressed()
+  → getCurrentSaveState()
+    → NoPresetLoaded:    openSavePresetDialog(initial=blank, isFirstSave=true)
+    → LoadedModified:    PresetManager::savePresetToFile(currentFile, currentData) [silent]
+                         → toast "Saved {name}"
+    → LoadedUnmodified:  return
+```
+
+### Cmd+Shift+S pressed
+```
+keyPressed()
+  → if NoPresetLoaded:
+      openSavePresetDialog(initial=blank, isFirstSave=true)
+      // Fresh state: Cmd+Shift+S behaves identically to Cmd+S
+  → else (LoadedModified or LoadedUnmodified):
+      openSavePresetDialog(
+        initial = currentPresetData with name = getNextAvailableName(currentName),
+        isFirstSave = false
+      )
+```
+
+In fresh state (no preset loaded), `Cmd+Shift+S` and `Cmd+S` are functionally identical — both open the rich dialog with blank defaults. The split only matters once a preset is loaded: `Cmd+S` silent-overwrites, `Cmd+Shift+S` opens the rich dialog for forking.
+
+### SavePresetDialog Save button
+```
+onSaveClicked()
+  → validateName() — sanitize via juce::File::createLegalFileName(); reject if empty
+  → buildTargetFile(sanitizedName)
+  → PresetManager::savePresetToFile(target, data, confirmOverwrite=showOverwriteDialog)
+    → if collision: showOverwriteDialog() — "A preset named X exists. [Overwrite] [Cancel]"
+      → user picks Overwrite → return true → save proceeds
+      → user picks Cancel → return false → save aborts (dialog stays open)
+    → on disk write success: close dialog, fire toast "Saved {name}"
+    → on disk write failure: keep dialog open, error toast, preserve user input
+```
+
+## Defaults
+
+| Field | Fresh-state default | Save As fork default |
+|---|---|---|
+| Name | empty | `getNextAvailableName(currentName)` (e.g. `"My Preset (2)"`) |
+| Mood | none (user must pick) | source preset's mood |
+| Category | none ("— None —") | source's category |
+| Tags | empty | source's tags |
+| Description | empty | source's description |
+| Author | from settings (`PresetManager::getAuthorFromSettings()` — auto, hidden) | inherit |
+| Version | auto: current XOceanus version (hidden) | auto: current XOceanus version |
+| Tier | auto: `"awakening"` for user-created (hidden) | inherit |
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| Empty name | `Save` button disabled; inline "Required" message under field |
+| Illegal characters in name | Silently stripped via `juce::File::createLegalFileName()` (no error UI) |
+| Disk write failure | Keep dialog open; toast `"Save failed: {error}"`; user input preserved |
+| Permission error (read-only filesystem) | Same as disk write failure |
+| Collision detected | Confirm-overwrite dialog (Q4 D logic) |
+
+## Visual specification
+
+- Modal background: `Tokens::Submarine::PanelBg` (D1)
+- Border: depth-ring style per D5
+- Type: D3 2-font stack (heading + body)
+- Animation: 200ms fade-in, 0.18 ease-out (D4)
+- Mood swatches: 12×12px circle, `GalleryColors::Ocean` mood mapping
+- Dialog dimensions: ~480×360px content; resizable false
+- **No new tokens.** Implementing sonnet must reuse what's locked in `Source/UI/Tokens.h`.
+
+## Testing
+
+### Unit
+- `SavePresetDialog::validateName()` — empty / illegal-chars / sanitized-result cases
+- `PresetManager::getNextAvailableName()` — base / `(2)` / `(2)` already exists → `(3)` cases
+- `PresetManager::savePresetToFile(file, data, confirmOverwrite)` — collision returns false aborts; collision returns true proceeds; no collision proceeds without invoking callback
+
+### Manual smoke
+1. **Fresh state Cmd+S** → rich dialog opens, all fields blank except Name; saving creates a new preset visible in `DnaMapBrowser` filtered by mood
+2. **Loaded modified Cmd+S** → no dialog; file mtime updates; toast appears
+3. **Loaded unmodified Cmd+S** → no dialog, no toast, no file mtime change
+4. **Cmd+Shift+S on loaded preset** → rich dialog opens, name pre-filled `{parent} (2)`, mood/category/tags inherited
+5. **Save As fork** → both original and forked preset coexist in browser
+6. **Manual collision in Save As** → user types existing name, Save → confirm dialog → Overwrite path replaces file, Cancel path keeps dialog open
+
+### Visual smoke
+- Dialog matches submarine theme (depth-tone background, depth-ring border)
+- All 16 moods listed alphabetically in dropdown with correct swatch colors
+- Tab order: Name → Mood → Category → Tags → Description → Save → Cancel
+- Cancel button or `Escape` key dismisses without saving
+- Modal blocks clicks on background editor
+
+## Out of scope (deferred)
+
+- "Save as a copy" as a separate menu item (collapsed into Save As)
+- Folder/collection support (`PresetData` doesn't model it yet)
+- Editing favorites or play-count via dialog (external to preset JSON, owned by `PresetBrowser::toggleFavorite()`)
+- Drag-to-reorder in browser
+- Mood selector grid variant (deferred to v1.1 if dropdown proves too compact in user testing)
+
+## Implementation estimate
+
+- `SavePresetDialog.h`: ~250 lines (Component + MoodDropdownLookAndFeel)
+- `XOceanusEditor.h` changes: ~50 lines (state matrix + 2 keyboard handlers; ~50 lines of `onSavePreset` lambda removed)
+- `PresetManager.h` additions: ~20 lines (overload + helper)
+- **Total ~320 lines added, ~50 removed.** ~3-4 hour sonnet session for Day 3.
+
+## Downstream impact on other Lane B Day 2-7 features
+
+- **#22 Cmd+K palette (Day 3 brainstorm)**: keyboard handler in `XOceanusEditor::keyPressed()` will need an early-out for `Cmd+K`; design should land before #22 wires its handler
+- **#24 modulation viz, #25 A/B compare**: independent, no expected interaction
+- **#1428 ChainMatrix (Day 4-5 brainstorm)**: may benefit from `MoodDropdownLookAndFeel` reuse if ChainMatrix needs mood-based filtering — exposed as a public reusable LookAndFeel
+- **Dead Gallery panel removal #979**: independent, no interaction
+
+## Source-of-truth references
+
+- `Source/Core/PresetManager.h` lines 337-376 — `PresetData` struct
+- `Source/Core/PresetManager.h` lines 517-589 — current `savePresetToFile` + JSON serialization
+- `Source/UI/XOceanusEditor.h` lines 1129-1186 — current `onSavePreset` lambda (to be replaced)
+- `Source/UI/XOceanusEditor.h` line 1952 — current `Cmd+S` handler
+- `Source/Core/PresetTaxonomy.h` — category/timbre enums
+- `Source/UI/GalleryColors.h` lines 576-621 — mood color mapping
+- `Source/UI/Tokens.h` — locked design tokens (D1-D5, no additions allowed)

--- a/Source/Engines/Obese/ObeseEngine.h
+++ b/Source/Engines/Obese/ObeseEngine.h
@@ -222,6 +222,12 @@ class FatLadderFilter
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse; // Host must provide a valid sample rate
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
         s[0] = s[1] = s[2] = s[3] = 0.0f;

--- a/Source/Engines/Oblong/OblongEngine.h
+++ b/Source/Engines/Oblong/OblongEngine.h
@@ -94,6 +94,12 @@ class BobOscA
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in updatePhaseInc()
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         // FIX-Sound: soft-triangle smoothing coefficient is SR-dependent.
         // Recompute here so triangle character is consistent at 44.1/48/88.2/96 kHz.
@@ -305,6 +311,12 @@ class BobOscB
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in updatePhaseInc()
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         reset();
     }
@@ -442,6 +454,12 @@ class BobTextureOsc
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
         // FIX-Sound: Breath HP coefficient is SR-dependent — recompute on prepare
@@ -549,7 +567,7 @@ public:
 
 private:
     double sr = 0.0;   // Sentinel: must be set by prepare() before use
-    float invSR = 1.0f / 44100.0f;  // overwritten by prepare() — avoids per-sample division
+    float invSR = 0.0f; // Sentinel 0.0 — set by prepare(); pre-prepare use is a silent bug at 1/44100
     float breathHPCoeff = 0.001f;   // overwritten by prepare() — SR-correct DC-block coefficient
     int mode = 1;
     float tone = 0.5f;
@@ -584,6 +602,12 @@ class BobSnoutFilter
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
         reset();
@@ -780,6 +804,12 @@ class BobCuriosityLFO
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
         sniffSmooth = 0.001f * 44100.0f * invSR;
@@ -1012,6 +1042,12 @@ class BobDustTape
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
         lpState = 0.0f;
@@ -1051,7 +1087,7 @@ public:
 
 private:
     double sr = 0.0;   // Sentinel: must be set by prepare() before use
-    float invSR = 1.0f / 44100.0f;  // overwritten by prepare()
+    float invSR = 0.0f; // Sentinel 0.0 — set by prepare(); pre-prepare use is a silent bug at 1/44100
     float lpState = 0.0f;
     float lastTone = -1.0f;
     float cachedCoeff = 0.5f;

--- a/Source/Engines/Overbite/OverbiteEngine.h
+++ b/Source/Engines/Overbite/OverbiteEngine.h
@@ -92,6 +92,12 @@ class BiteOscA
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in setFrequency()
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         // Precompute drift LFO phase increment — avoids a per-sample division
         driftPhaseInc = 0.37 / sr;
@@ -450,6 +456,12 @@ class BiteSubOsc
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in setFrequency()
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         reset();
     }
@@ -488,6 +500,12 @@ class BiteWeightEngine
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in setFrequency()
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         reset();
     }
@@ -566,6 +584,12 @@ class BiteNoiseSource
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
         // Pink noise IIR: three leaky integrators at pole frequencies 399 Hz, 112 Hz, 32 Hz.
@@ -1166,6 +1190,12 @@ class BiteLFO
 public:
     void prepare(double sampleRate) noexcept
     {
+        // P37: guard against sr=0 (host probe or pre-prepare call) — avoids invSR=Inf
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         invSR = 1.0f / static_cast<float>(sr);
     }

--- a/Source/Engines/Overtone/OvertoneEngine.h
+++ b/Source/Engines/Overtone/OvertoneEngine.h
@@ -183,12 +183,22 @@ struct OverPartialOsc
     float phase = 0.f;
     float sr = 0.0f; // sentinel: must be set by prepare() before use (#671)
 
-    void prepare(double s) { sr = (float)s; }
+    void prepare(double s)
+    {
+        // P37: guard against sr=0 — avoids freq/0=Inf in tick()
+        if (s <= 0.0 || !std::isfinite(s))
+        {
+            jassertfalse;
+            return;
+        }
+        sr = (float)s;
+    }
     void reset() { phase = 0.f; }
 
     // freq in Hz, returns one sample of sine
     float tick(float freq)
     {
+        if (sr <= 0.0f) return 0.0f; // pre-prepare safety: silent, not NaN
         phase += freq / sr;
         if (phase >= 1.f)
             phase -= 1.f;
@@ -527,6 +537,12 @@ public:
     //--------------------------------------------------------------------------
     void prepare(double sampleRate, int maxBlockSize) override
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in partial oscillators
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = (float)sampleRate;
 
         for (int i = 0; i < kNumPartials; ++i)
@@ -639,6 +655,9 @@ public:
     void renderBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi, int numSamples) override
     {
         juce::ScopedNoDenormals noDenormals;
+        // P37: sr=0.0 sentinel — renderBlock must never run without a valid prepare()
+        jassert(sr > 0.0f);
+        if (sr <= 0.0f) { buffer.clear(); return; }
         // 1. Parse MIDI — note-on/off, CC1 (mod wheel D006), aftertouch (D006)
         for (const auto meta : midi)
         {

--- a/Source/Engines/Overworld/OverworldEngine.h
+++ b/Source/Engines/Overworld/OverworldEngine.h
@@ -54,6 +54,12 @@ public:
 
     void prepare(double sampleRate, int maxBlockSize) override
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in VoicePool phase increments
+        if (sampleRate <= 0.0 || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = static_cast<float>(sampleRate);
         voicePool.prepare(sr);
         filter.prepare(sr);
@@ -294,6 +300,9 @@ public:
     void renderBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi, int numSamples) override
     {
         juce::ScopedNoDenormals noDenormals;
+        // P37: sr=0.0 sentinel — renderBlock must never run without a valid prepare()
+        jassert(sr > 0.0f);
+        if (sr <= 0.0f) { buffer.clear(); return; }
         if (numSamples <= 0)
             return;
 

--- a/Source/Engines/Overworld/engine/VoicePool.h
+++ b/Source/Engines/Overworld/engine/VoicePool.h
@@ -845,6 +845,12 @@ public:
 
     void prepare(float sampleRate)
     {
+        // P37: guard against sr=0 — avoids freq/sr=Inf in phase increments
+        if (sampleRate <= 0.0f || !std::isfinite(sampleRate))
+        {
+            jassertfalse;
+            return;
+        }
         sr = sampleRate;
         gWavetables.build(sampleRate);
         for (auto& v : voices)


### PR DESCRIPTION
## Summary

- Addresses P37 pattern: unguarded `invSR = 1.0f / sampleRate` or `freq / sr` in sub-struct `prepare()` calls without `sr > 0` validation — produces `Inf`/`NaN` when host calls `prepare(sr=0)` or before first prepare
- 5 engines fixed across 6 files: Obese, Oblong, Overbite, Overtone, Overworld
- 2 false positives documented (Opsin, Organon already fully guarded)
- 1 skip (Orphica — culled to v1.1)

## Engines fixed

| Engine | Files | What changed |
|--------|-------|--------------|
| **Obese** | ObeseEngine.h | FatLadderFilter::prepare() sr guard |
| **Oblong** | OblongEngine.h | 6 sub-structs guarded (BobOscA/B, BobTextureOsc, BobSnoutFilter, BobCuriosityLFO, BobDustTape); 2 wrong member defaults `1.0f/44100.0f` → `0.0f` sentinel |
| **Overbite** | OverbiteEngine.h | 5 sub-structs guarded (BiteOscA, BiteSubOsc, BiteWeightEngine, BiteNoiseSource, BiteLFO) |
| **Overtone** | OvertoneEngine.h | OverPartialOsc::prepare() guard + tick() sr≤0 silent-return; main engine prepare() + renderBlock() guards (engine had NO sr sentinels at all) |
| **Overworld** | OverworldEngine.h, VoicePool.h | VoicePool::prepare() guard; main engine prepare() guard; renderBlock() sr sentinel |

## False positives (no change)

- **Opsin**: already has explicit `if (sampleRate <= 0.0) { jassertfalse; return; }` at top of prepare()
- **Organon**: already uses `(sampleRate > 0.0) ? (1.0 / sampleRate) : 0.0` inline guard
- **Orphica**: culled to v1.1 per V1 scope — skip

## Clobber-on-reset check

None of the 5 engines' `reset()` methods write back `sr` or `invSR` — no clobber-on-reset pattern found.

## Build sentinel

Build: `cmake --build build --target XOceanus_AU --config Release` — **PASS** (58 pre-existing warnings, 0 errors)

## Test plan

- [ ] Load engine in AU host at 44.1kHz — verify normal audio output
- [ ] Load engine in AU host at 96kHz — verify normal audio output
- [ ] Confirm no regression in any of the 5 engines via preset playback

## References

- Fleet audit: `fathom-fleet-report-2026-04-26.md` §P37
- Prior P34 sweep: PR #1516 (merged 2026-05-04)
- Prior P36 sweep: PR #1517 (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)