### PR TITLE
feat(ui): Save / Save As dialog with mood capture (#1405)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,7 @@ add_executable(XOceanusTests
     Tests/PresetTests/PresetRoundTripTests.cpp
     Tests/PresetTests/BackwardCompatibilityTests.cpp
     Tests/PresetTests/CommandPaletteTests.cpp
+    Tests/PresetTests/SavePresetDialogTests.cpp
     Tests/ExportTests/XPNExportTests.cpp
     Tests/DoctrineTests/DoctrineTests.cpp
     Tests/PlaySurfaceTests/HarmonicFieldTests.cpp

--- a/Source/Core/PresetManager.h
+++ b/Source/Core/PresetManager.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <algorithm>
 #include <deque>
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>
@@ -554,16 +555,46 @@ public:
         return file.replaceWithText(json);
     }
 
-    /** Save with collision check. confirmOverwrite is invoked only if the target
-        file already exists. Return false from the callback to abort the save.
-        Returns true on successful write, false on abort or write failure. */
-    bool savePresetToFile (const juce::File& file,
-                           const PresetData& preset,
-                           std::function<bool (juce::File)> confirmOverwrite)
+    /** Save with collision check. confirmOverwrite is invoked only if file exists.
+        Return false from the callback to abort. Returns true on successful save. */
+    bool savePresetToFile(const juce::File& file,
+                          const PresetData& data,
+                          std::function<bool(juce::File)> confirmOverwrite)
     {
-        if (file.existsAsFile() && confirmOverwrite && ! confirmOverwrite (file))
+        if (file.existsAsFile() && confirmOverwrite && !confirmOverwrite(file))
             return false;
-        return savePresetToFile (file, preset);
+        auto json = serializeToJSON(data);
+        if (json.isEmpty())
+            return false;
+        return file.replaceWithText(json);
+    }
+
+    /** Returns the next non-colliding preset name in the given directory.
+        For "My Preset" with "My Preset.xometa" present -> "My Preset (2)".
+        For "My Preset" with both base and (2) present -> "My Preset (3)". */
+    static juce::String getNextAvailableName(const juce::String& baseName, const juce::File& presetDir)
+    {
+        auto sanitized = juce::File::createLegalFileName(baseName);
+        if (!presetDir.getChildFile(sanitized + ".xometa").existsAsFile())
+            return sanitized;
+
+        for (int n = 2; n < 10000; ++n)
+        {
+            auto candidate = sanitized + " (" + juce::String(n) + ")";
+            if (!presetDir.getChildFile(candidate + ".xometa").existsAsFile())
+                return candidate;
+        }
+        return sanitized + " (" + juce::Time::getCurrentTime().formatted("%H%M%S") + ")"; // fallback
+    }
+
+    /** Returns the canonical user preset directory, creating it if needed. */
+    static juce::File getUserPresetDirectory()
+    {
+        auto dir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+                       .getChildFile("Application Support/XO_OX/XOceanus/Presets");
+        if (!dir.exists())
+            dir.createDirectory();
+        return dir;
     }
 
     // Serialize a PresetData to a JSON string.

--- a/Source/Core/PresetManager.h
+++ b/Source/Core/PresetManager.h
@@ -569,34 +569,6 @@ public:
         return file.replaceWithText(json);
     }
 
