### PR TITLE
arch(#1184): Phase 4 — drop selectedSlot mirror, read from StateMachine directly

### DIFF
--- a/Source/UI/Ocean/OceanLayout.h
+++ b/Source/UI/Ocean/OceanLayout.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 XO_OX Designs
 #pragma once
-// OceanLayout.h  —  Phase 2 + 2.5 of the OceanView decomposition (issue #1184).
+// OceanLayout.h  —  Phase 2 + 2.5 + 4 of the OceanView decomposition (issue #1184).
 //
 // OceanLayout owns all geometry/layout logic that previously lived directly in
 // OceanView.  It holds references to every component it must position — no
@@ -9,7 +9,7 @@
 //
 // Construction
 // ────────────
-//   OceanLayout layout_{children_, /* LayoutTargets */ { ..., selectedSlot_, detailShowing_, firstLaunch_ }};
+//   OceanLayout layout_{children_, /* LayoutTargets */ { ..., stateMachine_, detailShowing_, firstLaunch_ }};
 //
 //   OceanView::resized() becomes:
 //     layout_.layoutForState(viewState_, getLocalBounds());
@@ -22,13 +22,11 @@
 //   - LayoutTargets members are plain Component& / Component* references; they
 //     are never used to call back into OceanView — only setBounds/setVisible/
 //     toFront.
-//   - LayoutTargets also holds const-ref bindings to the three layout-input state
-//     members (selectedSlot, detailShowing, firstLaunch) added in Phase 2.5.
+//   - LayoutTargets holds const-ref bindings to layout-input state: detailShowing,
+//     firstLaunch (Phase 2.5), and stateMachine (Phase 4 — replaces selectedSlot_
+//     mirror; layout reads selectedSlot() directly from the state machine).
 //   - All geometry constants (kDashboardH, kStatusBarH, etc.) duplicated here
 //     for now; Phase 3 should consolidate them into a shared constants header.
-//
-// Phase 3 will extract OceanStateMachine.  At that point the `viewState_`
-// placeholder in layoutForState() will be replaced by a stateMachine_ query.
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "OceanLayoutConstants.h"
@@ -121,8 +119,9 @@ struct LayoutTargets
     SurfaceRightPanel&              surfaceRight;
 
     // Phase 2.5 (#1184): layout-input state — const refs to OceanView members.
-    // Removed from layoutForState() per-call args; now read directly from here.
-    const int&              selectedSlot;    ///< OceanView::selectedSlot_
+    // Phase 4 (#1184): selectedSlot_ mirror dropped; layout reads selectedSlot()
+    // directly from OceanStateMachine via the stateMachine const-ref below.
+    const OceanStateMachine& stateMachine;   ///< reads selectedSlot(), currentState()
     const bool&             detailShowing;   ///< OceanView::detailShowing_
     const bool&             firstLaunch;     ///< OceanView::firstLaunch_
     // D5 (1D-P2B): canonical tab state — source of truth for keyboard visibility.
@@ -442,7 +441,7 @@ private:
 
     void layoutZoomIn(juce::Rectangle<int> fullBounds)
     {
-        const int  selectedSlot  = targets_.selectedSlot;
+        const int  selectedSlot  = targets_.stateMachine.selectedSlot();
         const bool detailShowing = targets_.detailShowing;
         jassert(selectedSlot >= 0 && selectedSlot < 5);
 
@@ -522,7 +521,7 @@ private:
 
     void layoutSplitTransform(juce::Rectangle<int> fullBounds)
     {
-        const int selectedSlot = targets_.selectedSlot;
+        const int selectedSlot = targets_.stateMachine.selectedSlot();
         jassert(selectedSlot >= 0 && selectedSlot < 5);
 
         // Step 6: use computeOceanArea() so background/ambient edge stay within the

--- a/Source/UI/Ocean/OceanView.h
+++ b/Source/UI/Ocean/OceanView.h
@@ -754,8 +754,8 @@ public:
                 exprStrips_,
                 subPlaySurface_,
                 surfaceRight_,
-                // Phase 2.5 (#1184): layout-input state bindings (const-ref).
-                selectedSlot_,
+                // Phase 4 (#1184): stateMachine const-ref replaces selectedSlot_ mirror.
+                stateMachine_,
                 detailShowing_,
                 firstLaunch_,
                 // D5 (1D-P2B): canonical tab state for keyboard visibility.
@@ -764,15 +764,8 @@ public:
 
         // ── Phase 3 (#1184): wire OceanStateMachine callbacks ────────────────
         // onStateEntered: a completed transition triggers layout + repaint.
-        // Also syncs OceanView's mirror fields (viewState_, selectedSlot_) so
-        // any remaining OceanView code that still reads them is consistent.
-        // Step 9 removes the mirror fields; until then keep them in sync here.
         stateMachine_.onStateEntered = [this](OceanStateMachine::ViewState s)
         {
-            // Sync selectedSlot_ mirror (removed in step 9 final cleanup).
-            // viewState_ mirror removed in step 9 — read stateMachine_.currentState() instead.
-            selectedSlot_ = stateMachine_.selectedSlot();
-
             jassert(layout_ != nullptr);
             layout_->layoutForState(s, getLocalBounds(), 1.0f);
             layout_->reorderZStack();
@@ -1366,9 +1359,9 @@ public:
 
         // Fix #1005 (callAsync race): only reset view state if we are currently
         // zoomed into THIS slot.  If the user has already double-clicked into a
-        // different slot (selectedSlot_ != slot) or returned to Orbital between
-        // when the engine removal was queued and when this runs, do not clobber
-        // the new state.  Only ZoomIn / SplitTransform warrant a reset.
+        // different slot or returned to Orbital between when the engine removal
+        // was queued and when this runs, do not clobber the new state.
+        // Only ZoomIn / SplitTransform warrant a reset.
         const bool slotIsSelected = (stateMachine_.selectedSlot() == slot);
         const bool inEngagedState = (stateMachine_.currentState() == ViewState::ZoomIn ||
                                      stateMachine_.currentState() == ViewState::SplitTransform);
@@ -2324,7 +2317,7 @@ private:
                         // Force-select the target slot (no toggle) so the drawer
                         // replacement lands on the correct slot even if it was
                         // already selected before the right-click.
-                        selectedSlot_ = slot;
+                        stateMachine_.setSelectedSlot(slot);
                         for (int i = 0; i < 5; ++i)
                             orbits_[i].setSelected(i == slot);
                         if (onEngineSelected)
@@ -2488,7 +2481,7 @@ private:
                         // that slot so the drawer's engine-selected callback lands there.
                         if (slot >= 0 && slot < 5)
                         {
-                            selectedSlot_ = slot;
+                            stateMachine_.setSelectedSlot(slot);
                             for (int i = 0; i < 5; ++i)
                                 orbits_[i].setSelected(i == slot);
                             if (onEngineSelected)
@@ -2687,7 +2680,6 @@ private:
         // Toggle: clicking the already-selected orbit deselects it.
         if (stateMachine_.selectedSlot() == slot)
         {
-            selectedSlot_ = -1;                    // mirror (Phase 3; removed in step 9)
             stateMachine_.setSelectedSlot(-1);
             for (auto& o : orbits_)
                 o.setSelected(false);
@@ -2696,7 +2688,6 @@ private:
             return;
         }
 
-        selectedSlot_ = slot;                      // mirror (Phase 3; removed in step 9)
         stateMachine_.setSelectedSlot(slot);
         for (int i = 0; i < 5; ++i)
             orbits_[i].setSelected(i == slot);
@@ -3162,10 +3153,8 @@ private:
     //==========================================================================
 
     // Phase 3 (#1184): viewState_ removed — canonical state lives in stateMachine_.
-    // selectedSlot_ is kept as a mirror for LayoutTargets (const int& binding);
-    // it is updated in onStateEntered + selectOrbitInPlace.
-    // Step 9 will remove selectedSlot_ once LayoutTargets binds to stateMachine_ directly.
-    int       selectedSlot_    = -1;
+    // Phase 4 (#1184): selectedSlot_ mirror removed — LayoutTargets now holds a
+    // const OceanStateMachine& and reads selectedSlot() directly.
 
     /// Per-slot mute / solo toggle state — tracked locally so the context menu
     /// label can reflect the current state without a round-trip to the processor.


### PR DESCRIPTION
## Summary

Phase 4 of the OceanView decomposition (issue #1184), deferred from PR #1348.

- **Removes `selectedSlot_` mirror field from OceanView** — the last mirror field that `LayoutTargets` was bound to via `const int&`.
- **`LayoutTargets::selectedSlot` → `stateMachine`** — field type changes from `const int&` to `const OceanStateMachine&`, so `OceanLayout` reads slot state directly from the state machine.
- All layout reads updated: `targets_.selectedSlot` → `targets_.stateMachine.selectedSlot()` in `layoutZoomIn` and `layoutSplitTransform`.
- Mirror sync removed from `onStateEntered` callback.
- Two popup-menu direct writes (`selectedSlot_ = slot`) replaced with `stateMachine_.setSelectedSlot(slot)`.
- Mirror lines dropped from `selectOrbitInPlace`.
- `int selectedSlot_` member declaration removed.

## References

- Closes Phase 4 of #1184
- Deferred from #1348 (Phase 3) — see that PR's "Deliberate deviations" section
- Phase 4 cleanup work flagged in `OceanStateMachine.h` header comment ("Phase 4 cleanup candidates")

## Test plan

- [ ] `cmake --build build --target XOceanus_AU -j4` — exits 0
- [ ] Load plugin in AU host; verify Orbital → ZoomIn → SplitTransform → BrowserOpen transitions work
- [ ] Verify right-click "Replace engine" on a loaded orbit pre-selects correct slot for drawer
- [ ] Verify right-click on empty orbit pre-selects correct slot for drawer
- [ ] Verify Tab/arrow key selection in Orbital mode (selectOrbitInPlace toggle behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcdyPcDDSqp5jxDA3Gk3e4)_