### PR TITLE
chore(v1): cull addendum — Ogive + Outlook to V1.1 (triage regen)

### DIFF
--- a/Docs/engines.json
+++ b/Docs/engines.json
@@ -321,7 +321,9 @@
       "status": "implemented",
       "accent_color": "#9B1B30",
       "category": "cathedral",
-      "accent_name": "Selenium Ruby"
+      "accent_name": "Selenium Ruby",
+      "v1": false,
+      "v1_deferral_reason": "unseanced cathedral engine; 0 presets and no upstream artifacts for confident V1 preset fill (Day 8 cull addendum, 2026-05-09)"
     },
     {
       "id": "Ogre",
@@ -937,7 +939,9 @@
       "header": "Source/Engines/Outlook/OutlookEngine.h",
       "status": "implemented",
       "accent_color": "#4169E1",
-      "category": "visionary"
+      "category": "visionary",
+      "v1": false,
+      "v1_deferral_reason": "estimated seance ~7.1 (not formally validated); 0 presets — insufficient character anchor for confident V1 preset fill (Day 8 cull addendum, 2026-05-09)"
     },
     {
       "id": "Outcrop",


### PR DESCRIPTION
## Summary

Two engines missed in the original Day 8 cull PR #1543 are marked `v1: false` and deferred to V1.1, following 2026-05-09 triage regen.

**V1 fleet: 74 → 72 engines.**

## Deferred engines (2)

| Engine | Rationale |
|--------|-----------|
| Ogive | Unseanced cathedral engine; 0 presets and no upstream artifacts for confident V1 preset fill (ALERT-3) |
| Outlook | Estimated seance ~7.1 (not formally validated); 0 presets — insufficient character anchor for confident V1 preset fill (ALERT-4) |

## Source

Triage regen 2026-05-09, ALERT-3 and ALERT-4 in:
`~/.claude/projects/-Users-joshuacramblet/memory/triage-preset-floor-2026-05-07.md`

## V1.1 issues

- #1554 — [V1.1] Re-seance + preset fill: Ogive
- #1555 — [V1.1] Re-seance + preset fill: Outlook

## Closes

Closes: #1554, #1555.

## Checklist

- [x] `engines.json` shows `v1: false` for Ogive and Outlook
- [x] Both engines retain `status: "implemented"` (built, not removed)
- [x] Opera NOT touched (separate Day 9 decision)
- [x] No engine source code (DSP) touched
- [x] No preset files touched
- [x] The 10 engines already culled by #1543 NOT modified
- [x] 2 V1.1 issues filed (#1554, #1555)