-    /** Returns the next non-colliding preset name in the given directory.
-        For "My Preset" with "My Preset.xometa" present -> "My Preset (2)".
-        For "My Preset" with both base and (2) present -> "My Preset (3)". */
-    static juce::String getNextAvailableName(const juce::String& baseName, const juce::File& presetDir)
-    {
-        auto sanitized = juce::File::createLegalFileName(baseName);
-        if (!presetDir.getChildFile(sanitized + ".xometa").existsAsFile())
-            return sanitized;
-
-        for (int n = 2; n < 10000; ++n)
-        {
-            auto candidate = sanitized + " (" + juce::String(n) + ")";
-            if (!presetDir.getChildFile(candidate + ".xometa").existsAsFile())
-                return candidate;
-        }
-        return sanitized + " (" + juce::Time::getCurrentTime().formatted("%H%M%S") + ")"; // fallback
-    }
-
-    /** Returns the canonical user preset directory, creating it if needed. */
-    static juce::File getUserPresetDirectory()
-    {
-        auto dir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                       .getChildFile("Application Support/XO_OX/XOceanus/Presets");
-        if (!dir.exists())
-            dir.createDirectory();
-        return dir;
-    }
-
     // Serialize a PresetData to a JSON string.
     juce::String serializeToJSON(const PresetData& preset)
     {

--- a/Source/UI/Ocean/SavePresetDialog.h
+++ b/Source/UI/Ocean/SavePresetDialog.h
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 XO_OX Designs
+#pragma once
+
+// SavePresetDialog — rich modal dialog for Save / Save As preset workflow.
+//
+// Architecture: one new file (this), two modified (XOceanusEditor.h, PresetManager.h).
+// Spec: Docs/plans/2026-05-04-save-as-design.md
+// Tracking: issue #1405 (TODO #1354)
+//
+// Form: 480x360 modal Component hosted in a juce::DialogWindow.
+// Required fields: Name + Mood. Optional: Category, Tags, Description.
+// Reuses XO::Tokens::Color::* (D1-D5 locked tokens) — NO new tokens introduced.
+//
+// MoodDropdownLookAndFeel is exposed as a public nested class so future components
+// (e.g. #1428 ChainMatrix mood filter) can reuse it.
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "../../Core/PresetManager.h"
+#include "../../Core/PresetTaxonomy.h"
+#include "../Tokens.h"
+#include "../GalleryColors.h"
+#include "../ToastOverlay.h"
+
+namespace xoceanus
+{
+
+//==============================================================================
+/// Rich Save / Save As dialog for XOceanus presets.
+/// Hosts Name (required), Mood (required), Category / Tags / Description (optional).
+class SavePresetDialog : public juce::Component
+{
+public:
+    using SaveCallback   = std::function<void(PresetData)>;
+    using CancelCallback = std::function<void()>;
+
+    //==========================================================================
+    /// Custom LookAndFeel for the 16-mood ComboBox — renders 12x12 color swatches.
+    /// Exposed as public so other components can reuse it (e.g. #1428 ChainMatrix).
+    class MoodDropdownLookAndFeel : public juce::LookAndFeel_V4
+    {
+    public:
+        MoodDropdownLookAndFeel()
+        {
+            // Match the submarine dark palette.
+            setColour(juce::ComboBox::backgroundColourId,    juce::Colour(GalleryColors::Ocean::shallow));
+            setColour(juce::ComboBox::outlineColourId,       juce::Colour(GalleryColors::Ocean::surface).brighter(0.3f));
+            setColour(juce::ComboBox::textColourId,          juce::Colour(GalleryColors::Ocean::foam));
+            setColour(juce::ComboBox::arrowColourId,         juce::Colour(GalleryColors::Ocean::salt));
+            setColour(juce::PopupMenu::backgroundColourId,   juce::Colour(GalleryColors::Ocean::shallow));
+            setColour(juce::PopupMenu::textColourId,         juce::Colour(GalleryColors::Ocean::foam));
+            setColour(juce::PopupMenu::highlightedBackgroundColourId, juce::Colour(GalleryColors::Ocean::surface).brighter(0.2f));
+            setColour(juce::PopupMenu::highlightedTextColourId, juce::Colour(GalleryColors::Ocean::foam));
+        }
+
+        void drawPopupMenuItem(juce::Graphics& g, const juce::Rectangle<int>& area,
+                               bool isSeparator, bool isActive, bool isHighlighted,
+                               bool isTicked, bool hasSubMenu,
+                               const juce::String& text, const juce::String& shortcutKeyText,
+                               const juce::Drawable* icon, const juce::Colour* textColour) override
+        {
+            if (isSeparator || !isActive)
+            {
+                juce::LookAndFeel_V4::drawPopupMenuItem(g, area, isSeparator, isActive,
+                    isHighlighted, isTicked, hasSubMenu, text, shortcutKeyText, icon, textColour);
+                return;
+            }
+
+            if (isHighlighted)
+                g.fillAll(findColour(juce::PopupMenu::highlightedBackgroundColourId));
+
+            // 12x12 color swatch
+            auto swatchBounds = area.withWidth(20).reduced(4);
+            g.setColour(moodToColour(text));
+            g.fillEllipse(swatchBounds.toFloat());
+
+            // Mood name label
+            auto textBounds = area.withTrimmedLeft(24);
+            g.setColour(isHighlighted
+                ? findColour(juce::PopupMenu::highlightedTextColourId)
+                : findColour(juce::PopupMenu::textColourId));
+            g.setFont(juce::Font(juce::FontOptions{}.withHeight(12.0f)));
+            g.drawText(text, textBounds, juce::Justification::centredLeft);
+        }
+
+        /// Returns the mood color for a given mood name string.
+        static juce::Colour moodToColour(const juce::String& mood)
+        {
+            // Same table as DnaMapBrowser::moodColour() and XOceanusEditor::moodColourFor().
+            if (mood == "Foundation")  return juce::Colour(0xFF9E9B97);
+            if (mood == "Atmosphere")  return juce::Colour(0xFF48CAE4);
+            if (mood == "Entangled")   return juce::Colour(0xFF9B5DE5);
+            if (mood == "Prism")       return juce::Colour(0xFFBF40FF);
+            if (mood == "Flux")        return juce::Colour(0xFFFF6B6B);
+            if (mood == "Aether")      return juce::Colour(0xFFA8D8EA);
+            if (mood == "Family")      return juce::Colour(0xFFE9C46A);
+            if (mood == "Submerged")   return juce::Colour(0xFF0096C7);
+            if (mood == "Coupling")    return juce::Colour(0xFFE9C46A);
+            if (mood == "Crystalline") return juce::Colour(0xFFFFFFF0);
+            if (mood == "Deep")        return juce::Colour(0xFF1A6B5A);
+            if (mood == "Ethereal")    return juce::Colour(0xFF7FDBCA);
+            if (mood == "Kinetic")     return juce::Colour(0xFFFF8C00);
+            if (mood == "Luminous")    return juce::Colour(0xFFC6E377);
+            if (mood == "Organic")     return juce::Colour(0xFF228B22);
+            if (mood == "Shadow")      return juce::Colour(0xFF546E7A);
+            return juce::Colour(GalleryColors::Ocean::plankton); // fallback
+        }
+    };
+
+    //==========================================================================
+    SavePresetDialog(PresetData       initial,
+                     bool             /*isFirstSave*/,  // intent captured by caller's LaunchOptions.dialogTitle
+                     SaveCallback     onSave,
+                     CancelCallback   onCancel)
+        : initial_   (std::move(initial))
+        , onSave_    (std::move(onSave))
+        , onCancel_  (std::move(onCancel))
+    {
+        // ── Name field ────────────────────────────────────────────────────────
+        addAndMakeVisible(nameLabel_);
+        nameLabel_.setText("Name *", juce::dontSendNotification);
+        styleLabel(nameLabel_);
+
+        addAndMakeVisible(nameField_);
+        nameField_.setText(initial_.name, juce::dontSendNotification);
+        nameField_.setSelectAllWhenFocused(true);
+        nameField_.setColour(juce::TextEditor::backgroundColourId, juce::Colour(GalleryColors::Ocean::shallow));
+        nameField_.setColour(juce::TextEditor::textColourId,       juce::Colour(GalleryColors::Ocean::foam));
+        nameField_.setColour(juce::TextEditor::outlineColourId,    juce::Colour(GalleryColors::Ocean::surface).brighter(0.3f));
+        nameField_.setColour(juce::TextEditor::focusedOutlineColourId, juce::Colour(XO::Tokens::Color::Accent));
+        nameField_.onTextChange = [this] { updateSaveButtonState(); };
+
+        // ── Mood dropdown ─────────────────────────────────────────────────────
+        addAndMakeVisible(moodLabel_);
+        moodLabel_.setText("Mood *", juce::dontSendNotification);
+        styleLabel(moodLabel_);
+
+        addAndMakeVisible(moodDropdown_);
+        moodDropdown_.setLookAndFeel(&moodLAF_);
+        // 16 moods alphabetical (spec §3 decision Q3 — mood is required field)
+        static const juce::StringArray kMoods {
+            "Aether", "Atmosphere", "Coupling", "Crystalline", "Deep", "Entangled",
+            "Ethereal", "Family", "Flux", "Foundation", "Kinetic", "Luminous",
+            "Organic", "Prism", "Shadow", "Submerged"
+        };
+        for (int i = 0; i < kMoods.size(); ++i)
+            moodDropdown_.addItem(kMoods[i], i + 1);
+
+        if (initial_.mood.isNotEmpty())
+            moodDropdown_.setText(initial_.mood, juce::dontSendNotification);
+        moodDropdown_.onChange = [this] { updateSaveButtonState(); };
+
+        // ── Category dropdown ─────────────────────────────────────────────────
+        addAndMakeVisible(categoryLabel_);
+        categoryLabel_.setText("Category", juce::dontSendNotification);
+        styleLabel(categoryLabel_);
+
+        addAndMakeVisible(categoryDropdown_);
+        categoryDropdown_.setColour(juce::ComboBox::backgroundColourId, juce::Colour(GalleryColors::Ocean::shallow));
+        categoryDropdown_.setColour(juce::ComboBox::textColourId,       juce::Colour(GalleryColors::Ocean::foam));
+        categoryDropdown_.setColour(juce::ComboBox::outlineColourId,    juce::Colour(GalleryColors::Ocean::surface).brighter(0.3f));
+        categoryDropdown_.addItem("— None —", 1);
+        for (int i = 0; i < (int)kPresetCategories.size(); ++i)
+            categoryDropdown_.addItem(kPresetCategories[i], i + 2);
+
+        if (initial_.category.has_value() && initial_.category->isNotEmpty())
+            categoryDropdown_.setText(*initial_.category, juce::dontSendNotification);
+        else
+            categoryDropdown_.setSelectedId(1, juce::dontSendNotification); // "— None —"
+
+        // ── Tags field ────────────────────────────────────────────────────────
+        addAndMakeVisible(tagsLabel_);
+        tagsLabel_.setText("Tags", juce::dontSendNotification);
+        styleLabel(tagsLabel_);
+
+        addAndMakeVisible(tagsField_);
+        tagsField_.setText(initial_.tags.joinIntoString(", "), juce::dontSendNotification);
+        styleTextEditor(tagsField_);
+
+        // ── Description field ─────────────────────────────────────────────────
+        addAndMakeVisible(descriptionLabel_);
+        descriptionLabel_.setText("Description", juce::dontSendNotification);
+        styleLabel(descriptionLabel_);
+
+        addAndMakeVisible(descriptionField_);
+        descriptionField_.setMultiLine(true);
+        descriptionField_.setReturnKeyStartsNewLine(true);
+        descriptionField_.setText(initial_.description, juce::dontSendNotification);
+        styleTextEditor(descriptionField_);
+
+        // ── Buttons ───────────────────────────────────────────────────────────
+        addAndMakeVisible(saveButton_);
+        saveButton_.setButtonText("Save");
+        saveButton_.setColour(juce::TextButton::buttonColourId,    juce::Colour(XO::Tokens::Color::Accent));
+        saveButton_.setColour(juce::TextButton::textColourOffId,   juce::Colour(GalleryColors::Ocean::deep));
+        saveButton_.setColour(juce::TextButton::buttonOnColourId,  juce::Colour(XO::Tokens::Color::AccentBright));
+        saveButton_.onClick = [this] { handleSaveClicked(); };
+
+        addAndMakeVisible(cancelButton_);
+        cancelButton_.setButtonText("Cancel");
+        cancelButton_.setColour(juce::TextButton::buttonColourId,  juce::Colour(GalleryColors::Ocean::shallow));
+        cancelButton_.setColour(juce::TextButton::textColourOffId, juce::Colour(GalleryColors::Ocean::foam));
+        cancelButton_.onClick = [this] { if (onCancel_) onCancel_(); };
+
+        updateSaveButtonState();
+        setSize(480, 380);
+    }
+
+    ~SavePresetDialog() override
+    {
+        moodDropdown_.setLookAndFeel(nullptr);
+    }
+
+    void paint(juce::Graphics& g) override
+    {
+        // D1: submarine console depth-tone background
+        g.fillAll(juce::Colour(GalleryColors::Ocean::twilight));
+
+        // Depth-ring border (D5 style: subtle inner border)
+        g.setColour(juce::Colour(GalleryColors::Ocean::surface).brighter(0.15f));
+        g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(1.0f), 4.0f, 1.0f);
+    }
+
+    void resized() override
+    {
+        auto bounds = getLocalBounds().reduced(24);
+
+        // Button row at bottom
+        auto buttonRow = bounds.removeFromBottom(36);
+        bounds.removeFromBottom(12);
+
+        // Layout helper: label row above field
+        auto layoutLabeled = [&](juce::Label& lbl, juce::Component& field, int fieldH)
+        {
+            auto row = bounds.removeFromTop(16 + fieldH);
+            lbl.setBounds(row.removeFromTop(16));
+            field.setBounds(row.withHeight(fieldH));
+            bounds.removeFromTop(8);
+        };
+
+        layoutLabeled(nameLabel_,        nameField_,         28);
+        layoutLabeled(moodLabel_,        moodDropdown_,      28);
+        layoutLabeled(categoryLabel_,    categoryDropdown_,  28);
+        layoutLabeled(tagsLabel_,        tagsField_,         28);
+        layoutLabeled(descriptionLabel_, descriptionField_,  60);
+
+        cancelButton_.setBounds(buttonRow.removeFromRight(100));
+        buttonRow.removeFromRight(10);
+        saveButton_.setBounds(buttonRow.removeFromRight(100));
+    }
+
+    bool keyPressed(const juce::KeyPress& key) override
+    {
+        if (key == juce::KeyPress::escapeKey)
+        {
+            if (onCancel_) onCancel_();
+            return true;
+        }
+        if (key == juce::KeyPress::returnKey && saveButton_.isEnabled()
+            && !descriptionField_.hasKeyboardFocus(false))
+        {
+            handleSaveClicked();
+            return true;
+        }
+        return false;
+    }
+
+private:
+    //==========================================================================
+    void styleLabel(juce::Label& lbl)
+    {
+        lbl.setFont(juce::Font(juce::FontOptions{}.withHeight(11.0f)));
+        lbl.setColour(juce::Label::textColourId, juce::Colour(GalleryColors::Ocean::salt));
+    }
+
+    void styleTextEditor(juce::TextEditor& te)
+    {
+        te.setColour(juce::TextEditor::backgroundColourId, juce::Colour(GalleryColors::Ocean::shallow));
+        te.setColour(juce::TextEditor::textColourId,       juce::Colour(GalleryColors::Ocean::foam));
+        te.setColour(juce::TextEditor::outlineColourId,    juce::Colour(GalleryColors::Ocean::surface).brighter(0.3f));
+        te.setColour(juce::TextEditor::focusedOutlineColourId, juce::Colour(XO::Tokens::Color::Accent));
+    }
+
+    void updateSaveButtonState()
+    {
+        const bool nameOK = nameField_.getText().trim().isNotEmpty();
+        const bool moodOK = moodDropdown_.getSelectedId() > 0;
+        saveButton_.setEnabled(nameOK && moodOK);
+    }
+
+    void handleSaveClicked()
+    {
+        if (!onSave_) return;
+
+        // Build output preset from form fields
+        PresetData out = initial_;
+        out.name        = juce::File::createLegalFileName(nameField_.getText().trim());
+        out.mood        = moodDropdown_.getText();
+
+        const auto catText = categoryDropdown_.getText();
+        if (catText.isEmpty() || catText == "— None —")
+            out.category = std::nullopt;
+        else
+            out.category = catText;
+
+        out.tags = juce::StringArray::fromTokens(tagsField_.getText(), ",", "\"");
+        out.tags.trim();
+        out.tags.removeEmptyStrings();
+        out.description = descriptionField_.getText();
+
+        // Collision-check via the confirm-overwrite overload
+        auto presetDir = PresetManager::getUserPresetDirectory();
+        auto target    = presetDir.getChildFile(out.name + ".xometa");
+
+        // Check for collision without using the blocking showOkCancelBox.
+        // JUCE_MODAL_LOOPS_PERMITTED=0 in plugin context — use async confirm.
+        if (target.existsAsFile())
+        {
+            // Collision: show async confirm dialog. Fields remain intact.
+            const juce::String capturedName = out.name;
+            auto capturedOut = out;
+            auto capturedOnSave = onSave_;
+            auto capturedTarget = target;
+
+            auto* confirmDialog = new juce::AlertWindow(
+                "Overwrite preset?",
+                "A preset named \"" + capturedName + "\" already exists.\n\nOverwrite it?",
+                juce::MessageBoxIconType::QuestionIcon,
+                this);
+            confirmDialog->addButton("Overwrite", 1);
+            confirmDialog->addButton("Cancel",    0);
+
+            confirmDialog->enterModalState(
+                true,
+                juce::ModalCallbackFunction::create(
+                    [capturedTarget, capturedOut, capturedOnSave](int result) mutable
+                    {
+                        if (result != 1) return; // user cancelled
+                        PresetManager pm;
+                        if (pm.savePresetToFile(capturedTarget, capturedOut))
+                        {
+                            if (capturedOnSave)
+                                capturedOnSave(capturedOut);
+                        }
+                    }),
+                true /* deleteWhenDismissed */);
+        }
+        else
+        {
+            // No collision — save directly.
+            PresetManager pm;
+            if (pm.savePresetToFile(target, out))
+                onSave_(out); // caller is responsible for closing the dialog
+            else
+                ToastOverlay::show("Save failed — check disk space or permissions.",
+                                   Toast::Level::Warn);
+        }
+    }
+
+    //==========================================================================
+    PresetData     initial_;
+    // isFirstSave_ is used only by the caller (XOceanusEditor) to set the
+    // DialogWindow title and choose the initial name — not stored here.
+    SaveCallback   onSave_;
+    CancelCallback onCancel_;
+
+    MoodDropdownLookAndFeel moodLAF_;
+
+    juce::Label      nameLabel_;
+    juce::TextEditor nameField_;
+
+    juce::Label    moodLabel_;
+    juce::ComboBox moodDropdown_;
+
+    juce::Label    categoryLabel_;
+    juce::ComboBox categoryDropdown_;
+
+    juce::Label      tagsLabel_;
+    juce::TextEditor tagsField_;
+
+    juce::Label      descriptionLabel_;
+    juce::TextEditor descriptionField_;
+
+    juce::TextButton saveButton_;
+    juce::TextButton cancelButton_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SavePresetDialog)
+};
+
+} // namespace xoceanus

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -61,6 +61,8 @@
 #include "Tokens.h"
 // Cmd+K command palette — fuzzy preset + engine search (#22).
 #include "Ocean/CommandPalette.h"
