### PR TITLE
fix(v1): Day 8 Phase 1 — Ogre/Otis seance fixes + macro-init bundle

### DIFF
--- a/Presets/XOceanus/Aether/Ogre/Ogre_Seismic_Event.xometa
+++ b/Presets/XOceanus/Aether/Ogre/Ogre_Seismic_Event.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "OGRE — cinematic sub event. Maximum gravity, extreme tectonic depth, slow attack. A rumble, not a bass line.",
+  "description": "OGRE \u2014 cinematic sub event. Maximum gravity, maximum tectonic depth (20 cents), slow attack, vast space.",
   "dna": {
     "brightness": 0.06,
     "warmth": 0.9,
@@ -34,7 +34,7 @@
       "ogre_density": 0.7,
       "ogre_soil": 0.2,
       "ogre_tectonicRate": 0.003,
-      "ogre_tectonicDepth": 45.0,
+      "ogre_tectonicDepth": 20.0,
       "ogre_attack": 0.1,
       "ogre_decay": 4.0,
       "ogre_sustain": 0.7,

--- a/Presets/XOceanus/Aether/Otis/Otis_Steam_Ghost.xometa
+++ b/Presets/XOceanus/Aether/Otis/Otis_Steam_Ghost.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Calliope at near-zero instability — steam pressure barely breathing, pipes nearly in tune. The fairground organ at 4am when no one is watching: slow, dreamy, almost harmonic. MacroCHARACTER raises chaos.",
+  "description": "Calliope at near-zero instability \u2014 steam pressure barely breathing, pipes nearly in tune. The fairground organ at 4am when no one is watching: slow, dreamy, almost harmonic. MacroCHARACTER raises chaos.",
   "dna": {
     "aggression": 0.05,
     "brightness": 0.55,
@@ -51,10 +51,10 @@
       "otis_decay": 0.3,
       "otis_sustain": 1.0,
       "otis_release": 0.5,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.45,
+      "otis_macroCharacter": 0.1,
+      "otis_macroMovement": 0.2,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.4,
       "otis_lfo1Rate": 0.8,
       "otis_lfo1Depth": 0.1,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Atmosphere/Otis_Bayou_Mist.xometa
+++ b/Presets/XOceanus/Atmosphere/Otis_Bayou_Mist.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Musette accordion as atmospheric pad — slow attack, maximum musette beating, long release. The accordion heard from across the bayou at dusk: reeds in sympathy with the water.",
+  "description": "Musette accordion as atmospheric pad \u2014 slow attack, maximum musette beating, long release. The accordion heard from across the bayou at dusk: reeds in sympathy with the water.",
   "dna": {
     "aggression": 0.1,
     "brightness": 0.4,
@@ -51,10 +51,10 @@
       "otis_decay": 0.5,
       "otis_sustain": 0.8,
       "otis_release": 1.2,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.5,
+      "otis_macroCharacter": 0.15,
+      "otis_macroMovement": 0.1,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.45,
       "otis_lfo1Rate": 3.8,
       "otis_lfo1Depth": 0.015,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Atmosphere/Otis_Chorale_Hymn.xometa
+++ b/Presets/XOceanus/Atmosphere/Otis_Chorale_Hymn.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Gentle chorale organ — flute stops only (drawbars 1 and 3), slow Leslie rotation, no percussion, soft key click. Sunday evening vespers.",
+  "description": "Gentle chorale organ \u2014 flute stops only (drawbars 1 and 3), slow Leslie rotation, no percussion, soft key click. Sunday evening vespers.",
   "dna": {
     "aggression": 0.05,
     "brightness": 0.3,
@@ -50,10 +50,10 @@
       "otis_decay": 0.5,
       "otis_sustain": 0.9,
       "otis_release": 0.6,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.1,
+      "otis_macroMovement": 0.2,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.5,
       "otis_lfo1Rate": 0.1,
       "otis_lfo1Depth": 0.02,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Atmosphere/Otis_Midnight_Sermon.xometa
+++ b/Presets/XOceanus/Atmosphere/Otis_Midnight_Sermon.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Warm, breathy Hammond with all bass drawbars, slow Leslie, minimal percussion. The organ playing in an empty church at midnight — all warmth, no edges.",
+  "description": "Warm, breathy Hammond with all bass drawbars, slow Leslie, minimal percussion. The organ playing in an empty church at midnight \u2014 all warmth, no edges.",
   "dna": {
     "aggression": 0.05,
     "brightness": 0.2,
@@ -50,10 +50,10 @@
       "otis_decay": 0.8,
       "otis_sustain": 0.9,
       "otis_release": 1.0,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.1,
+      "otis_macroMovement": 0.2,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.5,
       "otis_lfo1Rate": 0.08,
       "otis_lfo1Depth": 0.015,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Deep/Ogre_Continental_Drift.xometa
+++ b/Presets/XOceanus/Deep/Ogre_Continental_Drift.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "OGRE — extreme tectonic depth (38 cents). The bass note shifts over a musical phrase like geology.",
+  "description": "OGRE — maximum tectonic depth (20 cents). The bass note drifts over a phrase like continental geology.",
   "dna": {
     "brightness": 0.15,
     "warmth": 0.8,
@@ -23,7 +23,7 @@
     "SPACE"
   ],
   "mood": "Deep",
-  "name": "Continental Drift (Ogre)",
+  "name": "Geological Maximum",
   "parameters": {
     "Ogre": {
       "ogre_oscMix": 0.15,
@@ -34,7 +34,7 @@
       "ogre_density": 0.55,
       "ogre_soil": 0.0,
       "ogre_tectonicRate": 0.005,
-      "ogre_tectonicDepth": 38.0,
+      "ogre_tectonicDepth": 20.0,
       "ogre_attack": 0.01,
       "ogre_decay": 1.5,
       "ogre_sustain": 0.85,

--- a/Presets/XOceanus/Flux/Otis/Otis_Carnival_Chaos.xometa
+++ b/Presets/XOceanus/Flux/Otis/Otis_Carnival_Chaos.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Full calliope steam organ — maximum instability, pipes wobbling wildly, steam pressure surging. The sound of a haunted carnival on the waterfront.",
+  "description": "Full calliope steam organ \u2014 maximum instability, pipes wobbling wildly, steam pressure surging. The sound of a haunted carnival on the waterfront.",
   "dna": {
     "aggression": 0.3,
     "brightness": 0.8,
@@ -51,10 +51,10 @@
       "otis_decay": 0.1,
       "otis_sustain": 1.0,
       "otis_release": 0.1,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.15,
+      "otis_macroMovement": 0.2,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.35,
       "otis_lfo1Rate": 3.0,
       "otis_lfo1Depth": 0.15,
       "otis_lfo1Shape": 4,

--- a/Presets/XOceanus/Flux/Otis/Otis_Steam_Dream.xometa
+++ b/Presets/XOceanus/Flux/Otis/Otis_Steam_Dream.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Gentle calliope with low instability — like a music box running on steam. Dreamy, nostalgic, slightly out-of-tune in all the right ways.",
+  "description": "Gentle calliope with low instability \u2014 like a music box running on steam. Dreamy, nostalgic, slightly out-of-tune in all the right ways.",
   "dna": {
     "aggression": 0.1,
     "brightness": 0.5,
@@ -51,10 +51,10 @@
       "otis_decay": 0.4,
       "otis_sustain": 0.85,
       "otis_release": 0.8,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.1,
+      "otis_macroMovement": 0.2,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.35,
       "otis_lfo1Rate": 0.2,
       "otis_lfo1Depth": 0.08,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Foundation/Otis/Otis_Bayou_Squeeze.xometa
+++ b/Presets/XOceanus/Foundation/Otis/Otis_Bayou_Squeeze.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Zydeco accordion — buzzy dual reeds with musette beating, strong bellows attack, dance-ready dynamics. Louisiana Saturday night in a squeeze box.",
+  "description": "Zydeco accordion \u2014 buzzy dual reeds with musette beating, strong bellows attack, dance-ready dynamics. Louisiana Saturday night in a squeeze box.",
   "dna": {
     "aggression": 0.45,
     "brightness": 0.6,
@@ -51,10 +51,10 @@
       "otis_decay": 0.15,
       "otis_sustain": 0.85,
       "otis_release": 0.12,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.2,
+      "otis_macroMovement": 0.15,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.4,
       "otis_lfo1Rate": 4.0,
       "otis_lfo1Depth": 0.02,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Foundation/Otis/Otis_Crossharp_Blues.xometa
+++ b/Presets/XOceanus/Foundation/Otis/Otis_Crossharp_Blues.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Raw blues harmonica in cross-harp position — deep pitch bends on attack, breath noise, overblows on hard velocity. Use aftertouch for breath pressure.",
+  "description": "Raw blues harmonica in cross-harp position \u2014 deep pitch bends on attack, breath noise, overblows on hard velocity. Use aftertouch for breath pressure.",
   "dna": {
     "aggression": 0.4,
     "brightness": 0.5,
@@ -51,10 +51,10 @@
       "otis_decay": 0.2,
       "otis_sustain": 0.75,
       "otis_release": 0.15,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.2,
+      "otis_macroMovement": 0.15,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.35,
       "otis_lfo1Rate": 5.5,
       "otis_lfo1Depth": 0.0,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Foundation/Otis/Otis_Deep_Purple.xometa
+++ b/Presets/XOceanus/Foundation/Otis/Otis_Deep_Purple.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Screaming rock organ — all drawbars blazing, maximum drive, fast Leslie spin. The Jon Lord wall of distortion that defined hard rock organ.",
+  "description": "Screaming rock organ \u2014 all drawbars blazing, maximum drive, fast Leslie spin. The Jon Lord wall of distortion that defined hard rock organ.",
   "dna": {
     "aggression": 0.85,
     "brightness": 0.85,
@@ -50,10 +50,10 @@
       "otis_decay": 0.1,
       "otis_sustain": 0.95,
       "otis_release": 0.15,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.35,
+      "otis_macroMovement": 0.3,
+      "otis_macroCoupling": 0.2,
+      "otis_macroSpace": 0.3,
       "otis_lfo1Rate": 6.0,
       "otis_lfo1Depth": 0.04,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Foundation/Otis/Otis_Gospel_Fire.xometa
+++ b/Presets/XOceanus/Foundation/Otis/Otis_Gospel_Fire.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Full Hammond B3 gospel registration — classic 888000000 drawbars with heavy key click, fast Leslie, and tube overdrive. The sound of Sunday morning.",
+  "description": "Full Hammond B3 gospel registration \u2014 classic 888000000 drawbars with heavy key click, fast Leslie, and tube overdrive. The sound of Sunday morning.",
   "dna": {
     "aggression": 0.5,
     "brightness": 0.7,
@@ -50,10 +50,10 @@
       "otis_decay": 0.2,
       "otis_sustain": 0.85,
       "otis_release": 0.25,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.25,
+      "otis_macroMovement": 0.4,
+      "otis_macroCoupling": 0.15,
+      "otis_macroSpace": 0.4,
       "otis_lfo1Rate": 5.5,
       "otis_lfo1Depth": 0.05,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Foundation/Otis/Otis_Jimmy_Smith.xometa
+++ b/Presets/XOceanus/Foundation/Otis/Otis_Jimmy_Smith.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Classic jazz organ — 888800000 registration with 3rd harmonic percussion, slow Leslie, moderate drive. The Jimmy Smith jazz club grind.",
+  "description": "Classic jazz organ \u2014 888800000 registration with 3rd harmonic percussion, slow Leslie, moderate drive. The Jimmy Smith jazz club grind.",
   "dna": {
     "aggression": 0.3,
     "brightness": 0.6,
@@ -50,10 +50,10 @@
       "otis_decay": 0.15,
       "otis_sustain": 0.9,
       "otis_release": 0.2,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.2,
+      "otis_macroMovement": 0.3,
+      "otis_macroCoupling": 0.15,
+      "otis_macroSpace": 0.45,
       "otis_lfo1Rate": 5.0,
       "otis_lfo1Depth": 0.03,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Kinetic/Otis_Tent_Revival.xometa
+++ b/Presets/XOceanus/Kinetic/Otis_Tent_Revival.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "High-energy Hammond with all upper harmonics blazing — the sound of a tent revival where the preacher is shouting and the organ player is possessed. Fast Leslie, maximum crosstalk, heavy percussion.",
+  "description": "High-energy Hammond with all upper harmonics blazing \u2014 the sound of a tent revival where the preacher is shouting and the organ player is possessed. Fast Leslie, maximum crosstalk, heavy percussion.",
   "dna": {
     "aggression": 0.7,
     "brightness": 0.8,
@@ -50,10 +50,10 @@
       "otis_decay": 0.15,
       "otis_sustain": 0.9,
       "otis_release": 0.15,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.3,
+      "otis_macroMovement": 0.4,
+      "otis_macroCoupling": 0.15,
+      "otis_macroSpace": 0.3,
       "otis_lfo1Rate": 6.5,
       "otis_lfo1Depth": 0.06,
       "otis_lfo1Shape": 0,

--- a/Presets/XOceanus/Prism/Otis_Wailing_Harp.xometa
+++ b/Presets/XOceanus/Prism/Otis_Wailing_Harp.xometa
@@ -4,7 +4,7 @@
     "pairs": []
   },
   "couplingIntensity": "None",
-  "description": "Expressive blues harmonica with deep bends and heavy vibrato — use mod wheel for vibrato intensity, aftertouch for breath pressure. The sound that makes grown men cry.",
+  "description": "Expressive blues harmonica with deep bends and heavy vibrato \u2014 use mod wheel for vibrato intensity, aftertouch for breath pressure. The sound that makes grown men cry.",
   "dna": {
     "aggression": 0.3,
     "brightness": 0.45,
@@ -51,10 +51,10 @@
       "otis_decay": 0.3,
       "otis_sustain": 0.7,
       "otis_release": 0.25,
-      "otis_macroCharacter": 0.0,
-      "otis_macroMovement": 0.0,
-      "otis_macroCoupling": 0.0,
-      "otis_macroSpace": 0.0,
+      "otis_macroCharacter": 0.2,
+      "otis_macroMovement": 0.15,
+      "otis_macroCoupling": 0.1,
+      "otis_macroSpace": 0.3,
       "otis_lfo1Rate": 5.8,
       "otis_lfo1Depth": 0.0,
       "otis_lfo1Shape": 0,

--- a/Source/Engines/Otis/OtisEngine.h
+++ b/Source/Engines/Otis/OtisEngine.h
@@ -1479,15 +1479,18 @@ public:
         params.push_back(std::make_unique<PF>(juce::ParameterID{"otis_musette", 1}, "Otis Musette (Accordion)",
                                               juce::NormalisableRange<float>(0.0f, 1.0f), 0.5f));
 
-        // Macros
+        // Macros — default to mid-range so fresh presets have bidirectional sweep.
+        // At 0.0 the macro can only ADD (one-directional); at 0.25-0.35 it can both
+        // add (toward max) and reduce (toward 0), giving full performance range.
+        // Seance P2 verdict: "macros showcased with non-zero defaults."
         params.push_back(std::make_unique<PF>(juce::ParameterID{"otis_macroCharacter", 1}, "Otis Macro CHARACTER",
-                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
+                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.25f));
         params.push_back(std::make_unique<PF>(juce::ParameterID{"otis_macroMovement", 1}, "Otis Macro MOVEMENT",
-                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
+                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.35f));
         params.push_back(std::make_unique<PF>(juce::ParameterID{"otis_macroCoupling", 1}, "Otis Macro COUPLING",
-                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
+                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.15f));
         params.push_back(std::make_unique<PF>(juce::ParameterID{"otis_macroSpace", 1}, "Otis Macro SPACE",
-                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.0f));
+                                              juce::NormalisableRange<float>(0.0f, 1.0f), 0.35f));
 
         // LFOs
         params.push_back(std::make_unique<PF>(juce::ParameterID{"otis_lfo1Rate", 1}, "Otis LFO1 Rate",


### PR DESCRIPTION
## Summary

Day 8 Phase 1 / unblocks 4 parallel preset-forge sessions.

This PR bundles 4 seance-verdict fixes. KC-P0-02 (Olate terroir) and KC-P0-04 (Ochre LFO2) were already resolved in a prior session — confirmed by code inspection; those findings are surfaced here but required no further code change.

---

### Fix 1 — KC-P0-01: Ogre tectonic depth out-of-range

**Seance citation:** `seance-cellar-garden-verdict.md` — "Parameter range: 0–20 cents. No preset uses `ogre_tectonicDepth` above 3.0. The maximum is 20 cents."

**Finding:** Two Ogre presets had values exceeding the 20-cent parameter max:
- `Deep/Ogre_Continental_Drift.xometa`: 38.0 → clamped to 20.0, renamed to "Geological Maximum" (duplicate name with Atmosphere preset)
- `Aether/Ogre/Ogre_Seismic_Event.xometa`: 45.0 → clamped to 20.0

Values above the NormalisableRange max are undefined behavior in JUCE; the DAW clips them silently. Preset descriptions updated to remove misleading centage claims.

---

### Fix 2 — KC-P0-02: Olate terroir (ALREADY FIXED — no change required)

**Seance citation:** `seance-cellar-garden-verdict.md` — "East Coast (pTerroir 0.7–1.0) and Japanese transparent (pTerroir = 1.0) have no DSP code. D004 partial violation."

**Finding:** Code inspection confirms all 4 terroir regions are already wired (comment: "D004 fix — all 4 regions active"). East Coast adds harmonic grit + presence lift; Japanese applies 0.88× clean gain reduction. The `Tokyo Transparent` preset uses olate_terroir = 0.99. No code change needed.

---

### Fix 3 — KC-P0-04: Ochre LFO2 wire (ALREADY FIXED — no change required)

**Seance citation:** `seance-kitchen-quad-verdict.md` — "`(void) lfo2Val;` — LFO2 is dead. D004 violation."

**Finding:** Code inspection confirms LFO2 is now wired to caramel saturation amount (line 899: `if (lfo2Val != 0.0f && caramelNow > 0.001f)`). Comment reads "D004: this wire makes LFO2 audible at any non-zero depth setting." No code change needed.

---

### Fix 4 — Otis macro-init (TWO PARTS)

**Seance citation:** `seance-otis-verdict.md` P2 — "All 11 presets: every macro defaults to 0.0. Macros have no bi-directional range from the preset's starting position. At minimum one preset per model should demonstrate macro range."

**(a) Engine defaults** (`Source/Engines/Otis/OtisEngine.h`):
Changed parameter defaults from 0.0 to:
- `otis_macroCharacter`: 0.0 → **0.25** (mid-drive; bidirectional sweep)
- `otis_macroMovement`: 0.0 → **0.35** (mid-Leslie; can increase or decrease speed)  
- `otis_macroCoupling`: 0.0 → **0.15** (light crosstalk base)
- `otis_macroSpace`: 0.0 → **0.35** (moderate Leslie depth)

This ensures freshly-initialized Otis patches have usable macro range in both directions.

**(b) Existing presets** — 13 Otis presets had all macros at 0.0. Each updated with character-appropriate values based on organ model, drive level, and mood:
- `Gospel_Fire`, `Deep_Purple`, `Tent_Revival` (energetic Hammond): CHARACTER 0.25–0.35, MOVEMENT 0.3–0.4
- `Jimmy_Smith`, `Midnight_Sermon`, `Chorale_Hymn` (moderate/ambient Hammond): CHARACTER 0.1–0.2, MOVEMENT 0.2–0.3
- `Wailing_Harp`, `Crossharp_Blues` (harmonica, no Leslie): CHARACTER 0.2, MOVEMENT 0.15
- `Bayou_Squeeze`, `Bayou_Mist` (accordion, no Leslie): CHARACTER 0.15–0.2, MOVEMENT 0.1–0.15
- `Carnival_Chaos`, `Steam_Dream`, `Steam_Ghost` (calliope): CHARACTER 0.1–0.15, MOVEMENT 0.2

**Sentinel:** `grep -r 'otis_macro.*: 0.0' Presets/` returns 0 all-zero presets. Confirmed clean.

---

## Build verification

- CMake configure: PASS (184s, Ninja)
- Build: PASS (331/331 steps, AU + Standalone)
- `auval -v aumu Xocn XoOx`: **AU VALIDATION SUCCEEDED**

## Net diff

16 files changed, +3 net lines (78 insertions, 75 deletions). Well within 200-line cap.

## Surfaces requiring orchestrator decision

**KC-P0-02 and KC-P0-04 were already fixed in prior sessions.** The `chore/v1-day8-cull-10-engines-to-v1.1` branch is already open — Phase 2 can proceed without waiting for this PR if the above sentinels are acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)