### PR TITLE
feat(abcompare): #25 A/B diff overlay — amber rings on changed knobs

### DIFF
--- a/Source/UI/Gallery/ABCompare.h
+++ b/Source/UI/Gallery/ABCompare.h
@@ -218,6 +218,20 @@ private:
     {
         dest.reset();
         processor.getStateInformation(dest);
+
+        // #25 Q1-D: parallel float snapshot of all APVTS params for diff overlay.
+        captureFloatSnapshot(&dest == &stateA ? snapshotA : snapshotB);
+    }
+
+    // #25 Q1-D snapshot of all APVTS raw param values.  Snapshots ALL params
+    // (not just visible) so the B-state preset-load case where active engine
+    // changes between A and B still produces a correct diff.
+    void captureFloatSnapshot(std::vector<std::pair<juce::String, float>>& dest)
+    {
+        dest.clear();
+        for (auto* p : processor.getParameters())
+            if (auto* withId = dynamic_cast<juce::AudioProcessorParameterWithID*>(p))
+                dest.emplace_back(withId->paramID, withId->getValue());
     }
 
     void restoreState(const juce::MemoryBlock& src)
@@ -232,7 +246,17 @@ private:
         showingA = true;
         stateA.reset();
         stateB.reset();
+        snapshotA.clear();
+        snapshotB.clear();
     }
+
+public:
+    // #25 Q1-D accessors — read by editor on A/B toggle to dispatch diff highlights.
+    const std::vector<std::pair<juce::String, float>>& getSnapshotA() const noexcept { return snapshotA; }
+    const std::vector<std::pair<juce::String, float>>& getSnapshotB() const noexcept { return snapshotB; }
+    bool hasBothSnapshots() const noexcept { return !snapshotA.empty() && !snapshotB.empty(); }
+
+private:
 
     //==========================================================================
     // Draw a single A or B button tile.
@@ -329,6 +353,10 @@ private:
 
     juce::MemoryBlock stateA; // captured processor state for slot A
     juce::MemoryBlock stateB; // captured processor state for slot B
+
+    // #25 Q1-D: parallel float snapshots — (paramID, normalised value) for every APVTS param.
+    std::vector<std::pair<juce::String, float>> snapshotA;
+    std::vector<std::pair<juce::String, float>> snapshotB;
 
     juce::Rectangle<float> btnABounds;
     juce::Rectangle<float> btnBBounds;

--- a/Source/UI/Gallery/EngineDetailPanel.h
+++ b/Source/UI/Gallery/EngineDetailPanel.h
@@ -457,6 +457,51 @@ public:
             grid->scrollToSection(s);
     }
 
+    // #25 A/B compare diff dispatch — called by editor on A/B toggle.
+    // Walks the (paramID, valueA, valueB) tuples and pushes diff state to
+    // the corresponding GalleryKnob in the active ParameterGrid.  Knobs not
+    // currently visible are silently skipped (next loadSlot() will reset).
+    // Snapshots are aligned by APVTS iteration order (deterministic), so we
+    // can do a parallel walk; for safety we also linear-scan B if a paramID
+    // mismatch occurs (preset load between A and B may reorder).
+    void applyABDiff(const std::vector<std::pair<juce::String, float>>& snapA,
+                     const std::vector<std::pair<juce::String, float>>& snapB)
+    {
+        auto* grid = dynamic_cast<ParameterGrid*>(viewport.getViewedComponent());
+        if (!grid)
+            return;
+        constexpr float kDiffThreshold = 0.005f;
+        grid->clearAllDiffRings();
+        for (size_t i = 0; i < snapA.size(); ++i)
+        {
+            const auto& [pid, aVal] = snapA[i];
+            // Fast path: parallel index match (snapshots aligned by APVTS order).
+            float bVal = 0.0f;
+            bool found = false;
+            if (i < snapB.size() && snapB[i].first == pid)
+            {
+                bVal  = snapB[i].second;
+                found = true;
+            }
+            else
+            {
+                for (const auto& [bpid, bv] : snapB)
+                    if (bpid == pid) { bVal = bv; found = true; break; }
+            }
+            if (!found)
+                continue;
+            if (std::abs(aVal - bVal) > kDiffThreshold)
+                if (auto* knob = grid->findKnobForParam(pid))
+                    knob->setDiffActive(true, aVal, bVal);
+        }
+    }
+
+    void clearABDiff()
+    {
+        if (auto* grid = dynamic_cast<ParameterGrid*>(viewport.getViewedComponent()))
+            grid->clearAllDiffRings();
+    }
+
     // Callback: fired when the back button is clicked. Parent should hide this panel.
     std::function<void()> onBackClicked;
 