+// Issue #1405 (TODO #1354): Save / Save As dialog with mood capture.
+#include "Ocean/SavePresetDialog.h"
 
 namespace xoceanus
 {
@@ -97,6 +99,7 @@ namespace xoceanus
 class XOceanusEditor : public juce::AudioProcessorEditor,
                        public CockpitHost, // B041: Dark Cockpit opacity interface
                        private juce::Timer,
+                       private juce::ValueTree::Listener,        // issue #1405: dirty-flag tracking
                        private XOceanusProcessor::SlotPresetListener // #1356 per-slot pill sync
 {
 public:
@@ -112,6 +115,8 @@ public:
         initPlaySurfaceAndPresets(proc);
         initSidebarAndWiring(proc);
         initOceanView(proc);
+        // Issue #1405: listen on APVTS state changes to track the dirty flag.
+        proc.getAPVTS().state.addListener(this);
         startTimerHz(10); // #1008 FIX 6: raised from 1Hz — OceanView voice counts
                           // and coupling routes need 10Hz minimum for responsive feel.
                           // MIDI-learn boost to 30Hz applied separately in MIDI callback.
@@ -1079,6 +1084,7 @@ public:
                 {
                     processor.applyPreset(preset);
                     pm.setCurrentPreset(preset);
+                    isDirty_ = false; // issue #1405: fresh load = clean state
                 }
                 catch (const std::exception& e)
                 {
@@ -1100,6 +1106,7 @@ public:
                 const auto& preset = pm.getCurrentPreset();
                 processor.getUndoManager().beginNewTransaction("Load preset: " + preset.name);
                 processor.applyPreset(preset);
+                isDirty_ = false; // issue #1405: fresh load = clean state
             }
             catch (const std::exception& e)
             {
@@ -1118,6 +1125,7 @@ public:
                 const auto& preset = pm.getCurrentPreset();
                 processor.getUndoManager().beginNewTransaction("Load preset: " + preset.name);
                 processor.applyPreset(preset);
+                isDirty_ = false; // issue #1405: fresh load = clean state
             }
             catch (const std::exception& e)
             {
@@ -1127,64 +1135,23 @@ public:
             }
         };
 
-        // onSavePreset — prompt for a name via juce::AlertWindow, then write the
-        // .xometa file via PresetManager::savePresetToFile().
-        // TODO(#1354): A richer "Save As" dialog (overwrite-check, mood selector)
-        // is a follow-up task.  For now, a modal input box is sufficient.
+        // onSavePreset — routes to the rich Save / Save As dialog (issue #1405).
+        // Replaces the old AlertWindow-based flow from the TODO(#1354) placeholder.
         oceanView_.onSavePreset = [this]()
         {
-            auto& pm = processor.getPresetManager();
-            const juce::String currentName = pm.getCurrentPreset().name;
-            const juce::String suggestion  = currentName.isEmpty() ? "My Preset" : currentName;
-
-            // takeOwnership=true: JUCE manages lifetime — do NOT delete dialog inside callback.
-            auto* dialog = new juce::AlertWindow(
-                "Save Preset",
-                "Enter a name for this preset:",
-                juce::MessageBoxIconType::NoIcon,
-                this);
-            dialog->addTextEditor("name", suggestion, "Preset name:");
-            dialog->addButton("Save",   1);
-            dialog->addButton("Cancel", 0);
-
-            dialog->enterModalState(
-                true,
-                juce::ModalCallbackFunction::create(
-                    [safeThis = juce::Component::SafePointer<XOceanusEditor>(this), dialog](int result)
-                    {
-                        if (result != 1 || safeThis == nullptr)
-                            return;
-
-                        const juce::String newName = dialog->getTextEditorContents("name").trim();
-                        if (newName.isEmpty())
-                            return;
-
-                        auto& pm2  = safeThis->processor.getPresetManager();
-                        auto  data = pm2.getCurrentPreset();
-                        data.name  = newName;
-
-                        const auto presetDir =
-                            juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                                .getChildFile("Application Support/XO_OX/XOceanus/Presets");
-                        presetDir.createDirectory();
-                        const auto file = presetDir.getChildFile(data.name + ".xometa");
-
-                        if (pm2.savePresetToFile(file, data))
-                        {
-                            pm2.setCurrentPreset(data);
-                            ToastOverlay::show("Preset saved: " + data.name, Toast::Level::Info);
-                            // Rescan so the new preset appears in the browser immediately.
-                            if (auto* sb = safeThis->oceanView_.getSidebar())
-                                sb->refreshPresetBrowser();
-                        }
-                        else
-                        {
-                            ToastOverlay::show(
-                                "Failed to save preset — check disk space or permissions.",
-                                Toast::Level::Warn);
-                        }
-                    }),
-                true /* deleteWhenDismissed */);
+            // Use the same decision logic as the Cmd+S keyboard handler.
+            switch (getCurrentSaveState())
+            {
+                case SaveState::NoPresetLoaded:
+                    openSavePresetDialog(/*isFirstSave=*/true);
+                    break;
+                case SaveState::LoadedModified:
+                    silentOverwriteCurrentPreset();
+                    break;
+                case SaveState::LoadedUnmodified:
+                    // no-op: nothing changed since last save
+                    break;
+            }
         };
 
         // onFavToggled — toggle favourite status on the current preset and persist.
@@ -1853,6 +1820,8 @@ public:
     {
         stopTimer();
         removeKeyListener(statusBar.getKeyListener());
+        // Issue #1405: Remove APVTS state listener before teardown.
+        processor.getAPVTS().state.removeListener(this);
         // #1356: Unsubscribe from per-slot preset change notifications before teardown.
         processor.removeSlotPresetListener(this);
         processor.onEngineChanged = nullptr; // prevent callback after editor is destroyed
@@ -1957,11 +1926,26 @@ public:
             showOverview();
             return true;
         }
-        // F2-014: Cmd+S — save current preset (mirrors the SAVE button in the sidebar).
+        // Issue #1405: Cmd+S — 3-way state matrix (spec §3 decision Q2).
         if (key == juce::KeyPress('s', juce::ModifierKeys::commandModifier, 0))
         {
-            if (oceanView_.onSavePreset)
-                oceanView_.onSavePreset();
+            switch (getCurrentSaveState())
+            {
+                case SaveState::NoPresetLoaded:
+                    openSavePresetDialog(/*isFirstSave=*/true);
+                    break;
+                case SaveState::LoadedModified:
+                    silentOverwriteCurrentPreset();
+                    break;
+                case SaveState::LoadedUnmodified:
+                    break; // no-op — identical to unmodified state
+            }
+            return true;
+        }
+        // Issue #1405: Cmd+Shift+S — always opens rich dialog (Save As fork).
+        if (key == juce::KeyPress('s', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0))
+        {
+            openSavePresetDialog(/*isFirstSave=*/(getCurrentSaveState() == SaveState::NoPresetLoaded));
             return true;
         }
         // Cmd+Z — undo last parameter change or preset load
@@ -2158,6 +2142,104 @@ public:
     }
 
 private:
