### PR TITLE
fix(Oort): DC blocker pole topology — 19e45f9ed regression

### DIFF
--- a/Source/Engines/Oort/OortEngine.h
+++ b/Source/Engines/Oort/OortEngine.h
@@ -1371,7 +1371,10 @@ private:
                     // tracks correctly at 48 kHz (0.99935) and 96 kHz (0.99967).
                     // Was constexpr 0.9997f which gave ~6.7 Hz at 44.1 kHz but ~13.4 Hz
                     // at 96 kHz due to sample count difference.
-                    const float dcCoeff = 1.0f - fastExp(-kOortTwoPi * 5.0f / sampleRateFloat);
+                    // Topology: y = x - x_prev + R·y_prev (standard DC blocker).
+                    // Pole R = exp(-2π·fc/sr). 19e45f9ed used 1-exp(...) which is the
+                    // leaky-integrator forward coeff — wrong form, pole sat near DC (~0.000713).
+                    const float dcCoeff = fastExp(-kOortTwoPi * 5.0f / sampleRateFloat);
                     const float dcOut = sig - v.dcBlockX + dcCoeff * v.dcBlockY;
                     v.dcBlockX = sig;
                     v.dcBlockY = flushDenormal(dcOut);


### PR DESCRIPTION
## Summary

Commit `19e45f9ed` introduced a topology mismatch in Oort's DC blocker by applying the leaky-integrator forward coefficient formula to the standard DC blocker topology.

**Before:** `R = 1 - fastExp(-2π·fc/sr)` → pole ≈ 0.000713 at 44.1kHz/5Hz (near DC → near-differentiator behavior)
**After:** `R = fastExp(-2π·fc/sr)` → pole ≈ 0.99929 at 44.1kHz/5Hz (correct near-unity HP pole)

**Topology confirmed:** `y = x - x_prev + R·y_prev` (standard DC blocker) — the comment block on lines 1371-1373 already cited correct expected values (0.99935 at 48kHz, 0.99967 at 96kHz) which match `exp(...)`, not `1 - exp(...)`.

**Why masked:** `oort_dcBlock` is a user-visible on/off parameter (defaults On in preset code), so the audible effect depended on whether the user had DC blocking enabled. With the broken pole the filter heavily differentiated the signal rather than blocking DC.

**`reset()` check (per `feedback-clobber-on-reset-bug-pattern.md`):** `dcBlockX`/`dcBlockY` state variables reset to `0.0f` — correct, no coefficient value is stored in state.

Discovered during P31a Euler IIR sweep (PR #1530), which noted the Oort regression but fixed only the 4 other engines in scope.

## Files changed

- `Source/Engines/Oort/OortEngine.h` — 1 line fix + 3 lines explanatory comment (line 1374→1377)

## Validation

- `cmake -B build-oort -G Ninja -DCMAKE_BUILD_TYPE=Release` ✓
- `cmake --build build-oort --target XOceanus_AU` ✓ (0 errors)
- `auval -v aumu Xocn XoOx` → **AU VALIDATION SUCCEEDED** ✓

## Context

- Reference: P31a sweep PR #1530
- Topology reference: catalog #1 (Smith DSP, matched-Z derivation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)