### PR TITLE
fix(perf): inline CPU repairs — Opcode/Oracle/Origami

### DIFF
--- a/Source/Engines/Opcode/OpcodeEngine.h
+++ b/Source/Engines/Opcode/OpcodeEngine.h
@@ -526,13 +526,14 @@ public:
                 // Filter — FM EP benefits from gentle LP to tame aliasing at high index.
                 // Tick filter env per sample; refresh SVF coeffs every 16 samples
                 // (~0.36ms @ 44.1k — below audible lag).
+                // Use setCoefficients_fast: mode is always LowPass (set at noteOn),
+                // so shelf-gain branch and mode-cache in setCoefficients() are dead cost.
                 float fEnvMod = voice.filterEnv.process() * pFilterEnvAmt * 4000.0f;
                 if (updateFilter)
                 {
                     float velBright = voice.velocity * 3000.0f;
                     float cutoff = std::clamp(brightNow + fEnvMod + velBright, 200.0f, 20000.0f);
-                    voice.svf.setMode(CytomicSVF::Mode::LowPass);
-                    voice.svf.setCoefficients(cutoff, 0.1f, srf);
+                    voice.svf.setCoefficients_fast(cutoff, 0.1f, srf);
                 }
                 float filtered = voice.svf.processSample(fmOutput);
 

--- a/Source/Engines/Oracle/OracleEngine.h
+++ b/Source/Engines/Oracle/OracleEngine.h
@@ -397,7 +397,9 @@ struct OracleVoice
         lfo2.reset();
         dcBlockerL.reset();
         dcBlockerR.reset();
-        rng.seed(1);
+        // rng seeded per-voice by the engine's prepare()/reset() loops using a
+        // voice-index-derived seed — prevents all voices sharing the same PRNG
+        // sequence after a transport reset (P36 fix).
         numBreakpoints = 16; // Default to 16 on reset — initBreakpoints() overrides on noteOn
 
         // Initialize breakpoints to a sine-like shape — the "primordial"
@@ -477,10 +479,13 @@ public:
         silenceGate.prepare(sampleRate, maxBlockSize);
         silenceGate.setHoldTime(500.0f); // Oracle has reverb tails
 
-        // Initialize all voices
-        for (auto& voice : voices)
+        // Initialize all voices — seed RNG per-voice index so transport reset
+        // never collapses all voices to the same PRNG sequence (P36 fix).
+        for (int vi = 0; vi < static_cast<int>(voices.size()); ++vi)
         {
+            auto& voice = voices[static_cast<size_t>(vi)];
             voice.reset();
+            voice.rng.seed(static_cast<uint64_t>(vi) * 2654435761ULL ^ 0xDEAD1234ULL);
             voice.dcBlockerL.prepare(sampleRateFloat);
             voice.dcBlockerR.prepare(sampleRateFloat);
         }