+    //==========================================================================
+    // juce::ValueTree::Listener — dirty-flag tracking (issue #1405)
+    //==========================================================================
+
+    void valueTreePropertyChanged(juce::ValueTree&, const juce::Identifier&) override
+    {
+        isDirty_ = true;
+    }
+
+    // Required overrides (no-op for our dirty-tracking use case).
+    void valueTreeChildAdded(juce::ValueTree&, juce::ValueTree&) override {}
+    void valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree&, int) override {}
+    void valueTreeChildOrderChanged(juce::ValueTree&, int, int) override {}
+    void valueTreeParentChanged(juce::ValueTree&) override {}
+
+    //==========================================================================
+    // Save / Save As helpers (issue #1405, TODO #1354)
+    //==========================================================================
+
+    enum class SaveState { NoPresetLoaded, LoadedModified, LoadedUnmodified };
+
+    SaveState getCurrentSaveState() const
+    {
+        const auto& pm = processor.getPresetManager();
+        if (pm.getCurrentPreset().name.isEmpty())
+            return SaveState::NoPresetLoaded;
+        return isDirty_ ? SaveState::LoadedModified : SaveState::LoadedUnmodified;
+    }
+
+    void openSavePresetDialog(bool isFirstSave)
+    {
+        auto& pm = processor.getPresetManager();
+        PresetData initial;
+
+        if (!isFirstSave && !pm.getCurrentPreset().name.isEmpty())
+        {
+            // Save As fork: inherit current preset data, bump name to next available.
+            initial = pm.getCurrentPreset();
+            initial.name = PresetManager::getNextAvailableName(
+                initial.name, PresetManager::getUserPresetDirectory());
+        }
+
+        auto* dialog = new SavePresetDialog(
+            std::move(initial),
+            isFirstSave,
+            [this](PresetData saved)
+            {
+                // Save succeeded: update PresetManager state, clear dirty, toast, close.
+                auto& pm2 = processor.getPresetManager();
+                pm2.setCurrentPreset(saved);
+                isDirty_ = false;
+                ToastOverlay::show("Saved " + saved.name, Toast::Level::Info);
+                // Rescan so the new preset appears in the browser immediately.
+                if (auto* sb = oceanView_.getSidebar())
+                    sb->refreshPresetBrowser();
+                // Close the owning DialogWindow.
+                if (auto* parent = juce::Component::getCurrentlyModalComponent())
+                    parent->exitModalState(0);
+            },
+            []
+            {
+                // Cancel: close the owning DialogWindow.
+                if (auto* parent = juce::Component::getCurrentlyModalComponent())
+                    parent->exitModalState(0);
+            });
+
+        juce::DialogWindow::LaunchOptions opts;
+        opts.content.setOwned(dialog);
+        opts.dialogTitle                = isFirstSave ? "Save Preset" : "Save Preset As...";
+        opts.dialogBackgroundColour     = juce::Colour(GalleryColors::Ocean::twilight);
+        opts.escapeKeyTriggersCloseButton = true;
+        opts.useNativeTitleBar          = false;
+        opts.resizable                  = false;
+        opts.launchAsync();
+    }
+
+    void silentOverwriteCurrentPreset()
+    {
+        auto& pm = processor.getPresetManager();
+        const auto& current = pm.getCurrentPreset();
+        if (current.name.isEmpty()) return; // defensive
+
+        auto target = PresetManager::getUserPresetDirectory()
+                         .getChildFile(current.name + ".xometa");
+
+        PresetManager pmLocal;
+        if (pmLocal.savePresetToFile(target, current))
+        {
+            isDirty_ = false;
+            ToastOverlay::show("Saved " + current.name, Toast::Level::Info);
+        }
+        else
+        {
+            ToastOverlay::show("Save failed — check disk space or permissions.",
+                               Toast::Level::Warn);
+        }
+    }
+
     //==========================================================================
     // XOceanusProcessor::SlotPresetListener (#1356)
     //==========================================================================
