### PR TITLE
chore: ignore .wt/ ad-hoc worktree dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ build_verify/
 
 # Preset backfill artifact (generated, not source)
 Docs/fleet-audit/instrument-taxonomy-proposal.csv
+.wt/


### PR DESCRIPTION
Day 5 housekeeping carry-over. Adds `.wt/` to `.gitignore` so ad-hoc worktree directories created during impl dispatches don't show up in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)