@@ -490,8 +495,15 @@ public:
 
     void reset() override
     {
-        for (auto& v : voices)
+        // Seed per-voice index after reset so all voices have distinct PRNG
+        // sequences post-transport-stop — noteOn() will reseed again on each note
+        // event, but this guard prevents a gap if state is read before first noteOn.
+        for (int vi = 0; vi < static_cast<int>(voices.size()); ++vi)
+        {
+            auto& v = voices[static_cast<size_t>(vi)];
             v.reset();
+            v.rng.seed(static_cast<uint64_t>(vi) * 2654435761ULL ^ 0xDEAD1234ULL);
+        }
 
         envelopeOutput = 0.0f;
         couplingBreakpointMod = 0.0f;

--- a/Source/Engines/Origami/OrigamiEngine.h
+++ b/Source/Engines/Origami/OrigamiEngine.h
@@ -1469,12 +1469,28 @@ private:
                 float imaginary = voice.fftImaginary[static_cast<size_t>(bin)];
 
                 // Use power-domain magnitude for analysis frame storage.
-                // Floor test in power domain avoids sqrt on near-zero bins;
-                // eliminates the redundant std::max on the common above-floor path.
+                // Floor test in power domain avoids sqrt on near-zero bins.
+                // Above-floor bins: Q_rsqrt approximation (Quake magic, one Newton step,
+                // ~0.2% error) — acceptable for spectral magnitudes. Eliminates 257
+                // std::sqrt calls per hop (~707K/sec at 8-voice, 44.1kHz). (CRIT P-sqrt fix)
                 const float power = real * real + imaginary * imaginary;
-                float magnitude = (power > kMagnitudeFloor * kMagnitudeFloor)
-                    ? std::sqrt(power)
-                    : kMagnitudeFloor;
+                float magnitude;
+                if (power > kMagnitudeFloor * kMagnitudeFloor)
+                {
+                    // fast inverse-sqrt via bit-cast, then sqrt(x) = x * invSqrt(x)
+                    float y = power;
+                    int32_t ybits;
+                    std::memcpy(&ybits, &y, sizeof(ybits));
+                    ybits = 0x5F375A86 - (ybits >> 1);
+                    float invSqrt;
+                    std::memcpy(&invSqrt, &ybits, sizeof(invSqrt));
+                    invSqrt *= (1.5f - 0.5f * power * invSqrt * invSqrt); // one NR step
+                    magnitude = power * invSqrt; // = sqrt(power)
+                }
+                else
+                {
+                    magnitude = kMagnitudeFloor;
+                }
 
                 float binPhase = std::atan2(imaginary, real);
 


### PR DESCRIPTION
## Summary

Targeted inline CPU fixes for three engines from the W1-A3 FATHOM audit. Fix-shape only — no architectural changes, no new APIs, no new files.

---

## Opcode — SVF filter: setCoefficients → setCoefficients_fast

**Hotspot**: `OpcodeEngine.h` line ~535 — `setCoefficients()` called every 16 samples in the voice render loop.

**Finding**: The audit flagged `setCoefficients()` (which checks shelf mode and stores `shelfGainDb_`) as an IMP. The mode is always `LowPass` (the CytomicSVF default) and never changes — so the shelf-gain branch and mode-cache in the full setter are dead overhead every block.

**Fix**: Switched to `setCoefficients_fast()` and removed the now-redundant `setMode(LowPass)` call before it. Default mode is `LowPass` (confirmed at `CytomicSVF.h:233`).

**False-positive triage**: The audit CRIT (std::pow → fastPow2 in noteOn) was already fixed at line 568. The DXModulationEnvelope "asymptotic" IMP was confirmed false positive — target of 1.02 ensures threshold crossing; `if (level >= 1.0f) { level = 1.0f; stage = Decay1; }` clamps correctly.

**auval**: PASS at 44.1k/48k/96k.

---

## Oracle — P36: rng.seed(1) in OracleVoice::reset()

**Hotspot**: `OracleEngine.h` line 400 — `rng.seed(1)` in `OracleVoice::reset()` collapsed all voices to the same PRNG sequence after every DAW transport-stop.

**Finding**: P36 pattern. After transport stop, the engine's `reset()` calls `v.reset()` on every voice — each resets to seed=1. Subsequent notes before another transport stop all have correlated stochastic breakpoint evolution (shared xorshift64 sequence after reset).

**Fix**: Removed `rng.seed(1)` from `OracleVoice::reset()`. Added per-voice-index seeding in the engine's `prepare()` and `reset()` loops: `vi * 2654435761ULL ^ 0xDEAD1234ULL`. `noteOn()` already reseeds per-note/per-voice with a note+voiceCounter hash — this guard prevents the gap between transport-stop and the first new noteOn.

**Memory pattern**: Matches `feedback-clobber-on-reset-bug-pattern.md` — prepare() side was seeded correctly by noteOn, but reset() was clobbering to a uniform state.

**False-positive triage**: The audit CRIT (std::pow → fastPow2 in computeMaqamFreq) was already fixed at lines 1184, 1223-1224. The smoothing 2π error was already fixed at line 464 (formula already correct without 2π factor, with comment).

**auval**: PASS at 44.1k/48k/96k.

---

## Origami — CRIT: std::sqrt per-bin in processSTFT

**Hotspot**: `OrigamiEngine.h` line ~1476 — `std::sqrt(power)` called for every above-floor bin in `processSTFT` analysis loop.

**Finding**: CRIT P-sqrt — 257 bins × ~344 hops/sec × 8 voices ≈ 707K `std::sqrt` calls/sec at 44.1kHz/128-hop. The power-domain floor test (partially applied) was deflecting near-zero bins but all above-floor bins (which in practice is nearly all 257 when a note plays) still hit `std::sqrt`.

**Fix**: Replaced `std::sqrt(power)` with Q_rsqrt approximation (Quake `0x5F375A86` bit-trick + one Newton-Raphson step, ~0.2% error). Since `sqrt(x) = x * invSqrt(x)`, magnitude is recovered as `power * invSqrt`. Error of ~0.2% is well within spectral magnitude storage precision requirements (downstream fold/mirror/rotate/stretch operations are all magnitude multiplications/additions).

**No fastSqrt in DSP library**: `FastMath.h` does not expose `fastSqrt` or `fastInvSqrt`. The Q_rsqrt pattern is used verbatim from `OceanicEngine.h:634-642` (same codebase precedent). Inline in the engine header, no new shared function.

**Full power-domain refactor** (storing magnitude² throughout): Flagged as v1.1 candidate in the audit. Not attempted here — would require changing `SpectralFrame::magnitude` semantics and all downstream spectral operations.

**auval**: PASS at 44.1k/48k/96k.

---

## Build & Validation

- `cmake --build build --target XOceanus_AU` — clean (58 warnings, 0 errors — pre-existing)
- `auval -v aumu Xocn XoOx` — **PASS**
- Binary verified to include Origami and Oracle engine symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)