@@ -3123,6 +3205,10 @@ private:
     // Last MIDI note number seen (for interval computation in session DNA drift).
     // -1 = no note played yet this session.
     int lastNote_ = -1;
+
+    // ── Save / Save As state (issue #1405) ──────────────────────────────────
+    // true after any parameter change since the last save/load; cleared on save.
+    bool isDirty_ = false;
 
     // Tracks the last known preset library size so we only re-seed preset dots
     // when the library is first populated or changes (e.g. after a background scan).

--- a/Tests/PresetTests/SavePresetDialogTests.cpp
+++ b/Tests/PresetTests/SavePresetDialogTests.cpp
@@ -1,0 +1,125 @@
+/*
+    SavePresetDialog + PresetManager Save-As Tests
+    =================================================
+    Tests for:
+    - PresetManager::getNextAvailableName() - base / (2) / (3) cases
+    - PresetManager::savePresetToFile() collision-check overload
+*/
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "Core/PresetManager.h"
+
+#include <juce_core/juce_core.h>
+
+using namespace xoceanus;
+
+//==============================================================================
+// getNextAvailableName tests
+//==============================================================================
+
+TEST_CASE("PresetManager::getNextAvailableName - returns base name when no collision", "[preset][saveas]")
+{
+    auto tempDir = juce::File::createTempFile("xoceanus_test_dir");
+    tempDir.deleteFile();
+    tempDir.createDirectory();
+
+    auto result = PresetManager::getNextAvailableName("My Preset", tempDir);
+    CHECK(result == "My Preset");
+
+    tempDir.deleteRecursively();
+}
+
+TEST_CASE("PresetManager::getNextAvailableName - appends (2) when base exists", "[preset][saveas]")
+{
+    auto tempDir = juce::File::createTempFile("xoceanus_test_dir");
+    tempDir.deleteFile();
+    tempDir.createDirectory();
+
+    tempDir.getChildFile("My Preset.xometa").create();
+    auto result = PresetManager::getNextAvailableName("My Preset", tempDir);
+    CHECK(result == "My Preset (2)");
+
+    tempDir.deleteRecursively();
+}
+
+TEST_CASE("PresetManager::getNextAvailableName - skips to (3) when (2) also exists", "[preset][saveas]")
+{
+    auto tempDir = juce::File::createTempFile("xoceanus_test_dir");
+    tempDir.deleteFile();
+    tempDir.createDirectory();
+
+    tempDir.getChildFile("My Preset.xometa").create();
+    tempDir.getChildFile("My Preset (2).xometa").create();
+    auto result = PresetManager::getNextAvailableName("My Preset", tempDir);
+    CHECK(result == "My Preset (3)");
+
+    tempDir.deleteRecursively();
+}
+
+//==============================================================================
+// savePresetToFile overwrite-confirm overload tests
+//==============================================================================
+
+TEST_CASE("PresetManager::savePresetToFile - confirm callback not invoked when no collision", "[preset][saveas]")
+{
+    auto tempDir = juce::File::createTempFile("xoceanus_test_dir");
+    tempDir.deleteFile();
+    tempDir.createDirectory();
+
+    auto target = tempDir.getChildFile("test.xometa");
+    PresetData data;
+    data.name = "test";
+    data.schemaVersion = 2;
+    data.mood = "Foundation";
+    data.engines.add("OddfeliX");
+    data.macroLabels.add("CHARACTER");
+    data.macroLabels.add("MOVEMENT");
+    data.macroLabels.add("COUPLING");
+    data.macroLabels.add("SPACE");
+    data.parametersByEngine["OddfeliX"] = juce::var(new juce::DynamicObject());
+
+    bool confirmCalled = false;
+    PresetManager pm;
+    auto result = pm.savePresetToFile(target, data,
+        [&](juce::File) { confirmCalled = true; return true; });
+
+    CHECK(result == true);
+    CHECK(confirmCalled == false); // no collision -> callback not invoked
+    CHECK(target.existsAsFile());
+
+    tempDir.deleteRecursively();
+}
+
+TEST_CASE("PresetManager::savePresetToFile - aborts save when confirm returns false", "[preset][saveas]")
+{
+    auto tempDir = juce::File::createTempFile("xoceanus_test_dir");
+    tempDir.deleteFile();
+    tempDir.createDirectory();
+
+    auto target = tempDir.getChildFile("test.xometa");
+    // Create a file that will be the "collision"
+    target.replaceWithText("{\"schema_version\":1,\"name\":\"original\"}");
+
+    PresetData data;
+    data.name = "test";
+    data.schemaVersion = 2;
+    data.mood = "Foundation";
+    data.author = "agent-test"; // marker we can verify is NOT written
+    data.engines.add("OddfeliX");
+    data.macroLabels.add("CHARACTER");
+    data.macroLabels.add("MOVEMENT");
+    data.macroLabels.add("COUPLING");
+    data.macroLabels.add("SPACE");
+    data.parametersByEngine["OddfeliX"] = juce::var(new juce::DynamicObject());
+
+    PresetManager pm;
+    auto result = pm.savePresetToFile(target, data,
+        [](juce::File) { return false; });
+
+    CHECK(result == false);
+    // File should be unchanged (still has "original", not "agent-test")
+    CHECK(!target.loadFileAsString().contains("agent-test"));
+
+    tempDir.deleteRecursively();
+}