--- a/Source/UI/Gallery/GalleryKnob.h
+++ b/Source/UI/Gallery/GalleryKnob.h
@@ -90,6 +90,38 @@ public:
         setBadgeRoutes({});
     }
 
+    // #25 A/B diff overlay — amber glow ring outside knob track when this
+    // knob's value differs between captured A and B states.  Q3-A primary
+    // path; Q3-C fallback (fill tint) is N/A here because GalleryKnob has
+    // 3px outer margin (see drawMidiLearnOverlay's b.reduced(3.0f)) — the
+    // diff ring fits between the knob body and the bounding rect.
+    //
+    //   active — true iff |A-B| > diff threshold (0.005).
+    //   aVal / bVal — raw param values for hover tooltip ("A: 0.42 / B: 0.78").
+    //
+    // Threshold and snapshot capture happen in EngineDetailPanel; this API
+    // is a pure paint-state setter.
+    void setDiffActive(bool active, float aVal = 0.0f, float bVal = 0.0f)
+    {
+        auto& props = getProperties();
+        const bool wasActive = (bool) props["diffActive"];
+        if (active != wasActive
+            || (float) props["diffAVal"] != aVal
+            || (float) props["diffBVal"] != bVal)
+        {
+            props.set("diffActive", active);
+            props.set("diffAVal",   aVal);
+            props.set("diffBVal",   bVal);
+            const juce::String tip = active
+                ? juce::String("A: ") + juce::String(aVal, 3) + "  B: " + juce::String(bVal, 3)
+                : juce::String();
+            setTooltip(tip);
+            repaint();
+        }
+    }
+
+    void clearDiff() { setDiffActive(false); }
+
     // Wire up MIDI Learn for this knob.  Call after SliderAttachment is created.
     // The caller must store the returned listener pointer in a unique_ptr vector.
     MidiLearnMouseListener* setupMidiLearn(const juce::String& pid, MIDILearnManager& mgr)
@@ -159,6 +191,7 @@ public:
     {
         juce::Slider::paint(g);
         drawMidiLearnOverlay(g);
+        drawABDiffRing(g);
     }
 
 private:
@@ -196,6 +229,18 @@ private:
             g.setColour(juce::Colour(0xFF4ADE80).withAlpha(0.70f));
             g.drawText("ML", b.getRight() - 16, b.getBottom() - 12, 14, 11, juce::Justification::centred);
         }
+    }
+
+    // #25: A/B diff amber ring — paints OUTSIDE the MIDI-learn ring at b.reduced(2.0f)
+    // (1px tighter than MIDI learn's 3px to ensure no overlap when both are active).
+    void drawABDiffRing(juce::Graphics& g)
+    {
+        if (! (bool) getProperties()["diffActive"])
+            return;
+        auto b = getLocalBounds().toFloat().reduced(2.0f);
+        const float r = juce::jmin(b.getWidth(), b.getHeight()) * 0.5f;
+        g.setColour(juce::Colour(GalleryColors::xoGold).withAlpha(0.85f)); // Tokens::Color::Warning
+        g.drawEllipse(b.getCentreX() - r, b.getCentreY() - r, r * 2.0f, r * 2.0f, 2.0f);
     }
 
     double defaultValue = 0.0;

--- a/Source/UI/Gallery/ParameterGrid.h
+++ b/Source/UI/Gallery/ParameterGrid.h
@@ -327,6 +327,16 @@ public:
                 lk->knob->clearBadgeRoutes();
     }
 
+    // #25 A/B diff: clear amber diff rings on every live knob in this grid.
+    // Called from EngineDetailPanel::applyABDiff() before re-applying, and on
+    // A/B mode exit / loadSlot().
+    void clearAllDiffRings()
+    {
+        for (auto& lk : liveKnobs)
+            if (lk && lk->knob)
+                lk->knob->clearDiff();
+    }
+
     // ── Flat mode — suppresses section headers and collapse behavior ────────
     // Used by the submarine detail panel for a continuous 4-column knob grid.
     void setFlatMode(bool flat)

--- a/Source/UI/XOceanusEditor.h
+++ b/Source/UI/XOceanusEditor.h
@@ -1175,6 +1175,9 @@ public:
         oceanView_.onABCompareToggled = [this](bool active)
         {
             abCompare.setABActive(active);
+            // #25: diff visualization — push amber rings on changed knobs.
+            // On exit (active=false), ABCompare clears its snapshots → diff also clears.
+            dispatchABCompareDiff();
         };
 
         // F3-006: Persist REACT dial level so it survives DAW session reload.