### PR DESCRIPTION
## Summary

Implements the rich Save / Save As preset dialog per design spec at `Docs/plans/2026-05-04-save-as-design.md`, closing `TODO(#1354)` and resolving GitHub issue #1405.

- **`Cmd+S`** — 3-way state matrix: rich dialog on fresh state, silent overwrite on modified loaded preset, no-op on unmodified
- **`Cmd+Shift+S`** — always opens rich dialog (Save As fork with `(2)` auto-number)
- **Required fields**: Name + Mood; **Optional**: Category, Tags, Description
- **Auto-numbering**: `getNextAvailableName()` returns `"My Preset (2)"` etc. on dialog open
- **Collision-confirm**: async `AlertWindow` when user manually types an existing name
- **Modal form factor**: submarine-themed via `GalleryColors::Ocean::*` + `XO::Tokens::Color::*` (no new tokens introduced)
- `MoodDropdownLookAndFeel` exposed as public nested class for reuse by #1428 ChainMatrix

## Spec

`Docs/plans/2026-05-04-save-as-design.md` — all 5 locked decisions implemented:
- Q1: Split Save / Save As ✓
- Q2: Cmd+S state matrix ✓
- Q3: Name + Mood required, others optional ✓
- Q4: Auto-number `(2)` + collision-confirm ✓
- Q5: Modal form factor + mood swatches ✓

## Files changed

- **NEW** `Source/UI/Ocean/SavePresetDialog.h` (~350 lines: Component + MoodDropdownLookAndFeel)
- **MOD** `Source/Core/PresetManager.h` (~55 lines: `getNextAvailableName`, `savePresetToFile` overload, `getUserPresetDirectory`)
- **MOD** `Source/UI/XOceanusEditor.h` (~120 added, -59 removed: state matrix, helpers, dirty tracking)
- **NEW** `Tests/PresetTests/SavePresetDialogTests.cpp` (5 Catch2 tests)
- **MOD** `CMakeLists.txt` (1 line: add test file to XOceanusTests)

## Adaptations from plan (documented inline)

| Plan assumption | Reality | Resolution |
|---|---|---|
| `juce::UnitTest` test framework | Project uses Catch2 v3 | Rewrote tests in Catch2 |
| `Tokens::Submarine::PanelBg` | Doesn't exist; closest is `GalleryColors::Ocean::twilight` | Used Ocean palette directly |
| `savePresetToFile` is static | Is non-static member | Tests use PresetManager instance |
| `isFirstSave_` stored in dialog | Not needed (caller sets LaunchOptions.dialogTitle) | Parameter kept in signature but comment-suppressed |

## Validation

- [x] 5 Catch2 tests PASS (`[saveas]` tag) — `getNextAvailableName` + `savePresetToFile` overload
- [x] Debug build GREEN: `XOceanus_Standalone`, `XOceanus_AU`, `XOceanusTests`
- [x] Release build GREEN: `XOceanus_AU`
- [x] `auval -v aumu Xocn XoOx` → **AU VALIDATION SUCCEEDED**
- [x] Sentinel: `strings <binary> | grep "Overwrite preset"` matches in Release AU binary
- [ ] Manual smoke test: deferred to user (see below)

## Manual smoke test plan

Run in order on the Standalone app:
1. **Fresh state Cmd+S** → rich dialog opens, all fields blank. Type name, select Mood "Foundation", click Save → toast "Saved {name}", file exists at `~/Library/Application Support/XO_OX/XOceanus/Presets/{name}.xometa`
2. **Loaded modified Cmd+S** → tweak any knob, Cmd+S → no dialog, toast "Saved {name}", file mtime updates
3. **Loaded unmodified Cmd+S** → without touching knobs, Cmd+S → no dialog, no toast, mtime unchanged
4. **Cmd+Shift+S on loaded preset** → rich dialog opens, name pre-filled "{parent} (2)", mood inherited. Click Save → both files exist
5. **Collision-confirm** → Cmd+Shift+S, type an existing preset name in Name field, click Save → "Overwrite?" dialog appears. Cancel → dialog stays open with name preserved. Save again → Overwrite → file replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)