@@ -2255,6 +2258,21 @@ private:
         jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
         oceanView_.setOrbitPresetName(slotIdx, preset.name);
         abCompare.onPresetLoaded(); // F3-001: capture new state into B slot
+        // #25: now that B is captured, refresh the diff overlay.
+        dispatchABCompareDiff();
+    }
+
+    // #25 A/B diff dispatch — pushes diff rings to the EngineDetailPanel based
+    // on ABCompare's current snapshot pair.  No-op when A/B mode is off or
+    // either snapshot is empty.
+    void dispatchABCompareDiff()
+    {
+        if (!abCompare.isActive() || !abCompare.hasBothSnapshots())
+        {
+            detail.clearABDiff();
+            return;
+        }
+        detail.applyABDiff(abCompare.getSnapshotA(), abCompare.getSnapshotB());
     }
 
     // ── Cmd+K Command Palette lifecycle (#22) ────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the diff visualization layer for #25 (IL-5: A/B compare with diff highlight) per the locked design in #1536 (merged earlier today).

## Decisions implemented

| Q | Decision | Status |
|---|----------|--------|
| Q1 — Diff scope | **D** — On-screen float snapshots via APVTS iteration | shipped |
| Q2 — Diff trigger | **B** — Snapshot diff on A/B toggle (no live timer) | shipped |
| Q3 — Diff visualization | **A** — Amber glow ring 2px outside knob track | shipped |
| Q4 — A vs B mutability | **A** — A=reference, B=comparison fixed | shipped (no UI changes) |
| Q5 — Persistence | **B** — DAW-session persistence | DEFERRED to V1.1 #1537 |

## Geometry audit (Q3-A → Q3-C fallback)

GalleryKnob has 3px outer margin (\`drawMidiLearnOverlay\` uses \`b.reduced(3.0f)\`). The diff ring uses \`b.reduced(2.0f)\` — 1px tighter than MIDI learn to ensure no overlap when both are active. **Q3-A (glow ring) feasible — Q3-C fallback NOT required.**

## Q5 deferred to V1.1 — issue #1537

Adding the schema-bumped \`<ABCompareState/>\` child + base64 blob storage was estimated at ~25 additional lines, taking the total over the 125-line cap.

Per Day 5 lesson #4 (framework hardcodes signal V1.1 widen, not V1 fix-pass), shipping V1 with session-only A/B states (current behavior) and filing the persistence widen as #1537.

## Diff stats

- Brainstorm estimate: 50–100 lines
- Cap (× 1.25): 125 lines
- **Actual: 146 lines** (17% over) — caused by per-file boilerplate (member declarations, public/private visibility re-anchors, doc comments). With Q5 deferred, the impl scope matches the original brainstorm intent of "diff highlight only".

| File | Lines | Role |
|------|-------|------|
| \`Source/UI/Gallery/GalleryKnob.h\` | +45 | \`setDiffActive()\` API + \`drawABDiffRing()\` |
| \`Source/UI/Gallery/EngineDetailPanel.h\` | +45 | \`applyABDiff()\` / \`clearABDiff()\` dispatch |
| \`Source/UI/Gallery/ABCompare.h\` | +28 | Float snapshot capture + accessors |
| \`Source/UI/XOceanusEditor.h\` | +18 | \`dispatchABCompareDiff()\` wire-up |
| \`Source/UI/Gallery/ParameterGrid.h\` | +10 | \`clearAllDiffRings()\` |

## Verification

- cmake Release build green on macOS universal (x86_64 + arm64)
- auval validation PASSED (full sample-rate matrix internally tested)
- Binary sentinel — \`nm\` confirms 4 new symbols baked into AU bundle
- Zero new compiler warnings (the 12 \`-Wunused-parameter\` warnings shown in build output are all in existing engines, not touched by this PR)

## Smoke test script

1. Load any preset
2. Click **A** → captures stateA + snapshotA
3. Tweak 4 knobs in the Engine Detail panel
4. Load a different preset (or click B if already stored) → captures stateB + snapshotB
5. **Expected**: amber rings appear on the 4 tweaked knobs (any param whose normalised |A − B| > 0.005)
6. **Hover** any ringed knob → tooltip shows \`A: 0.xxx  B: 0.xxx\`
7. Click currently-active button (A or B) → A/B mode exits, all rings clear
8. Switch engine slot → fresh knob set, no rings

## Test plan

- [ ] Functional smoke test (steps above)
- [ ] No clipping at the ring overlay boundary on small/large knob sizes
- [ ] No tooltip leak after exiting A/B mode
- [ ] Loading a preset that doesn't change a knob → no ring on that knob

🤖 Generated with [Claude Code](https://claude.com/claude-code)