### PR TITLE
feat(presets): Day 8 Session D — 264 Broth + Fusion + Obscura + Osmosis + quick-fills

### DIFF
--- a/Presets/XOceanus/Aether/Obscura_Reed_Organ_Pipe.xometa
+++ b/Presets/XOceanus/Aether/Obscura_Reed_Organ_Pipe.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Reed Organ Pipe",
+  "mood": "Aether",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.0,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.55,
+    "movement": 0.04,
+    "density": 0.3,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.42,
+      "obscura_damping": 0.14,
+      "obscura_nonlinear": 0.05,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.22,
+      "obscura_scanWidth": 0.52,
+      "obscura_boundary": 1,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.01,
+      "obscura_ampDecay": 0.4,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 3.0,
+      "obscura_physEnvAttack": 0.01,
+      "obscura_physEnvDecay": 0.4,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 3.0,
+      "obscura_lfo1Rate": 0.04,
+      "obscura_lfo1Depth": 0.08,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.1,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.2,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "organ",
+    "pipe",
+    "reed",
+    "hollow",
+    "aether"
+  ],
+  "description": "Resonant reed organ pipe \u2014 Free boundary (open-ended resonant cavity). Medium stiffness. The pipe resonates with the fundamental and odd harmonics (Free boundary: 1f, 3f, 5f). Low sustain because the pipe is driven by a reed outside the model \u2014 the pipe resonance decays when not re-excited. The hollow character of open pipe ends."
+}

--- a/Presets/XOceanus/Aether/Origami_Crease_Memory.xometa
+++ b/Presets/XOceanus/Aether/Origami_Crease_Memory.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "name": "Crease Memory",
+  "mood": "Aether",
+  "engines": [
+    "Origami"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Paper folded many times remembers each crease. Old folds echo in the tone as harmonic ghosts \u2014 the deeper the fold angle (foldDepth 0.72), the louder the memory sings. Very slow LFO1 (0.06Hz) breathes over a long sustain. Operation 0 (sine fold) keeps the tone warm and continuous.",
+  "tags": [
+    "aether",
+    "memory",
+    "harmonic",
+    "warm",
+    "pad"
+  ],
+  "macroLabels": [
+    "FOLD",
+    "MOTION",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Origami": {
+      "origami_foldPoint": 0.65,
+      "origami_foldDepth": 0.72,
+      "origami_foldCount": 3,
+      "origami_operation": 0,
+      "origami_freeze": 0.0,
+      "origami_foldEnvAttack": 0.25,
+      "origami_foldEnvDecay": 1.2,
+      "origami_foldEnvSustain": 0.65,
+      "origami_foldEnvRelease": 2.5,
+      "origami_ampAttack": 0.2,
+      "origami_ampDecay": 0.8,
+      "origami_ampSustain": 0.72,
+      "origami_ampRelease": 2.8,
+      "origami_level": 0.78,
+      "origami_glide": 0.0,
+      "origami_lfo1Rate": 0.06,
+      "origami_lfo1Depth": 0.3,
+      "origami_lfo1Shape": 0,
+      "origami_lfo2Rate": 0.12,
+      "origami_lfo2Depth": 0.18,
+      "origami_lfo2Shape": 0,
+      "origami_macroFold": 0.65,
+      "origami_macroMotion": 0.18,
+      "origami_macroCoupling": 0.0,
+      "origami_macroSpace": 0.78
+    }
+  },
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.65,
+    "movement": 0.18,
+    "density": 0.45,
+    "space": 0.78,
+    "aggression": 0.1
+  },
+  "macros": {
+    "FOLD": 0.65,
+    "MOTION": 0.18,
+    "COUPLING": 0.0,
+    "SPACE": 0.78
+  }
+}

--- a/Presets/XOceanus/Aether/Osprey_Cloud_Ceiling.xometa
+++ b/Presets/XOceanus/Aether/Osprey_Cloud_Ceiling.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Cloud Ceiling",
+  "mood": "Aether",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Above the clouds \u2014 fog at maximum (0.9), zero sea state, high coherence (0.95). Ultra-long release (5.0s). The aether preset \u2014 barely there, impossibly open.",
+  "tags": [
+    "aether",
+    "clouds",
+    "ethereal",
+    "vast"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.6,
+      "osprey_ampDecay": 2.0,
+      "osprey_ampSustain": 0.85,
+      "osprey_ampRelease": 5.0,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.95,
+      "osprey_depth": 0.7,
+      "osprey_filterTilt": 0.5,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.9,
+      "osprey_harborVerb": 0.7,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.2,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.1,
+      "osprey_macroSpace": 0.95,
+      "osprey_resonatorBright": 0.4,
+      "osprey_resonatorDecay": 4.0,
+      "osprey_seaState": 0.0,
+      "osprey_shore": 0.3,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.4,
+    "movement": 0.1,
+    "density": 0.28,
+    "space": 0.95,
+    "aggression": 0.05
+  },
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.0,
+    "SPACE": 0.95
+  }
+}

--- a/Presets/XOceanus/Aether/Overwash_Cloud_Diffusion.xometa
+++ b/Presets/XOceanus/Aether/Overwash_Cloud_Diffusion.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cloud Diffusion",
+  "mood": "Aether",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.68
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.6,
+    "movement": 0.18,
+    "density": 0.35,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.14,
+      "wash_viscosity": 0.72,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 25.0,
+      "wash_spreadMax": 85.0,
+      "wash_brightness": 0.35,
+      "wash_warmth": 0.6,
+      "wash_ampAttack": 2.5,
+      "wash_ampDecay": 2.0,
+      "wash_ampSustain": 0.86,
+      "wash_ampRelease": 11.0,
+      "wash_filterCutoff": 1000.0,
+      "wash_filterRes": 0.06,
+      "wash_filtEnvAmount": 0.15,
+      "wash_filtAttack": 2.0,
+      "wash_filtDecay": 3.0,
+      "wash_filtSustain": 0.78,
+      "wash_filtRelease": 7.0,
+      "wash_lfo1Rate": 0.01,
+      "wash_lfo1Depth": 0.18,
+      "wash_lfo2Rate": 0.005,
+      "wash_lfo2Depth": 0.09,
+      "wash_stereoWidth": 0.75,
+      "wash_level": 0.74,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "cloud",
+    "aether",
+    "wide",
+    "eight-harmonic",
+    "drift"
+  ],
+  "description": "Eight harmonics at moderate viscosity with wide stereo \u2014 the spectral equivalent of watching clouds move. Neither slow nor fast."
+}

--- a/Presets/XOceanus/Aether/Overwash_High_Atmosphere.xometa
+++ b/Presets/XOceanus/Aether/Overwash_High_Atmosphere.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "High Atmosphere",
+  "mood": "Aether",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.52,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.72
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.3,
+    "movement": 0.2,
+    "density": 0.28,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.18,
+      "wash_viscosity": 0.58,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 15.0,
+      "wash_spreadMax": 150.0,
+      "wash_brightness": 0.52,
+      "wash_warmth": 0.3,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.8,
+      "wash_ampRelease": 9.0,
+      "wash_filterCutoff": 1800.0,
+      "wash_filterRes": 0.08,
+      "wash_filtEnvAmount": 0.2,
+      "wash_filtAttack": 1.5,
+      "wash_filtDecay": 2.0,
+      "wash_filtSustain": 0.7,
+      "wash_filtRelease": 6.0,
+      "wash_lfo1Rate": 0.012,
+      "wash_lfo1Depth": 0.18,
+      "wash_lfo2Rate": 0.006,
+      "wash_lfo2Depth": 0.09,
+      "wash_stereoWidth": 0.8,
+      "wash_level": 0.72,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "aether",
+    "altitude",
+    "thin",
+    "cold",
+    "wide"
+  ],
+  "description": "Six harmonics at low warmth and moderate brightness \u2014 the cold, thin character of high-altitude air. Spread maximum 150Hz, thin and wide."
+}

--- a/Presets/XOceanus/Aether/Overwash_Ionosphere.xometa
+++ b/Presets/XOceanus/Aether/Overwash_Ionosphere.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Ionosphere",
+  "mood": "Aether",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.32,
+    "COUPLING": 0.5,
+    "SPACE": 0.62
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.32,
+    "movement": 0.32,
+    "density": 0.55,
+    "space": 0.62,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.25,
+      "wash_viscosity": 0.45,
+      "wash_harmonics": 16,
+      "wash_diffusionTime": 8.0,
+      "wash_spreadMax": 160.0,
+      "wash_brightness": 0.65,
+      "wash_warmth": 0.32,
+      "wash_ampAttack": 0.8,
+      "wash_ampDecay": 1.2,
+      "wash_ampSustain": 0.78,
+      "wash_ampRelease": 6.0,
+      "wash_filterCutoff": 2200.0,
+      "wash_filterRes": 0.11,
+      "wash_filtEnvAmount": 0.28,
+      "wash_filtAttack": 0.8,
+      "wash_filtDecay": 1.5,
+      "wash_filtSustain": 0.68,
+      "wash_filtRelease": 4.0,
+      "wash_lfo1Rate": 0.022,
+      "wash_lfo1Depth": 0.26,
+      "wash_lfo2Rate": 0.011,
+      "wash_lfo2Depth": 0.14,
+      "wash_stereoWidth": 0.82,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "ionosphere",
+    "chaotic",
+    "maximum",
+    "aether",
+    "bouncing"
+  ],
+  "description": "Maximum harmonics at low viscosity \u2014 the chaotic diffusion of the ionosphere, where signals bounce between layers unpredictably."
+}

--- a/Presets/XOceanus/Aether/Overwash_Silver_Cirrus.xometa
+++ b/Presets/XOceanus/Aether/Overwash_Silver_Cirrus.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Silver Cirrus",
+  "mood": "Aether",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.6,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.28,
+    "movement": 0.15,
+    "density": 0.22,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.16,
+      "wash_viscosity": 0.65,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 18.0,
+      "wash_spreadMax": 120.0,
+      "wash_brightness": 0.6,
+      "wash_warmth": 0.28,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.8,
+      "wash_ampRelease": 8.0,
+      "wash_filterCutoff": 2000.0,
+      "wash_filterRes": 0.08,
+      "wash_filtEnvAmount": 0.22,
+      "wash_filtAttack": 1.5,
+      "wash_filtDecay": 2.0,
+      "wash_filtSustain": 0.7,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.01,
+      "wash_lfo1Depth": 0.16,
+      "wash_lfo2Rate": 0.005,
+      "wash_lfo2Depth": 0.08,
+      "wash_stereoWidth": 0.78,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "cirrus",
+    "silver",
+    "bright",
+    "thin",
+    "aether"
+  ],
+  "description": "The cirrus cloud \u2014 high, thin, and bright. Four harmonics at medium viscosity, brightness high, warmth low."
+}

--- a/Presets/XOceanus/Aether/Overworn_Ghost_Broth.xometa
+++ b/Presets/XOceanus/Aether/Overworn_Ghost_Broth.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Ghost Broth",
+  "mood": "Aether",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.22
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.6,
+    "movement": 0.08,
+    "density": 0.16,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.06,
+      "worn_heat": 0.25,
+      "worn_richness": 0.28,
+      "worn_maillard": 0.1,
+      "worn_umamiDepth": 0.22,
+      "worn_concentrate": 0.15,
+      "worn_sessionTarget": 25.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.82,
+      "worn_filterCutoff": 1000.0,
+      "worn_filterRes": 0.04,
+      "worn_filtEnvAmount": 0.1,
+      "worn_ampAttack": 2.5,
+      "worn_ampDecay": 3.0,
+      "worn_ampSustain": 0.84,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.006,
+      "worn_lfo1Depth": 0.08,
+      "worn_lfo2Rate": 0.003,
+      "worn_lfo2Depth": 0.04,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "aether",
+    "ghost",
+    "invisible",
+    "minimal",
+    "suspended"
+  ],
+  "description": "Nearly invisible reduction \u2014 barely there, hanging in the mix like steam that barely forms. Maximum stereo width, minimum density."
+}

--- a/Presets/XOceanus/Aether/Overworn_Session_Cloud.xometa
+++ b/Presets/XOceanus/Aether/Overworn_Session_Cloud.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Session Cloud",
+  "mood": "Aether",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.35
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.65,
+    "movement": 0.12,
+    "density": 0.32,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.09,
+      "worn_heat": 0.32,
+      "worn_richness": 0.42,
+      "worn_maillard": 0.18,
+      "worn_umamiDepth": 0.35,
+      "worn_concentrate": 0.26,
+      "worn_sessionTarget": 22.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.72,
+      "worn_filterCutoff": 1000.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.13,
+      "worn_ampAttack": 2.5,
+      "worn_ampDecay": 3.0,
+      "worn_ampSustain": 0.86,
+      "worn_ampRelease": 11.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.008,
+      "worn_lfo1Depth": 0.12,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "aether",
+    "cloud",
+    "slow",
+    "wide",
+    "session"
+  ],
+  "description": "The reduction-as-atmosphere \u2014 slow heat, wide stereo, moderate richness. The session creates clouds overhead."
+}

--- a/Presets/XOceanus/Aether/Overworn_Umami_Cloud.xometa
+++ b/Presets/XOceanus/Aether/Overworn_Umami_Cloud.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Umami Cloud",
+  "mood": "Aether",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.62
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.72,
+    "movement": 0.1,
+    "density": 0.42,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.4,
+      "worn_richness": 0.5,
+      "worn_maillard": 0.25,
+      "worn_umamiDepth": 0.62,
+      "worn_concentrate": 0.32,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.75,
+      "worn_filterCutoff": 750.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.12,
+      "worn_ampAttack": 3.0,
+      "worn_ampDecay": 3.0,
+      "worn_ampSustain": 0.9,
+      "worn_ampRelease": 12.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.007,
+      "worn_lfo1Depth": 0.1,
+      "worn_lfo2Rate": 0.003,
+      "worn_lfo2Depth": 0.05,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "aether",
+    "umami",
+    "cloud",
+    "rich",
+    "floating"
+  ],
+  "description": "High umami depth creates a rich cloud-like suspension \u2014 floating above the mix."
+}

--- a/Presets/XOceanus/Aether/Overworn_Vapor_Reduction.xometa
+++ b/Presets/XOceanus/Aether/Overworn_Vapor_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Vapor Reduction",
+  "mood": "Aether",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.25
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.52,
+    "movement": 0.14,
+    "density": 0.22,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.3,
+      "worn_richness": 0.35,
+      "worn_maillard": 0.12,
+      "worn_umamiDepth": 0.25,
+      "worn_concentrate": 0.2,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.8,
+      "worn_filterCutoff": 1200.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 2.0,
+      "worn_ampDecay": 2.5,
+      "worn_ampSustain": 0.84,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.01,
+      "worn_lfo1Depth": 0.14,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.07,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "aether",
+    "vapor",
+    "light",
+    "evaporated",
+    "wide"
+  ],
+  "description": "The evaporated portion \u2014 what the steam carries away. Low concentrate, high stereo width. The light that left the pot."
+}

--- a/Presets/XOceanus/Atmosphere/Obiont/Cloud_Logic.xometa
+++ b/Presets/XOceanus/Atmosphere/Obiont/Cloud_Logic.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Cloud Logic",
+  "mood": "Atmosphere",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 110 \u2014 the only elementary CA proved Turing-complete. Patterns that never resolve but never collapse. Slow-medium evolution (2Hz), open filter (5500Hz), wide projection. The sound of a machine that could think anything, choosing to drift.",
+  "tags": [
+    "atmosphere",
+    "complex",
+    "ambient",
+    "rule-110",
+    "turing",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 110,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 2.0,
+      "obnt_gridDensity": 0.5,
+      "obnt_chaos": 0.05,
+      "obnt_projection": 0.7,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 5500.0,
+      "obnt_filterResonance": 0.18,
+      "obnt_attack": 0.18,
+      "obnt_decay": 1.0,
+      "obnt_sustain": 0.8,
+      "obnt_release": 2.2,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.15,
+      "obnt_lfo1Depth": 0.25,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.5,
+    "movement": 0.28,
+    "density": 0.45,
+    "space": 0.82,
+    "aggression": 0.1
+  },
+  "macros": {
+    "CHAOS": 0.1,
+    "EVOLUTION": 0.28,
+    "SPACE": 0.82,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Obiont/Humid_Lattice.xometa
+++ b/Presets/XOceanus/Atmosphere/Obiont/Humid_Lattice.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Humid Lattice",
+  "mood": "Atmosphere",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 22 \u2014 isolated triangles that never merge, like islands in fog. 2D mode spreads isolation spatially. High grid density (0.78) but low chaos. Warm filter sweep evokes moisture rising.",
+  "tags": [
+    "atmosphere",
+    "warm",
+    "ambient",
+    "rule-22",
+    "humid",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 1,
+      "obnt_rule": 22,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 1.5,
+      "obnt_gridDensity": 0.78,
+      "obnt_chaos": 0.03,
+      "obnt_projection": 0.6,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 2000.0,
+      "obnt_filterResonance": 0.28,
+      "obnt_attack": 0.25,
+      "obnt_decay": 1.2,
+      "obnt_sustain": 0.65,
+      "obnt_release": 2.5,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.1,
+      "obnt_lfo1Depth": 0.3,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.55,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.65,
+    "movement": 0.22,
+    "density": 0.6,
+    "space": 0.75,
+    "aggression": 0.1
+  },
+  "macros": {
+    "CHAOS": 0.06,
+    "EVOLUTION": 0.22,
+    "SPACE": 0.75,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Obiont/Pressure_Front.xometa
+++ b/Presets/XOceanus/Atmosphere/Obiont/Pressure_Front.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Pressure Front",
+  "mood": "Atmosphere",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 90 \u2014 the XOR rule, creating the Sierpinski triangle fractal. At 4Hz the fractal unfolds and collapses rhythmically. Wide projection (0.75) maps the full self-similar structure to pitch \u2014 fractal harmony.",
+  "tags": [
+    "atmosphere",
+    "fractal",
+    "sierpinski",
+    "rule-90",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 90,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 4.0,
+      "obnt_gridDensity": 0.5,
+      "obnt_chaos": 0.06,
+      "obnt_projection": 0.75,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4000.0,
+      "obnt_filterResonance": 0.25,
+      "obnt_attack": 0.12,
+      "obnt_decay": 0.9,
+      "obnt_sustain": 0.72,
+      "obnt_release": 1.8,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.2,
+      "obnt_lfo1Depth": 0.28,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.58,
+    "warmth": 0.4,
+    "movement": 0.38,
+    "density": 0.5,
+    "space": 0.72,
+    "aggression": 0.2
+  },
+  "macros": {
+    "CHAOS": 0.12,
+    "EVOLUTION": 0.44,
+    "SPACE": 0.72,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Obiont/Spore_Drift.xometa
+++ b/Presets/XOceanus/Atmosphere/Obiont/Spore_Drift.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Spore Drift",
+  "mood": "Atmosphere",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 126 \u2014 the most complex totalistic 1D rule, overlapping triangular interference. Very slow evolution (0.4Hz) lets each generation linger. Wide projection (0.85) maps the full grid to pitch space. Long attack (0.3s) fades in like spores dispersing.",
+  "tags": [
+    "atmosphere",
+    "slow",
+    "ambient",
+    "rule-126",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 126,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 0.4,
+      "obnt_gridDensity": 0.45,
+      "obnt_chaos": 0.08,
+      "obnt_projection": 0.85,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4500.0,
+      "obnt_filterResonance": 0.22,
+      "obnt_attack": 0.3,
+      "obnt_decay": 1.5,
+      "obnt_sustain": 0.75,
+      "obnt_release": 2.8,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.06,
+      "obnt_lfo1Depth": 0.35,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.45,
+    "movement": 0.18,
+    "density": 0.4,
+    "space": 0.88,
+    "aggression": 0.12
+  },
+  "macros": {
+    "CHAOS": 0.16,
+    "EVOLUTION": 0.08,
+    "SPACE": 0.88,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Obiont/Thermal_Column.xometa
+++ b/Presets/XOceanus/Atmosphere/Obiont/Thermal_Column.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Thermal Column",
+  "mood": "Atmosphere",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 57 \u2014 asymmetric columns that rise, stabilize, then scatter. Creates a natural breathing quality \u2014 the automaton inhales and exhales. LFO1 very slow (0.05Hz) adds a long thermal swell.",
+  "tags": [
+    "atmosphere",
+    "breathing",
+    "column",
+    "rule-57",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 57,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 5.0,
+      "obnt_gridDensity": 0.55,
+      "obnt_chaos": 0.09,
+      "obnt_projection": 0.65,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 3500.0,
+      "obnt_filterResonance": 0.32,
+      "obnt_attack": 0.4,
+      "obnt_decay": 0.8,
+      "obnt_sustain": 0.7,
+      "obnt_release": 3.0,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.05,
+      "obnt_lfo1Depth": 0.45,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.58,
+    "movement": 0.35,
+    "density": 0.5,
+    "space": 0.78,
+    "aggression": 0.12
+  },
+  "macros": {
+    "CHAOS": 0.18,
+    "EVOLUTION": 0.42,
+    "SPACE": 0.78,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Obscura_Bowed_Cello.xometa
+++ b/Presets/XOceanus/Atmosphere/Obscura_Bowed_Cello.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bowed Cello",
+  "mood": "Atmosphere",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.2,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.65,
+    "movement": 0.08,
+    "density": 0.45,
+    "space": 0.6,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.48,
+      "obscura_damping": 0.12,
+      "obscura_nonlinear": 0.14,
+      "obscura_excitePos": 0.15,
+      "obscura_exciteWidth": 0.28,
+      "obscura_scanWidth": 0.55,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.6,
+      "obscura_ampAttack": 0.3,
+      "obscura_ampDecay": 0.0,
+      "obscura_ampSustain": 1.0,
+      "obscura_ampRelease": 1.8,
+      "obscura_physEnvAttack": 0.6,
+      "obscura_physEnvDecay": 0.0,
+      "obscura_physEnvSustain": 1.0,
+      "obscura_physEnvRelease": 0.5,
+      "obscura_lfo1Rate": 0.08,
+      "obscura_lfo1Depth": 0.12,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.1,
+      "obscura_macroCoupling": 0.2,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "cello",
+    "bowed",
+    "string",
+    "sustained",
+    "warm"
+  ],
+  "description": "Cello string simulation \u2014 Fixed boundary, medium stiffness. Bowing force (sustain=0.6) with slow physics envelope attack to simulate bow pressure build. Excite position at 0.15 from one end (near the bridge) emphasizes upper harmonics as in bridge-bow playing. Slight nonlinearity captures string stretching at high amplitude."
+}

--- a/Presets/XOceanus/Atmosphere/Oceanic_Pelagic_Haze.xometa
+++ b/Presets/XOceanus/Atmosphere/Oceanic_Pelagic_Haze.xometa
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "name": "Pelagic Haze",
+  "mood": "Atmosphere",
+  "engines": [
+    "Oceanic"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Open-ocean atmospherics. High separation (0.8) keeps swarm fronts far apart \u2014 vast spaces between each pulse. Deep damping (0.65). Very slow LFO1 (0.04Hz). A pad of oceanic distance.",
+  "tags": [
+    "atmosphere",
+    "open-ocean",
+    "vast",
+    "pad"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Oceanic": {
+      "ocean_alignment": 0.7,
+      "ocean_cohesion": 0.25,
+      "ocean_scatter": 0.5,
+      "ocean_separation": 0.8,
+      "ocean_damping": 0.65,
+      "ocean_tether": 0.15,
+      "ocean_subflocks": 3,
+      "ocean_waveform": 0,
+      "ocean_voiceMode": 1,
+      "ocean_glide": 0.0,
+      "ocean_ampAttack": 0.4,
+      "ocean_ampDecay": 1.5,
+      "ocean_ampSustain": 0.75,
+      "ocean_ampRelease": 3.5,
+      "ocean_swarmEnvAttack": 0.5,
+      "ocean_swarmEnvDecay": 1.0,
+      "ocean_swarmEnvSustain": 0.7,
+      "ocean_swarmEnvRelease": 2.5,
+      "ocean_lfo1Rate": 0.04,
+      "ocean_lfo1Depth": 0.4,
+      "ocean_lfo1Shape": 0,
+      "ocean_lfo2Rate": 0.06,
+      "ocean_lfo2Depth": 0.2,
+      "ocean_lfo2Shape": 0,
+      "ocean_macroCharacter": 0.3,
+      "ocean_macroMovement": 0.15,
+      "ocean_macroCoupling": 0.0,
+      "ocean_macroSpace": 0.88
+    }
+  },
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.55,
+    "movement": 0.15,
+    "density": 0.35,
+    "space": 0.88,
+    "aggression": 0.08
+  },
+  "macros": {
+    "CHARACTER": 0.3,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.0,
+    "SPACE": 0.88
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Atmospheric_Entry.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Atmospheric_Entry.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Atmospheric Entry",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.25,
+    "COUPLING": 0.48,
+    "SPACE": 0.4
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.5,
+    "movement": 0.22,
+    "density": 0.32,
+    "space": 0.65,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.48,
+      "osmo_selectivity": 0.88,
+      "osmo_reactivity": 0.55,
+      "osmo_memory": 0.4,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.06,
+      "osmo_lfo1Depth": 0.25,
+      "osmo_macroCharacter": 0.7040000000000001,
+      "osmo_macroMovement": 0.25,
+      "osmo_macroCoupling": 0.48,
+      "osmo_macroSpace": 0.4
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "ionosphere",
+    "selective",
+    "charged",
+    "penetrate"
+  ],
+  "description": "The ionosphere as membrane \u2014 very high selectivity, medium reactivity. Only certain frequencies penetrate the charged layer."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Cloud_Layer.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Cloud_Layer.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cloud Layer",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.44,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.52,
+    "SPACE": 0.3
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.6,
+    "movement": 0.25,
+    "density": 0.3,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.52,
+      "osmo_selectivity": 0.55,
+      "osmo_reactivity": 0.7,
+      "osmo_memory": 0.3,
+      "osmo_filterEnvAmt": 0.38,
+      "osmo_lfo1Rate": 0.07,
+      "osmo_lfo1Depth": 0.28,
+      "osmo_macroCharacter": 0.44000000000000006,
+      "osmo_macroMovement": 0.28,
+      "osmo_macroCoupling": 0.52,
+      "osmo_macroSpace": 0.3
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "cloud",
+    "moisture",
+    "medium",
+    "reactive"
+  ],
+  "description": "The cloud membrane \u2014 medium permeability, moderate selectivity, fast reactivity. Sound passing through moisture."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Fog_Layer.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Fog_Layer.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Fog Layer",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.48,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.32,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.18,
+    "warmth": 0.62,
+    "movement": 0.12,
+    "density": 0.28,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.32,
+      "osmo_selectivity": 0.6,
+      "osmo_reactivity": 0.3,
+      "osmo_memory": 0.55,
+      "osmo_filterEnvAmt": 0.3,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.12,
+      "osmo_macroCharacter": 0.48,
+      "osmo_macroMovement": 0.12,
+      "osmo_macroCoupling": 0.32,
+      "osmo_macroSpace": 0.55
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "fog",
+    "diffuse",
+    "muffled",
+    "slow"
+  ],
+  "description": "Dense fog membrane \u2014 lower permeability, medium selectivity, slow reactivity. Muffling and diffusing."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Mist_Gate.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Mist_Gate.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Mist Gate",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.1,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.82,
+    "SPACE": 0.22
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.52,
+    "movement": 0.18,
+    "density": 0.22,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.82,
+      "osmo_selectivity": 0.12,
+      "osmo_reactivity": 0.55,
+      "osmo_memory": 0.22,
+      "osmo_filterEnvAmt": 0.35,
+      "osmo_lfo1Rate": 0.05,
+      "osmo_lfo1Depth": 0.2,
+      "osmo_macroCharacter": 0.096,
+      "osmo_macroMovement": 0.2,
+      "osmo_macroCoupling": 0.82,
+      "osmo_macroSpace": 0.22
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "mist",
+    "thin",
+    "transparent",
+    "high-pass"
+  ],
+  "description": "Thin mist \u2014 high permeability, low selectivity. Nearly everything passes, barely colored."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Rain_Curtain.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Rain_Curtain.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Rain Curtain",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.36,
+    "MOVEMENT": 0.32,
+    "COUPLING": 0.65,
+    "SPACE": 0.15
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.55,
+    "movement": 0.3,
+    "density": 0.32,
+    "space": 0.6,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.65,
+      "osmo_selectivity": 0.45,
+      "osmo_reactivity": 0.85,
+      "osmo_memory": 0.15,
+      "osmo_filterEnvAmt": 0.42,
+      "osmo_lfo1Rate": 0.08,
+      "osmo_lfo1Depth": 0.32,
+      "osmo_macroCharacter": 0.36000000000000004,
+      "osmo_macroMovement": 0.32,
+      "osmo_macroCoupling": 0.65,
+      "osmo_macroSpace": 0.15
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "rain",
+    "transient",
+    "curtain",
+    "fast"
+  ],
+  "description": "Rainfall membrane \u2014 medium-high permeability, fast reactivity, short memory. The transient pass-through of rain."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Stratosphere.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Stratosphere.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Stratosphere",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.66,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.45,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.4,
+    "movement": 0.1,
+    "density": 0.22,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.45,
+      "osmo_selectivity": 0.82,
+      "osmo_reactivity": 0.25,
+      "osmo_memory": 0.58,
+      "osmo_filterEnvAmt": 0.32,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.12,
+      "osmo_macroCharacter": 0.656,
+      "osmo_macroMovement": 0.12,
+      "osmo_macroCoupling": 0.45,
+      "osmo_macroSpace": 0.58
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "stratosphere",
+    "high",
+    "thin",
+    "selective"
+  ],
+  "description": "High-altitude thin air \u2014 high selectivity, medium permeability, slow reactivity. The cold thin upper atmosphere."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Thermal_Layer.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Thermal_Layer.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Thermal Layer",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.54,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.4,
+    "SPACE": 0.8
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.65,
+    "movement": 0.08,
+    "density": 0.25,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.4,
+      "osmo_selectivity": 0.68,
+      "osmo_reactivity": 0.18,
+      "osmo_memory": 0.8,
+      "osmo_filterEnvAmt": 0.28,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.544,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.4,
+      "osmo_macroSpace": 0.8
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "thermal",
+    "inversion",
+    "trapped",
+    "slow"
+  ],
+  "description": "Thermal inversion layer \u2014 medium selectivity, high memory, slow reactivity. The warm air pocket that traps sound below it."
+}

--- a/Presets/XOceanus/Atmosphere/Osmosis_Wind_Membrane.xometa
+++ b/Presets/XOceanus/Atmosphere/Osmosis_Wind_Membrane.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Wind Membrane",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.12,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.78,
+    "SPACE": 0.12
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.5,
+    "movement": 0.35,
+    "density": 0.28,
+    "space": 0.6,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.78,
+      "osmo_selectivity": 0.15,
+      "osmo_reactivity": 0.88,
+      "osmo_memory": 0.12,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.09,
+      "osmo_lfo1Depth": 0.35,
+      "osmo_macroCharacter": 0.12,
+      "osmo_macroMovement": 0.35,
+      "osmo_macroCoupling": 0.78,
+      "osmo_macroSpace": 0.12
+    }
+  },
+  "tags": [
+    "osmosis",
+    "atmosphere",
+    "wind",
+    "moving",
+    "high",
+    "reactive"
+  ],
+  "description": "Moving air membrane \u2014 high permeability, low selectivity, high reactivity. Wind carries everything."
+}

--- a/Presets/XOceanus/Atmosphere/Osprey_Thermal_Soar.xometa
+++ b/Presets/XOceanus/Atmosphere/Osprey_Thermal_Soar.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Thermal Soar",
+  "mood": "Atmosphere",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Effortless thermal soaring at altitude. Low sea state (0.1), high depth (0.85), high fog (0.6). Very long release (4.0s). Maximum coherence for stable air.",
+  "tags": [
+    "atmosphere",
+    "thermal",
+    "soaring",
+    "effortless"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.5,
+      "osprey_ampDecay": 1.5,
+      "osprey_ampSustain": 0.8,
+      "osprey_ampRelease": 4.0,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.85,
+      "osprey_depth": 0.85,
+      "osprey_filterTilt": 0.5,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.6,
+      "osprey_harborVerb": 0.55,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.28,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.15,
+      "osprey_macroSpace": 0.92,
+      "osprey_resonatorBright": 0.4,
+      "osprey_resonatorDecay": 3.5,
+      "osprey_seaState": 0.1,
+      "osprey_shore": 0.3,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.42,
+    "movement": 0.15,
+    "density": 0.32,
+    "space": 0.92,
+    "aggression": 0.08
+  },
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.0,
+    "SPACE": 0.92
+  }
+}

--- a/Presets/XOceanus/Atmosphere/Overflow_Afternoon_Simmer.xometa
+++ b/Presets/XOceanus/Atmosphere/Overflow_Afternoon_Simmer.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Afternoon Simmer",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.3,
+    "MOVEMENT": 0.11,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.65,
+    "movement": 0.12,
+    "density": 0.3,
+    "space": 0.68,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.72,
+      "flow_accumRate": 0.28,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.58,
+      "flow_strainColor": 0.3,
+      "flow_releaseTime": 3.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 880.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.13,
+      "flow_ampAttack": 2.0,
+      "flow_ampDecay": 2.2,
+      "flow_ampSustain": 0.87,
+      "flow_ampRelease": 10.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.008,
+      "flow_lfo1Depth": 0.11,
+      "flow_lfo2Rate": 0.004,
+      "flow_lfo2Depth": 0.06,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "atmosphere",
+    "afternoon",
+    "gentle",
+    "slow",
+    "exhale"
+  ],
+  "description": "Low accumulation, high threshold, gradual valve. Long gentle tension that occasionally exhales."
+}

--- a/Presets/XOceanus/Atmosphere/Overflow_Barely_There.xometa
+++ b/Presets/XOceanus/Atmosphere/Overflow_Barely_There.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Barely There",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.6
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.7,
+    "movement": 0.08,
+    "density": 0.25,
+    "space": 0.75,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.7,
+      "flow_accumRate": 0.18,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.6,
+      "flow_strainColor": 0.2,
+      "flow_releaseTime": 4.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 750.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.1,
+      "flow_ampAttack": 2.5,
+      "flow_ampDecay": 2.5,
+      "flow_ampSustain": 0.88,
+      "flow_ampRelease": 11.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.006,
+      "flow_lfo1Depth": 0.08,
+      "flow_lfo2Rate": 0.003,
+      "flow_lfo2Depth": 0.04,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "atmosphere",
+    "subtle",
+    "quiet",
+    "imperceptible",
+    "barely"
+  ],
+  "description": "Minimum accumulation rate and low strain color \u2014 pressure events almost imperceptible when they occur."
+}

--- a/Presets/XOceanus/Atmosphere/Overflow_Kettle_Boil.xometa
+++ b/Presets/XOceanus/Atmosphere/Overflow_Kettle_Boil.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Kettle Boil",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.6,
+    "movement": 0.15,
+    "density": 0.35,
+    "space": 0.62,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.6,
+      "flow_accumRate": 0.42,
+      "flow_valveType": 2,
+      "flow_vesselSize": 0.52,
+      "flow_strainColor": 0.4,
+      "flow_releaseTime": 1.5,
+      "flow_whistlePitch": 0.6,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1000.0,
+      "flow_filterRes": 0.06,
+      "flow_filtEnvAmount": 0.16,
+      "flow_ampAttack": 1.5,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.83,
+      "flow_ampRelease": 8.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.01,
+      "flow_lfo1Depth": 0.14,
+      "flow_lfo2Rate": 0.005,
+      "flow_lfo2Depth": 0.07,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "atmosphere",
+    "kettle",
+    "kitchen",
+    "whistle",
+    "gentle"
+  ],
+  "description": "Medium threshold, medium accumulation, whistle valve. The kitchen kettle reaching temperature."
+}

--- a/Presets/XOceanus/Atmosphere/Overflow_Still_Waters.xometa
+++ b/Presets/XOceanus/Atmosphere/Overflow_Still_Waters.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Still Waters",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.62
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.25,
+    "warmth": 0.68,
+    "movement": 0.1,
+    "density": 0.28,
+    "space": 0.72,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.92,
+      "flow_accumRate": 0.25,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.62,
+      "flow_strainColor": 0.28,
+      "flow_releaseTime": 3.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 800.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.12,
+      "flow_ampAttack": 2.0,
+      "flow_ampDecay": 2.5,
+      "flow_ampSustain": 0.88,
+      "flow_ampRelease": 11.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.007,
+      "flow_lfo1Depth": 0.1,
+      "flow_lfo2Rate": 0.003,
+      "flow_lfo2Depth": 0.05,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "atmosphere",
+    "serene",
+    "high-threshold",
+    "quiet",
+    "gentle"
+  ],
+  "description": "Very high threshold \u2014 pressure rarely builds. Most playing passes without triggering. Serene."
+}

--- a/Presets/XOceanus/Atmosphere/Overflow_Tension_Hold.xometa
+++ b/Presets/XOceanus/Atmosphere/Overflow_Tension_Hold.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tension Hold",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.33,
+    "MOVEMENT": 0.11,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.63,
+    "movement": 0.12,
+    "density": 0.32,
+    "space": 0.68,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.78,
+      "flow_accumRate": 0.38,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.58,
+      "flow_strainColor": 0.33,
+      "flow_releaseTime": 6.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 880.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.13,
+      "flow_ampAttack": 2.0,
+      "flow_ampDecay": 2.2,
+      "flow_ampSustain": 0.86,
+      "flow_ampRelease": 10.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.008,
+      "flow_lfo1Depth": 0.11,
+      "flow_lfo2Rate": 0.004,
+      "flow_lfo2Depth": 0.06,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "atmosphere",
+    "tension",
+    "hold",
+    "graceful",
+    "long"
+  ],
+  "description": "High threshold, medium accumulation, very long release. The pad holds its tension gracefully for a long time before releasing."
+}

--- a/Presets/XOceanus/Atmosphere/Overflow_Weather_Pressure.xometa
+++ b/Presets/XOceanus/Atmosphere/Overflow_Weather_Pressure.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Weather Pressure",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.56
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.62,
+    "movement": 0.14,
+    "density": 0.32,
+    "space": 0.65,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.62,
+      "flow_accumRate": 0.4,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.56,
+      "flow_strainColor": 0.35,
+      "flow_releaseTime": 2.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 900.0,
+      "flow_filterRes": 0.06,
+      "flow_filtEnvAmount": 0.14,
+      "flow_ampAttack": 1.8,
+      "flow_ampDecay": 2.0,
+      "flow_ampSustain": 0.85,
+      "flow_ampRelease": 9.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.009,
+      "flow_lfo1Depth": 0.12,
+      "flow_lfo2Rate": 0.005,
+      "flow_lfo2Depth": 0.06,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "atmosphere",
+    "weather",
+    "barometric",
+    "pressure",
+    "ambient"
+  ],
+  "description": "The barometric pressure pad \u2014 medium everything, slightly elevated strain. Like playing in high pressure weather."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Amber_Suspension.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Amber_Suspension.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Amber Suspension",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.68
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.75,
+    "movement": 0.1,
+    "density": 0.25,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.08,
+      "wash_viscosity": 0.82,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 30.0,
+      "wash_spreadMax": 50.0,
+      "wash_brightness": 0.2,
+      "wash_warmth": 0.75,
+      "wash_ampAttack": 3.0,
+      "wash_ampDecay": 2.0,
+      "wash_ampSustain": 0.9,
+      "wash_ampRelease": 15.0,
+      "wash_filterCutoff": 700.0,
+      "wash_filterRes": 0.05,
+      "wash_filtEnvAmount": 0.1,
+      "wash_filtAttack": 2.5,
+      "wash_filtDecay": 4.0,
+      "wash_filtSustain": 0.88,
+      "wash_filtRelease": 10.0,
+      "wash_lfo1Rate": 0.006,
+      "wash_lfo1Depth": 0.14,
+      "wash_lfo2Rate": 0.003,
+      "wash_lfo2Depth": 0.07,
+      "wash_stereoWidth": 0.6,
+      "wash_level": 0.73,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "amber",
+    "warm",
+    "suspended",
+    "resin",
+    "golden"
+  ],
+  "description": "Warm golden diffusion \u2014 harmonics suspended like particles in resin. Diffusion time 30 seconds, viscosity high but not maximum."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Coral_Slow.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Coral_Slow.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Coral Slow",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.62
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.6,
+    "movement": 0.12,
+    "density": 0.35,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.14,
+      "wash_viscosity": 0.7,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 35.0,
+      "wash_spreadMax": 100.0,
+      "wash_brightness": 0.42,
+      "wash_warmth": 0.6,
+      "wash_ampAttack": 2.0,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.88,
+      "wash_ampRelease": 12.0,
+      "wash_filterCutoff": 1200.0,
+      "wash_filterRes": 0.07,
+      "wash_filtEnvAmount": 0.18,
+      "wash_filtAttack": 1.5,
+      "wash_filtDecay": 3.0,
+      "wash_filtSustain": 0.8,
+      "wash_filtRelease": 7.0,
+      "wash_lfo1Rate": 0.012,
+      "wash_lfo1Depth": 0.18,
+      "wash_lfo2Rate": 0.006,
+      "wash_lfo2Depth": 0.09,
+      "wash_stereoWidth": 0.7,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "coral",
+    "slow",
+    "six-harmonic",
+    "underwater",
+    "light"
+  ],
+  "description": "Six harmonics slowly spreading across 100Hz bandwidth. The texture of light through shallow water \u2014 broken into spectrum by sediment."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Lavender_Tide.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Lavender_Tide.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Lavender Tide",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.7
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.68,
+    "movement": 0.08,
+    "density": 0.22,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.1,
+      "wash_viscosity": 0.8,
+      "wash_harmonics": 3,
+      "wash_diffusionTime": 60.0,
+      "wash_spreadMax": 60.0,
+      "wash_brightness": 0.3,
+      "wash_warmth": 0.68,
+      "wash_ampAttack": 3.0,
+      "wash_ampDecay": 2.0,
+      "wash_ampSustain": 0.9,
+      "wash_ampRelease": 14.0,
+      "wash_filterCutoff": 900.0,
+      "wash_filterRes": 0.05,
+      "wash_filtEnvAmount": 0.1,
+      "wash_filtAttack": 2.0,
+      "wash_filtDecay": 4.0,
+      "wash_filtSustain": 0.85,
+      "wash_filtRelease": 8.0,
+      "wash_lfo1Rate": 0.007,
+      "wash_lfo1Depth": 0.12,
+      "wash_lfo2Rate": 0.004,
+      "wash_lfo2Depth": 0.06,
+      "wash_stereoWidth": 0.65,
+      "wash_level": 0.74,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "lavender",
+    "slow",
+    "diffusion",
+    "gentle"
+  ],
+  "description": "High viscosity lavender wash \u2014 harmonics spreading upward like dye blooming through still water. Very slow diffusion, 60-second spread arc."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Morning_Haze.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Morning_Haze.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Morning Haze",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.12,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.5,
+    "SPACE": 0.68
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.12,
+    "warmth": 0.82,
+    "movement": 0.06,
+    "density": 0.16,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.06,
+      "wash_viscosity": 0.92,
+      "wash_harmonics": 2,
+      "wash_diffusionTime": 50.0,
+      "wash_spreadMax": 40.0,
+      "wash_brightness": 0.12,
+      "wash_warmth": 0.82,
+      "wash_ampAttack": 4.0,
+      "wash_ampDecay": 2.5,
+      "wash_ampSustain": 0.95,
+      "wash_ampRelease": 20.0,
+      "wash_filterCutoff": 500.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.08,
+      "wash_filtAttack": 3.0,
+      "wash_filtDecay": 3.0,
+      "wash_filtSustain": 0.9,
+      "wash_filtRelease": 10.0,
+      "wash_lfo1Rate": 0.004,
+      "wash_lfo1Depth": 0.08,
+      "wash_lfo2Rate": 0.002,
+      "wash_lfo2Depth": 0.04,
+      "wash_stereoWidth": 0.55,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "morning",
+    "haze",
+    "warm",
+    "two-harmonic",
+    "ambient"
+  ],
+  "description": "Low harmonics, maximum warmth \u2014 two partials diffusing through thick morning air. The kind of pad that exists before the world is awake."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Peat_Mist.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Peat_Mist.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Peat Mist",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.08,
+    "MOVEMENT": 0.05,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.78,
+    "movement": 0.05,
+    "density": 0.28,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.05,
+      "wash_viscosity": 0.95,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 45.0,
+      "wash_spreadMax": 30.0,
+      "wash_brightness": 0.08,
+      "wash_warmth": 0.78,
+      "wash_ampAttack": 5.0,
+      "wash_ampDecay": 3.0,
+      "wash_ampSustain": 0.92,
+      "wash_ampRelease": 18.0,
+      "wash_filterCutoff": 400.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.06,
+      "wash_filtAttack": 4.0,
+      "wash_filtDecay": 5.0,
+      "wash_filtSustain": 0.92,
+      "wash_filtRelease": 12.0,
+      "wash_lfo1Rate": 0.003,
+      "wash_lfo1Depth": 0.06,
+      "wash_lfo2Rate": 0.002,
+      "wash_lfo2Depth": 0.03,
+      "wash_stereoWidth": 0.48,
+      "wash_level": 0.72,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "peat",
+    "dark",
+    "ambient",
+    "earth",
+    "narrow"
+  ],
+  "description": "Warm earth tones from dense viscosity. Spread confined to 30Hz \u2014 almost stationary, like bog-filtered light."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Still_Basin.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Still_Basin.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Still Basin",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.18,
+    "MOVEMENT": 0.02,
+    "COUPLING": 0.5,
+    "SPACE": 0.8
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.18,
+    "warmth": 0.72,
+    "movement": 0.02,
+    "density": 0.2,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.02,
+      "wash_viscosity": 0.98,
+      "wash_harmonics": 3,
+      "wash_diffusionTime": 120.0,
+      "wash_spreadMax": 20.0,
+      "wash_brightness": 0.18,
+      "wash_warmth": 0.72,
+      "wash_ampAttack": 6.0,
+      "wash_ampDecay": 3.0,
+      "wash_ampSustain": 0.95,
+      "wash_ampRelease": 24.0,
+      "wash_filterCutoff": 600.0,
+      "wash_filterRes": 0.03,
+      "wash_filtEnvAmount": 0.05,
+      "wash_filtAttack": 5.0,
+      "wash_filtDecay": 5.0,
+      "wash_filtSustain": 0.95,
+      "wash_filtRelease": 15.0,
+      "wash_lfo1Rate": 0.002,
+      "wash_lfo1Depth": 0.04,
+      "wash_lfo2Rate": 0.001,
+      "wash_lfo2Depth": 0.02,
+      "wash_stereoWidth": 0.5,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "still",
+    "suspended",
+    "minimal",
+    "geological",
+    "ambient"
+  ],
+  "description": "Near-zero diffusion rate \u2014 a spectral snapshot suspended. The tone barely moves; the diffusion is geological."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Tide_Chart.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Tide_Chart.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tide Chart",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.25,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.65
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.25,
+    "warmth": 0.65,
+    "movement": 0.18,
+    "density": 0.3,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.12,
+      "wash_viscosity": 0.75,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 25.0,
+      "wash_spreadMax": 70.0,
+      "wash_brightness": 0.25,
+      "wash_warmth": 0.65,
+      "wash_ampAttack": 2.0,
+      "wash_ampDecay": 2.0,
+      "wash_ampSustain": 0.85,
+      "wash_ampRelease": 10.0,
+      "wash_filterCutoff": 800.0,
+      "wash_filterRes": 0.06,
+      "wash_filtEnvAmount": 0.12,
+      "wash_filtAttack": 2.0,
+      "wash_filtDecay": 3.5,
+      "wash_filtSustain": 0.8,
+      "wash_filtRelease": 8.0,
+      "wash_lfo1Rate": 0.005,
+      "wash_lfo1Depth": 0.22,
+      "wash_lfo2Rate": 0.003,
+      "wash_lfo2Depth": 0.1,
+      "wash_stereoWidth": 0.6,
+      "wash_level": 0.74,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "tidal",
+    "LFO",
+    "slow",
+    "coastal",
+    "cycle"
+  ],
+  "description": "Medium diffusion with tidal LFO \u2014 the spread rises and falls with a 200-second period, simulating coastal tidal cycles."
+}

--- a/Presets/XOceanus/Atmosphere/Overwash_Velvet_Shore.xometa
+++ b/Presets/XOceanus/Atmosphere/Overwash_Velvet_Shore.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Velvet Shore",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.38,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.62
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.62,
+    "movement": 0.14,
+    "density": 0.38,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.16,
+      "wash_viscosity": 0.68,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 20.0,
+      "wash_spreadMax": 90.0,
+      "wash_brightness": 0.38,
+      "wash_warmth": 0.62,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.85,
+      "wash_ampRelease": 10.0,
+      "wash_filterCutoff": 1400.0,
+      "wash_filterRes": 0.08,
+      "wash_filtEnvAmount": 0.2,
+      "wash_filtAttack": 1.5,
+      "wash_filtDecay": 2.5,
+      "wash_filtSustain": 0.78,
+      "wash_filtRelease": 7.0,
+      "wash_lfo1Rate": 0.015,
+      "wash_lfo1Depth": 0.2,
+      "wash_lfo2Rate": 0.008,
+      "wash_lfo2Depth": 0.1,
+      "wash_stereoWidth": 0.75,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "velvet",
+    "warm",
+    "wide-stereo",
+    "harmonics",
+    "dawn"
+  ],
+  "description": "Eight harmonics, moderate diffusion, wide stereo. The harmonic fan opens slowly \u2014 brightness rising like dawn over calm water."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Aromatic_Reduction.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Aromatic_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Aromatic Reduction",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.32
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.6,
+    "movement": 0.14,
+    "density": 0.32,
+    "space": 0.6,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.12,
+      "worn_heat": 0.35,
+      "worn_richness": 0.42,
+      "worn_maillard": 0.18,
+      "worn_umamiDepth": 0.32,
+      "worn_concentrate": 0.28,
+      "worn_sessionTarget": 18.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1100.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.15,
+      "worn_ampAttack": 1.8,
+      "worn_ampDecay": 2.2,
+      "worn_ampSustain": 0.84,
+      "worn_ampRelease": 9.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.011,
+      "worn_lfo1Depth": 0.14,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.07,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "aromatic",
+    "herbs",
+    "fresh",
+    "medium"
+  ],
+  "description": "Herb and aromatics reduction \u2014 medium warmth, elevated brightness because of volatile aromatics still present. Fresh reduction."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Bouillon_Cube.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Bouillon_Cube.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bouillon Cube",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.55,
+    "MOVEMENT": 0.13,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.65,
+    "movement": 0.12,
+    "density": 0.48,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.12,
+      "worn_heat": 0.5,
+      "worn_richness": 0.55,
+      "worn_maillard": 0.35,
+      "worn_umamiDepth": 0.45,
+      "worn_concentrate": 0.48,
+      "worn_sessionTarget": 18.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 800.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 2.0,
+      "worn_ampDecay": 2.5,
+      "worn_ampSustain": 0.88,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.01,
+      "worn_lfo1Depth": 0.13,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "concentrated",
+    "compressed",
+    "bold",
+    "instant"
+  ],
+  "description": "Concentrated from the start \u2014 high concentrate parameter, medium warmth. All the flavor already extracted and compressed."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Ramen_Base.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Ramen_Base.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Ramen Base",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.58,
+    "MOVEMENT": 0.11,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.18,
+    "warmth": 0.78,
+    "movement": 0.1,
+    "density": 0.45,
+    "space": 0.62,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.45,
+      "worn_richness": 0.58,
+      "worn_maillard": 0.28,
+      "worn_umamiDepth": 0.52,
+      "worn_concentrate": 0.35,
+      "worn_sessionTarget": 22.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 700.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.12,
+      "worn_ampAttack": 2.2,
+      "worn_ampDecay": 2.8,
+      "worn_ampSustain": 0.9,
+      "worn_ampRelease": 11.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.008,
+      "worn_lfo1Depth": 0.11,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "ramen",
+    "rich",
+    "milky",
+    "warmth"
+  ],
+  "description": "Rich tonkotsu-style \u2014 milky warmth from prolonged bone extraction. High richness, high umami from the start."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Saffron_Thread.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Saffron_Thread.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Saffron Thread",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.4
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.7,
+    "movement": 0.12,
+    "density": 0.38,
+    "space": 0.6,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.42,
+      "worn_richness": 0.5,
+      "worn_maillard": 0.2,
+      "worn_umamiDepth": 0.4,
+      "worn_concentrate": 0.32,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 900.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 1.8,
+      "worn_ampDecay": 2.2,
+      "worn_ampSustain": 0.88,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.009,
+      "worn_lfo1Depth": 0.12,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "saffron",
+    "golden",
+    "warm",
+    "rich"
+  ],
+  "description": "Warm saffron-tinted \u2014 golden warmth from high richness, moderate heat. The most expensive of the atmosphere reductions."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Session_Start.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Session_Start.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Session Start",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.11,
+    "COUPLING": 0.5,
+    "SPACE": 0.28
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.58,
+    "movement": 0.12,
+    "density": 0.22,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.09,
+      "worn_heat": 0.28,
+      "worn_richness": 0.35,
+      "worn_maillard": 0.1,
+      "worn_umamiDepth": 0.28,
+      "worn_concentrate": 0.2,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1200.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 1.5,
+      "worn_ampDecay": 2.0,
+      "worn_ampSustain": 0.84,
+      "worn_ampRelease": 8.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.009,
+      "worn_lfo1Depth": 0.11,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "fresh",
+    "start",
+    "beginning",
+    "clean"
+  ],
+  "description": "Fresh session \u2014 the stock just beginning. Near-zero session age, clean flavors, everything still to come."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Simmer_Study.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Simmer_Study.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Simmer Study",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.38,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.32
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.68,
+    "movement": 0.09,
+    "density": 0.28,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.28,
+      "worn_richness": 0.38,
+      "worn_maillard": 0.15,
+      "worn_umamiDepth": 0.32,
+      "worn_concentrate": 0.24,
+      "worn_sessionTarget": 25.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 800.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.12,
+      "worn_ampAttack": 2.5,
+      "worn_ampDecay": 3.0,
+      "worn_ampSustain": 0.88,
+      "worn_ampRelease": 11.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.007,
+      "worn_lfo1Depth": 0.1,
+      "worn_lfo2Rate": 0.003,
+      "worn_lfo2Depth": 0.05,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "steady",
+    "gentle",
+    "simmer",
+    "background"
+  ],
+  "description": "A steady gentle simmer \u2014 low heat, slow reduction. Background presence that barely registers until you listen."
+}

--- a/Presets/XOceanus/Atmosphere/Overworn_Soup_du_Jour.xometa
+++ b/Presets/XOceanus/Atmosphere/Overworn_Soup_du_Jour.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Soup du Jour",
+  "mood": "Atmosphere",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.38
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.62,
+    "movement": 0.14,
+    "density": 0.35,
+    "space": 0.58,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.11,
+      "worn_heat": 0.38,
+      "worn_richness": 0.45,
+      "worn_maillard": 0.22,
+      "worn_umamiDepth": 0.38,
+      "worn_concentrate": 0.3,
+      "worn_sessionTarget": 22.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1000.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.15,
+      "worn_ampAttack": 2.0,
+      "worn_ampDecay": 2.5,
+      "worn_ampSustain": 0.86,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.01,
+      "worn_lfo1Depth": 0.14,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.07,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "atmosphere",
+    "daily",
+    "balanced",
+    "evolving",
+    "moderate"
+  ],
+  "description": "A daily evolving soup \u2014 moderate reduction, balanced flavors. Changes with the session but never becomes extreme."
+}

--- a/Presets/XOceanus/Atmosphere/Owlfish_Pressure_Glow.xometa
+++ b/Presets/XOceanus/Atmosphere/Owlfish_Pressure_Glow.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Pressure Glow",
+  "mood": "Atmosphere",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "The owlfish's bioluminescent organs glow steadily in deep water. High filter cutoff (0.75), low body level, long amp release (1800ms), generous reverb.",
+  "tags": [
+    "atmosphere",
+    "glow",
+    "ambient",
+    "bioluminescent"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 90.0,
+      "owl_bodyLevel": 0.3,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.75,
+      "owl_filterEnvDepth": 0.25,
+      "owl_filterReso": 0.3,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.0,
+      "owl_grainMix": 0.0,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.5,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.4,
+      "owl_reverbMix": 0.38,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.65,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.6,
+      "owl_subLevel2": 0.4,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 350,
+      "owl_ampDecay": 600,
+      "owl_ampSustain": 0.8,
+      "owl_ampRelease": 1800,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.55,
+    "movement": 0.18,
+    "density": 0.4,
+    "space": 0.82,
+    "aggression": 0.1
+  },
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.0,
+    "SPACE": 0.82
+  }
+}

--- a/Presets/XOceanus/Crystalline/Obiont/Crystal_Lattice_2D.xometa
+++ b/Presets/XOceanus/Crystalline/Obiont/Crystal_Lattice_2D.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Crystal Lattice 2D",
+  "mood": "Crystalline",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "2D mode, Rule 110 \u2014 Turing-complete computation rendered as a 2D crystal growing outward. Very low evolution (0.8Hz) lets each generation crystallize. High filter resonance (0.68) at 3500Hz catches the crystal's harmonic cluster.",
+  "tags": [
+    "crystalline",
+    "2d",
+    "growing",
+    "rule-110",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 1,
+      "obnt_rule": 110,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 0.8,
+      "obnt_gridDensity": 0.45,
+      "obnt_chaos": 0.04,
+      "obnt_projection": 0.55,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 3500.0,
+      "obnt_filterResonance": 0.68,
+      "obnt_attack": 0.5,
+      "obnt_decay": 2.0,
+      "obnt_sustain": 0.8,
+      "obnt_release": 3.5,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.04,
+      "obnt_lfo1Depth": 0.2,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.68,
+    "warmth": 0.2,
+    "movement": 0.15,
+    "density": 0.55,
+    "space": 0.7,
+    "aggression": 0.08
+  },
+  "macros": {
+    "CHAOS": 0.08,
+    "EVOLUTION": 0.12,
+    "SPACE": 0.7,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Crystalline/Obiont/Dendritic_Growth.xometa
+++ b/Presets/XOceanus/Crystalline/Obiont/Dendritic_Growth.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Dendritic Growth",
+  "mood": "Crystalline",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 33 \u2014 produces dendritic (tree-branch) patterns like frost crystal formation. Low grid density (0.3) gives dendrites room to branch. Projection 0.7 maps branching distance to pitch \u2014 higher notes grow longer arms.",
+  "tags": [
+    "crystalline",
+    "dendritic",
+    "frost",
+    "rule-33",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 33,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 3.0,
+      "obnt_gridDensity": 0.3,
+      "obnt_chaos": 0.05,
+      "obnt_projection": 0.7,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4200.0,
+      "obnt_filterResonance": 0.5,
+      "obnt_attack": 0.04,
+      "obnt_decay": 1.0,
+      "obnt_sustain": 0.55,
+      "obnt_release": 2.0,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.18,
+      "obnt_lfo1Depth": 0.22,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.18,
+    "movement": 0.2,
+    "density": 0.35,
+    "space": 0.65,
+    "aggression": 0.12
+  },
+  "macros": {
+    "CHAOS": 0.1,
+    "EVOLUTION": 0.32,
+    "SPACE": 0.65,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Crystalline/Obiont/Facet_Collapse.xometa
+++ b/Presets/XOceanus/Crystalline/Obiont/Facet_Collapse.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Facet Collapse",
+  "mood": "Crystalline",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 193 \u2014 high-complexity rule producing sudden phase transitions where a stable lattice abruptly collapses and reforms. The collapses are audible as brief silences or pitch jumps. High evolution (10Hz) makes collapses frequent.",
+  "tags": [
+    "crystalline",
+    "collapse",
+    "phase-transition",
+    "rule-193",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 193,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 10.0,
+      "obnt_gridDensity": 0.62,
+      "obnt_chaos": 0.18,
+      "obnt_projection": 0.45,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 5500.0,
+      "obnt_filterResonance": 0.45,
+      "obnt_attack": 0.006,
+      "obnt_decay": 0.35,
+      "obnt_sustain": 0.3,
+      "obnt_release": 0.4,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 2.0,
+      "obnt_lfo1Depth": 0.32,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.7,
+    "warmth": 0.18,
+    "movement": 0.72,
+    "density": 0.55,
+    "space": 0.42,
+    "aggression": 0.45
+  },
+  "macros": {
+    "CHAOS": 0.36,
+    "EVOLUTION": 0.82,
+    "SPACE": 0.42,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Crystalline/Obiont/Quartz_Resonance.xometa
+++ b/Presets/XOceanus/Crystalline/Obiont/Quartz_Resonance.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Quartz Resonance",
+  "mood": "Crystalline",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 90 in 2D mode \u2014 Sierpinski triangle becomes a 2D diamond lattice. Extremely low chaos (0.01) keeps the crystal perfect. High resonance (0.75) at 4000Hz amplifies the lattice's natural frequency. Slow evolution (1.5Hz) lets each generation ring.",
+  "tags": [
+    "crystalline",
+    "quartz",
+    "diamond",
+    "rule-90",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 1,
+      "obnt_rule": 90,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 1.5,
+      "obnt_gridDensity": 0.5,
+      "obnt_chaos": 0.01,
+      "obnt_projection": 0.6,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4000.0,
+      "obnt_filterResonance": 0.75,
+      "obnt_attack": 0.15,
+      "obnt_decay": 1.5,
+      "obnt_sustain": 0.7,
+      "obnt_release": 2.8,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.08,
+      "obnt_lfo1Depth": 0.15,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.75,
+    "warmth": 0.2,
+    "movement": 0.2,
+    "density": 0.55,
+    "space": 0.68,
+    "aggression": 0.08
+  },
+  "macros": {
+    "CHAOS": 0.02,
+    "EVOLUTION": 0.2,
+    "SPACE": 0.68,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Crystalline/Obscura_Glass_Plate.xometa
+++ b/Presets/XOceanus/Crystalline/Obscura_Glass_Plate.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Glass Plate",
+  "mood": "Crystalline",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.32,
+    "movement": 0.04,
+    "density": 0.42,
+    "space": 0.68,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.8,
+      "obscura_damping": 0.25,
+      "obscura_nonlinear": 0.38,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.5,
+      "obscura_scanWidth": 0.4,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.35,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 4.0,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.35,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 4.0,
+      "obscura_lfo1Rate": 0.04,
+      "obscura_lfo1Depth": 0.06,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.2,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.2,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "glass",
+    "plate",
+    "rigid",
+    "crystalline",
+    "flexural"
+  ],
+  "description": "Large glass plate \u2014 Periodic boundary (free-floating circular approximation). High stiffness from glass rigidity. Moderate nonlinearity capturing glass flexural behavior. Wide scanner aperture to reflect the distributed energy of a plate. Short release makes this percussive \u2014 glass stops ringing quickly under any damping."
+}

--- a/Presets/XOceanus/Crystalline/Obscura_Tuning_Fork.xometa
+++ b/Presets/XOceanus/Crystalline/Obscura_Tuning_Fork.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tuning Fork",
+  "mood": "Crystalline",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.3
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.42,
+    "movement": 0.02,
+    "density": 0.12,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.88,
+      "obscura_damping": 0.04,
+      "obscura_nonlinear": 0.02,
+      "obscura_excitePos": 0.98,
+      "obscura_exciteWidth": 0.08,
+      "obscura_scanWidth": 0.48,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.3,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 12.0,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.3,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 12.0,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.3,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "tuning-fork",
+    "steel",
+    "linear",
+    "pure",
+    "crystal"
+  ],
+  "description": "Steel tuning fork \u2014 Fixed boundary (handle anchored), very high stiffness (steel tine). Minimal damping so it rings for an extremely long time. Near-zero nonlinearity (perfect linearity is the goal of tuning fork design). The fork produces a nearly pure sine \u2014 only the fundamental survives the long decay. Point excitation at the tip."
+}

--- a/Presets/XOceanus/Crystalline/Osmosis_Crystal_Lattice_Gate.xometa
+++ b/Presets/XOceanus/Crystalline/Osmosis_Crystal_Lattice_Gate.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Crystal Lattice Gate",
+  "mood": "Crystalline",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.3,
+    "SPACE": 0.88
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.45,
+    "movement": 0.04,
+    "density": 0.22,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.3,
+      "osmo_selectivity": 1.0,
+      "osmo_reactivity": 0.05,
+      "osmo_memory": 0.88,
+      "osmo_filterEnvAmt": 0.22,
+      "osmo_lfo1Rate": 0.01,
+      "osmo_lfo1Depth": 0.04,
+      "osmo_macroCharacter": 0.8,
+      "osmo_macroMovement": 0.04,
+      "osmo_macroCoupling": 0.3,
+      "osmo_macroSpace": 0.88
+    }
+  },
+  "tags": [
+    "osmosis",
+    "crystalline",
+    "lattice",
+    "ions",
+    "selective",
+    "crystal",
+    "diffusion"
+  ],
+  "description": "Ion diffusion through crystal lattice \u2014 maximum selectivity, minimum reactivity. Only specific ions in exact lattice positions."
+}

--- a/Presets/XOceanus/Crystalline/Osmosis_Electrolyte_Gate.xometa
+++ b/Presets/XOceanus/Crystalline/Osmosis_Electrolyte_Gate.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Electrolyte Gate",
+  "mood": "Crystalline",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.66,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.45,
+    "SPACE": 0.6
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.48,
+    "movement": 0.1,
+    "density": 0.25,
+    "space": 0.72,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.45,
+      "osmo_selectivity": 0.82,
+      "osmo_reactivity": 0.3,
+      "osmo_memory": 0.6,
+      "osmo_filterEnvAmt": 0.3,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.12,
+      "osmo_macroCharacter": 0.656,
+      "osmo_macroMovement": 0.12,
+      "osmo_macroCoupling": 0.45,
+      "osmo_macroSpace": 0.6
+    }
+  },
+  "tags": [
+    "osmosis",
+    "crystalline",
+    "electrolyte",
+    "charged",
+    "particles",
+    "selective"
+  ],
+  "description": "Electrolyte membrane \u2014 medium permeability, high selectivity. Charged particles passing through crystalline structure."
+}

--- a/Presets/XOceanus/Crystalline/Osmosis_Mineral_Seep.xometa
+++ b/Presets/XOceanus/Crystalline/Osmosis_Mineral_Seep.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Mineral Seep",
+  "mood": "Crystalline",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.15,
+    "SPACE": 0.95
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.52,
+    "movement": 0.04,
+    "density": 0.18,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.15,
+      "osmo_selectivity": 0.88,
+      "osmo_reactivity": 0.08,
+      "osmo_memory": 0.95,
+      "osmo_filterEnvAmt": 0.15,
+      "osmo_lfo1Rate": 0.01,
+      "osmo_lfo1Depth": 0.04,
+      "osmo_macroCharacter": 0.7040000000000001,
+      "osmo_macroMovement": 0.04,
+      "osmo_macroCoupling": 0.15,
+      "osmo_macroSpace": 0.95
+    }
+  },
+  "tags": [
+    "osmosis",
+    "crystalline",
+    "mineral",
+    "rock",
+    "geological",
+    "slow",
+    "seep"
+  ],
+  "description": "Mineral diffusion through rock \u2014 very low permeability, high selectivity, maximum memory."
+}

--- a/Presets/XOceanus/Crystalline/Osmosis_Silica_Filter.xometa
+++ b/Presets/XOceanus/Crystalline/Osmosis_Silica_Filter.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Silica Filter",
+  "mood": "Crystalline",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.35,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.45,
+    "movement": 0.06,
+    "density": 0.2,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.35,
+      "osmo_selectivity": 0.9,
+      "osmo_reactivity": 0.2,
+      "osmo_memory": 0.75,
+      "osmo_filterEnvAmt": 0.2,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.7200000000000001,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.35,
+      "osmo_macroSpace": 0.75
+    }
+  },
+  "tags": [
+    "osmosis",
+    "crystalline",
+    "silica",
+    "filter",
+    "desiccant",
+    "selective"
+  ],
+  "description": "Silica gel filter \u2014 high selectivity, medium permeability. The desiccant absorbing specific molecules."
+}

--- a/Presets/XOceanus/Crystalline/Osprey_Ice_Updraft.xometa
+++ b/Presets/XOceanus/Crystalline/Osprey_Ice_Updraft.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Ice Updraft",
+  "mood": "Crystalline",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Cold winter thermal rising off an ice field. Maximum fog (0.75), low sea state (0.05), high filterTilt (0.8), resonatorBright at maximum (0.9). Crystal-clear high end.",
+  "tags": [
+    "crystalline",
+    "cold",
+    "winter",
+    "high"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.2,
+      "osprey_ampDecay": 1.0,
+      "osprey_ampSustain": 0.7,
+      "osprey_ampRelease": 2.5,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.9,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.8,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.75,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.35,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.42,
+      "osprey_macroSpace": 0.8,
+      "osprey_resonatorBright": 0.9,
+      "osprey_resonatorDecay": 2.0,
+      "osprey_seaState": 0.05,
+      "osprey_shore": 0.2,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.82,
+    "warmth": 0.15,
+    "movement": 0.42,
+    "density": 0.35,
+    "space": 0.8,
+    "aggression": 0.1
+  },
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.42,
+    "COUPLING": 0.0,
+    "SPACE": 0.8
+  }
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Crystal_Grid.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Crystal_Grid.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Crystal Grid",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.88,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.35,
+    "movement": 0.02,
+    "density": 0.52,
+    "space": 0.68,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 8,
+      "cast_transition": 1,
+      "cast_latticeSnap": 1.0,
+      "cast_purity": 0.88,
+      "cast_crackle": 0.3,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.68,
+      "cast_filterCutoff": 1500.0,
+      "cast_filterRes": 0.08,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.83,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "grid",
+    "maximum",
+    "harmonic",
+    "locked"
+  ],
+  "description": "Maximum peaks, maximum lattice snap \u2014 a complete harmonic grid locked in place."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Crystal_Rain.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Crystal_Rain.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Crystal Rain",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.42,
+    "movement": 0.08,
+    "density": 0.35,
+    "space": 0.65,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.78,
+      "cast_crystalSize": 0.45,
+      "cast_numPeaks": 5,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.75,
+      "cast_purity": 0.8,
+      "cast_crackle": 0.6,
+      "cast_shatterGap": 0.03,
+      "cast_stereoWidth": 0.67,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.82,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "rain",
+    "freezing",
+    "reform",
+    "brief"
+  ],
+  "description": "Short shatter gap \u2014 crystals form, shatter briefly, reform. Like freezing rain crystallizing on impact."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Diamond_Lattice.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Diamond_Lattice.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Diamond Lattice",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.95,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.42
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.58,
+    "warmth": 0.35,
+    "movement": 0.02,
+    "density": 0.38,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.88,
+      "cast_crystalSize": 0.42,
+      "cast_numPeaks": 5,
+      "cast_transition": 1,
+      "cast_latticeSnap": 1.0,
+      "cast_purity": 0.95,
+      "cast_crackle": 0.3,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 1500.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "diamond",
+    "maximum",
+    "precise",
+    "hard"
+  ],
+  "description": "Maximum lattice snap, high purity, crackle transition. The hardest crystal, most precisely ordered."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Frost_Lattice.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Frost_Lattice.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Frost Lattice",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.78,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.45,
+    "movement": 0.03,
+    "density": 0.25,
+    "space": 0.72,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.75,
+      "cast_crystalSize": 0.75,
+      "cast_numPeaks": 3,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.72,
+      "cast_purity": 0.78,
+      "cast_crackle": 0.5,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.06,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.009,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "frost",
+    "wide",
+    "large",
+    "irregular"
+  ],
+  "description": "Wide crystal size, lower peak count, crackle transition. Frost patterns on a window \u2014 large and irregular."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Ice_Lattice.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Ice_Lattice.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Ice Lattice",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.85,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.4,
+    "movement": 0.03,
+    "density": 0.32,
+    "space": 0.68,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.8,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 5,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.8,
+      "cast_purity": 0.85,
+      "cast_crackle": 0.4,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.67,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 11.0,
+      "cast_lfo1Rate": 0.009,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "ice",
+    "hexagonal",
+    "water",
+    "freezing"
+  ],
+  "description": "Hexagonal ice \u2014 medium crystal size, medium peaks, high purity, subtle crackle. Water freezing at natural pace."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Mineral_Pure.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Mineral_Pure.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Mineral Pure",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 1.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.38,
+    "movement": 0.02,
+    "density": 0.28,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.9,
+      "cast_crystalSize": 0.45,
+      "cast_numPeaks": 4,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.95,
+      "cast_purity": 1.0,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.68,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.06,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.85,
+      "cast_ampRelease": 13.0,
+      "cast_lfo1Rate": 0.007,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "mineral",
+    "pure",
+    "laboratory",
+    "cold"
+  ],
+  "description": "Maximum purity, no crackle, very high lattice snap. Laboratory-grown crystal \u2014 perfect and cold."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Quartz_Crystal.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Quartz_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Quartz Crystal",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.9,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.42,
+    "movement": 0.02,
+    "density": 0.35,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.45,
+      "cast_numPeaks": 5,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.9,
+      "cast_purity": 0.9,
+      "cast_crackle": 0.2,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.68,
+      "cast_filterCutoff": 1300.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "quartz",
+    "pure",
+    "lattice",
+    "archetype"
+  ],
+  "description": "High purity, high lattice snap, medium peaks. The archetype of crystalline structure."
+}

--- a/Presets/XOceanus/Crystalline/Overcast_Salt_Crystal.xometa
+++ b/Presets/XOceanus/Crystalline/Overcast_Salt_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Salt Crystal",
+  "mood": "Crystalline",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.88,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.48,
+    "movement": 0.02,
+    "density": 0.28,
+    "space": 0.7,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.88,
+      "cast_crystalSize": 0.2,
+      "cast_numPeaks": 4,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.85,
+      "cast_purity": 0.88,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.06,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.85,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "crystalline",
+    "salt",
+    "fine",
+    "small",
+    "precise"
+  ],
+  "description": "Small crystal size, high purity, instant transition. The fine-grained salt crystal."
+}

--- a/Presets/XOceanus/Crystalline/Owlfish_Translucent_Body.xometa
+++ b/Presets/XOceanus/Crystalline/Owlfish_Translucent_Body.xometa
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "name": "Translucent Body",
+  "mood": "Crystalline",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "The owlfish has a translucent body \u2014 you can see its organs. High filter (0.9), low body level, maximum filter track (1.0) for note-following brightness. Crystal clarity.",
+  "tags": [
+    "crystalline",
+    "translucent",
+    "clear"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 120.0,
+      "owl_bodyLevel": 0.25,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.9,
+      "owl_filterEnvDepth": 0.3,
+      "owl_filterReso": 0.5,
+      "owl_filterTrack": 1.0,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.0,
+      "owl_grainMix": 0.0,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.5,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.4,
+      "owl_reverbMix": 0.32,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.6,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.8,
+      "owl_subLevel2": 0.6,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 120,
+      "owl_ampDecay": 500,
+      "owl_ampSustain": 0.72,
+      "owl_ampRelease": 1200,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.78,
+    "warmth": 0.18,
+    "movement": 0.35,
+    "density": 0.32,
+    "space": 0.72,
+    "aggression": 0.1
+  },
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.0,
+    "SPACE": 0.72
+  }
+}

--- a/Presets/XOceanus/Deep/Obiont/Benthic_Automaton.xometa
+++ b/Presets/XOceanus/Deep/Obiont/Benthic_Automaton.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Benthic Automaton",
+  "mood": "Deep",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 9 \u2014 sparse, isolated, long-lived stable cells that never interact. Filter at 400Hz, long release (3.5s), ultra-slow evolution (0.3Hz). Each stable cell rings for nearly 4 seconds before the next generation.",
+  "tags": [
+    "deep",
+    "sparse",
+    "stable",
+    "rule-9",
+    "subterranean",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 9,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 0.3,
+      "obnt_gridDensity": 0.35,
+      "obnt_chaos": 0.02,
+      "obnt_projection": 0.5,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 400.0,
+      "obnt_filterResonance": 0.45,
+      "obnt_attack": 0.8,
+      "obnt_decay": 2.0,
+      "obnt_sustain": 0.6,
+      "obnt_release": 3.5,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.02,
+      "obnt_lfo1Depth": 0.35,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.6,
+    "movement": 0.08,
+    "density": 0.35,
+    "space": 0.85,
+    "aggression": 0.08
+  },
+  "macros": {
+    "CHAOS": 0.04,
+    "EVOLUTION": 0.06,
+    "SPACE": 0.85,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Deep/Obiont/Hadal_Layer.xometa
+++ b/Presets/XOceanus/Deep/Obiont/Hadal_Layer.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Hadal Layer",
+  "mood": "Deep",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "2D mode, Rule 22 \u2014 isolated droplets of pressure in a vast grid. Sub-bass filter (250Hz) with very low resonance (0.15) gives weight without peak. Ultra-slow evolution (0.15Hz) \u2014 each generation takes 6.7 seconds.",
+  "tags": [
+    "deep",
+    "2d",
+    "sub-bass",
+    "rule-22",
+    "vast",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 1,
+      "obnt_rule": 22,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 0.15,
+      "obnt_gridDensity": 0.4,
+      "obnt_chaos": 0.03,
+      "obnt_projection": 0.4,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 250.0,
+      "obnt_filterResonance": 0.15,
+      "obnt_attack": 1.5,
+      "obnt_decay": 3.0,
+      "obnt_sustain": 0.7,
+      "obnt_release": 5.0,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.01,
+      "obnt_lfo1Depth": 0.4,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.12,
+    "warmth": 0.72,
+    "movement": 0.05,
+    "density": 0.4,
+    "space": 0.95,
+    "aggression": 0.05
+  },
+  "macros": {
+    "CHAOS": 0.06,
+    "EVOLUTION": 0.03,
+    "SPACE": 0.95,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Deep/Obscura_Mantle_Resonance.xometa
+++ b/Presets/XOceanus/Deep/Obscura_Mantle_Resonance.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Mantle Resonance",
+  "mood": "Deep",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.2,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.68,
+    "movement": 0.18,
+    "density": 0.42,
+    "space": 0.72,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.58,
+      "obscura_damping": 0.14,
+      "obscura_nonlinear": 0.32,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.38,
+      "obscura_scanWidth": 0.48,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.38,
+      "obscura_ampAttack": 0.25,
+      "obscura_ampDecay": 0.0,
+      "obscura_ampSustain": 1.0,
+      "obscura_ampRelease": 2.0,
+      "obscura_physEnvAttack": 0.35,
+      "obscura_physEnvDecay": 0.0,
+      "obscura_physEnvSustain": 1.0,
+      "obscura_physEnvRelease": 1.0,
+      "obscura_lfo1Rate": 0.05,
+      "obscura_lfo1Depth": 0.1,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.12,
+      "obscura_lfo2Depth": 0.32,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.2,
+      "obscura_macroMovement": 0.1,
+      "obscura_macroCoupling": 0.2,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "squid",
+    "mantle",
+    "collagen",
+    "deep",
+    "creature"
+  ],
+  "description": "The squid's pressurized collagen mantle \u2014 this is Obscura's creature identity. Periodic boundary (cylindrical mantle cross-section). Medium stiffness from hydrostatic pressure-loaded collagen. LFO2 sweeps excitation position at 0.12Hz to simulate peristaltic mantle contractions shifting which modes are driven. The creature's body IS the resonator."
+}

--- a/Presets/XOceanus/Deep/Obscura_Rubber_Membrane.xometa
+++ b/Presets/XOceanus/Deep/Obscura_Rubber_Membrane.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Rubber Membrane",
+  "mood": "Deep",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.72,
+    "movement": 0.06,
+    "density": 0.22,
+    "space": 0.6,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.15,
+      "obscura_damping": 0.28,
+      "obscura_nonlinear": 0.75,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.35,
+      "obscura_scanWidth": 0.5,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.5,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 1.5,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.5,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 1.5,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 3,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.2,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "membrane",
+    "rubber",
+    "dark",
+    "nonlinear",
+    "compliant"
+  ],
+  "description": "Stretched rubber membrane \u2014 Fixed boundary (rim-mounted). Very low stiffness (rubber is compliant). High nonlinearity: at small amplitudes rubber behaves almost linearly, but large displacements rapidly increase tension (geometric stiffening). Result: dark, warm timbre that gets dramatically brighter when struck hard. The velocity-dependent timbre change is enormous."
+}

--- a/Presets/XOceanus/Deep/Oceanic_Pressure_Thermocline.xometa
+++ b/Presets/XOceanus/Deep/Oceanic_Pressure_Thermocline.xometa
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "name": "Pressure Thermocline",
+  "mood": "Deep",
+  "engines": [
+    "Oceanic"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "The thermocline layer where warm and cold water meet. Extreme damping (0.85) slows all motion to geological time. Waveform 2 (square sub). Ultra-slow LFO1 (0.02Hz). Only the deepest tidal pressure remains active.",
+  "tags": [
+    "deep",
+    "thermocline",
+    "pressure",
+    "sub-bass"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Oceanic": {
+      "ocean_alignment": 0.6,
+      "ocean_cohesion": 0.3,
+      "ocean_scatter": 0.1,
+      "ocean_separation": 0.5,
+      "ocean_damping": 0.85,
+      "ocean_tether": 0.6,
+      "ocean_subflocks": 2,
+      "ocean_waveform": 2,
+      "ocean_voiceMode": 0,
+      "ocean_glide": 0.0,
+      "ocean_ampAttack": 1.0,
+      "ocean_ampDecay": 2.5,
+      "ocean_ampSustain": 0.7,
+      "ocean_ampRelease": 5.0,
+      "ocean_swarmEnvAttack": 0.8,
+      "ocean_swarmEnvDecay": 2.0,
+      "ocean_swarmEnvSustain": 0.65,
+      "ocean_swarmEnvRelease": 4.0,
+      "ocean_lfo1Rate": 0.02,
+      "ocean_lfo1Depth": 0.5,
+      "ocean_lfo1Shape": 0,
+      "ocean_lfo2Rate": 0.04,
+      "ocean_lfo2Depth": 0.25,
+      "ocean_lfo2Shape": 0,
+      "ocean_macroCharacter": 0.2,
+      "ocean_macroMovement": 0.08,
+      "ocean_macroCoupling": 0.0,
+      "ocean_macroSpace": 0.92
+    }
+  },
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.65,
+    "movement": 0.08,
+    "density": 0.55,
+    "space": 0.92,
+    "aggression": 0.08
+  },
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.0,
+    "SPACE": 0.92
+  }
+}

--- a/Presets/XOceanus/Deep/Osmosis_Abyssal_Gate.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Abyssal_Gate.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Abyssal Gate",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.76,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.08,
+    "SPACE": 0.88
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.04,
+    "warmth": 0.7,
+    "movement": 0.04,
+    "density": 0.18,
+    "space": 0.9,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.08,
+      "osmo_selectivity": 0.95,
+      "osmo_reactivity": 0.1,
+      "osmo_memory": 0.88,
+      "osmo_filterEnvAmt": 0.15,
+      "osmo_lfo1Rate": 0.01,
+      "osmo_lfo1Depth": 0.04,
+      "osmo_macroCharacter": 0.76,
+      "osmo_macroMovement": 0.04,
+      "osmo_macroCoupling": 0.08,
+      "osmo_macroSpace": 0.88
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "abyss",
+    "gate",
+    "minimal",
+    "extreme"
+  ],
+  "description": "The deepest membrane \u2014 minimum permeability, maximum selectivity. Almost nothing passes."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Bathyal_Gradient.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Bathyal_Gradient.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bathyal Gradient",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.58,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.38,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.65,
+    "movement": 0.08,
+    "density": 0.25,
+    "space": 0.82,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.38,
+      "osmo_selectivity": 0.72,
+      "osmo_reactivity": 0.22,
+      "osmo_memory": 0.75,
+      "osmo_filterEnvAmt": 0.28,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.576,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.38,
+      "osmo_macroSpace": 0.75
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "bathyal",
+    "gradient",
+    "medium",
+    "selective"
+  ],
+  "description": "Mid-water gradient \u2014 medium everything but biased toward selectivity and memory."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Benthic_Filter.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Benthic_Filter.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Benthic Filter",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.68,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.28,
+    "SPACE": 0.9
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.68,
+    "movement": 0.06,
+    "density": 0.28,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.28,
+      "osmo_selectivity": 0.85,
+      "osmo_reactivity": 0.18,
+      "osmo_memory": 0.9,
+      "osmo_filterEnvAmt": 0.22,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.06,
+      "osmo_macroCharacter": 0.68,
+      "osmo_macroMovement": 0.06,
+      "osmo_macroCoupling": 0.28,
+      "osmo_macroSpace": 0.9
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "benthic",
+    "filter",
+    "sediment",
+    "low-frequency"
+  ],
+  "description": "Deep ocean floor filter \u2014 maximum memory, high selectivity. Only the lowest-frequency signals penetrate the sediment."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Hadal_Seep.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Hadal_Seep.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Hadal Seep",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.03,
+    "COUPLING": 0.22,
+    "SPACE": 0.95
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.04,
+    "warmth": 0.68,
+    "movement": 0.04,
+    "density": 0.22,
+    "space": 0.88,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.22,
+      "osmo_selectivity": 0.9,
+      "osmo_reactivity": 0.08,
+      "osmo_memory": 0.95,
+      "osmo_filterEnvAmt": 0.18,
+      "osmo_lfo1Rate": 0.01,
+      "osmo_lfo1Depth": 0.03,
+      "osmo_macroCharacter": 0.7200000000000001,
+      "osmo_macroMovement": 0.03,
+      "osmo_macroCoupling": 0.22,
+      "osmo_macroSpace": 0.95
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "hadal",
+    "seep",
+    "chemical",
+    "slow",
+    "maximum"
+  ],
+  "description": "Hadal cold seep \u2014 very slow, very selective, maximum memory. The chemical membrane of a deep ocean seep."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Halocline_Layer.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Halocline_Layer.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Halocline Layer",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.42,
+    "SPACE": 0.72
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.65,
+    "movement": 0.1,
+    "density": 0.38,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.42,
+      "osmo_selectivity": 0.88,
+      "osmo_reactivity": 0.3,
+      "osmo_memory": 0.72,
+      "osmo_filterEnvAmt": 0.38,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.12,
+      "osmo_macroCharacter": 0.7040000000000001,
+      "osmo_macroMovement": 0.12,
+      "osmo_macroCoupling": 0.42,
+      "osmo_macroSpace": 0.72
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "halocline",
+    "ocean",
+    "gradient",
+    "selective"
+  ],
+  "description": "The ocean's salt gradient membrane \u2014 high selectivity, medium permeability, long memory. Only specific frequency bands cross the density boundary."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Oceanic_Divide.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Oceanic_Divide.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Oceanic Divide",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.76,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.3,
+    "SPACE": 0.85
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.64,
+    "movement": 0.06,
+    "density": 0.2,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.3,
+      "osmo_selectivity": 0.95,
+      "osmo_reactivity": 0.15,
+      "osmo_memory": 0.85,
+      "osmo_filterEnvAmt": 0.22,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.06,
+      "osmo_macroCharacter": 0.76,
+      "osmo_macroMovement": 0.06,
+      "osmo_macroCoupling": 0.3,
+      "osmo_macroSpace": 0.85
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "ocean",
+    "divide",
+    "boundary",
+    "massive"
+  ],
+  "description": "The boundary between oceanic water masses \u2014 maximum selectivity, long memory."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Pressure_Membrane.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Pressure_Membrane.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pressure Membrane",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.52,
+    "MOVEMENT": 0.05,
+    "COUPLING": 0.32,
+    "SPACE": 0.95
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.05,
+    "warmth": 0.72,
+    "movement": 0.05,
+    "density": 0.25,
+    "space": 0.88,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.32,
+      "osmo_selectivity": 0.65,
+      "osmo_reactivity": 0.12,
+      "osmo_memory": 0.95,
+      "osmo_filterEnvAmt": 0.2,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.05,
+      "osmo_macroCharacter": 0.52,
+      "osmo_macroMovement": 0.05,
+      "osmo_macroCoupling": 0.32,
+      "osmo_macroSpace": 0.95
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "pressure",
+    "membrane",
+    "slow",
+    "deep"
+  ],
+  "description": "Deep pressure membrane \u2014 medium permeability, maximum memory, slow reactivity. Everything moving very slowly through enormous water pressure."
+}

--- a/Presets/XOceanus/Deep/Osmosis_Thermocline.xometa
+++ b/Presets/XOceanus/Deep/Osmosis_Thermocline.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Thermocline",
+  "mood": "Deep",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.74,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.35,
+    "SPACE": 0.8
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.6,
+    "movement": 0.06,
+    "density": 0.3,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.35,
+      "osmo_selectivity": 0.92,
+      "osmo_reactivity": 0.2,
+      "osmo_memory": 0.8,
+      "osmo_filterEnvAmt": 0.3,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.7360000000000001,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.35,
+      "osmo_macroSpace": 0.8
+    }
+  },
+  "tags": [
+    "osmosis",
+    "deep",
+    "thermocline",
+    "temperature",
+    "boundary",
+    "selective"
+  ],
+  "description": "Temperature boundary layer \u2014 very high selectivity, low reactivity. The membrane of temperature difference that separates ocean zones."
+}

--- a/Presets/XOceanus/Deep/Osprey_Dive_Entry.xometa
+++ b/Presets/XOceanus/Deep/Osprey_Dive_Entry.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Dive Entry",
+  "mood": "Deep",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "The moment of dive entry \u2014 maximum hull compression (0.85), folded depth (0.2), high sea state (0.8) for turbulent water. Instant attack, fast decay. Percussive.",
+  "tags": [
+    "deep",
+    "dive",
+    "precise",
+    "impact"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.0,
+      "osprey_ampDecay": 0.4,
+      "osprey_ampSustain": 0.3,
+      "osprey_ampRelease": 0.8,
+      "osprey_brine": 0.55,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.2,
+      "osprey_filterTilt": 0.5,
+      "osprey_foam": 0.65,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.85,
+      "osprey_macroCharacter": 0.75,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.72,
+      "osprey_macroSpace": 0.4,
+      "osprey_resonatorBright": 0.65,
+      "osprey_resonatorDecay": 1.2,
+      "osprey_seaState": 0.8,
+      "osprey_shore": 0.7,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.4,
+    "movement": 0.72,
+    "density": 0.6,
+    "space": 0.4,
+    "aggression": 0.65
+  },
+  "macros": {
+    "CHARACTER": 0.75,
+    "MOVEMENT": 0.72,
+    "COUPLING": 0.0,
+    "SPACE": 0.4
+  }
+}

--- a/Presets/XOceanus/Deep/Overflow_Abyss_Pressure.xometa
+++ b/Presets/XOceanus/Deep/Overflow_Abyss_Pressure.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Abyss Pressure",
+  "mood": "Deep",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.22,
+    "MOVEMENT": 0.05,
+    "COUPLING": 0.5,
+    "SPACE": 0.85
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.05,
+    "warmth": 0.8,
+    "movement": 0.07,
+    "density": 0.5,
+    "space": 0.88,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.9,
+      "flow_accumRate": 0.22,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.85,
+      "flow_strainColor": 0.22,
+      "flow_releaseTime": 5.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 350.0,
+      "flow_filterRes": 0.03,
+      "flow_filtEnvAmount": 0.07,
+      "flow_ampAttack": 4.5,
+      "flow_ampDecay": 4.0,
+      "flow_ampSustain": 0.93,
+      "flow_ampRelease": 18.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.003,
+      "flow_lfo1Depth": 0.05,
+      "flow_lfo2Rate": 0.001,
+      "flow_lfo2Depth": 0.03,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "deep",
+    "abyss",
+    "weight",
+    "dark",
+    "pressure"
+  ],
+  "description": "Near-zero brightness, maximum vessel size. The pressure of the deepest ocean zone \u2014 incomprehensible weight."
+}

--- a/Presets/XOceanus/Deep/Overflow_Dark_Consequence.xometa
+++ b/Presets/XOceanus/Deep/Overflow_Dark_Consequence.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Dark Consequence",
+  "mood": "Deep",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.24,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.5,
+    "SPACE": 0.72
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.76,
+    "movement": 0.09,
+    "density": 0.4,
+    "space": 0.85,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.65,
+      "flow_accumRate": 0.35,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.72,
+      "flow_strainColor": 0.24,
+      "flow_releaseTime": 3.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 400.0,
+      "flow_filterRes": 0.03,
+      "flow_filtEnvAmount": 0.08,
+      "flow_ampAttack": 3.0,
+      "flow_ampDecay": 3.5,
+      "flow_ampSustain": 0.91,
+      "flow_ampRelease": 15.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.004,
+      "flow_lfo1Depth": 0.06,
+      "flow_lfo2Rate": 0.002,
+      "flow_lfo2Depth": 0.03,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "deep",
+    "consequence",
+    "dark",
+    "heavy",
+    "low"
+  ],
+  "description": "The consequence pad for dark playing \u2014 dark, slow, heavy. When the player commits to the lowest register."
+}

--- a/Presets/XOceanus/Deep/Overflow_Hadal_Zone.xometa
+++ b/Presets/XOceanus/Deep/Overflow_Hadal_Zone.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Hadal Zone",
+  "mood": "Deep",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.5,
+    "SPACE": 0.9
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.04,
+    "warmth": 0.82,
+    "movement": 0.05,
+    "density": 0.48,
+    "space": 0.9,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.88,
+      "flow_accumRate": 0.15,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.9,
+      "flow_strainColor": 0.2,
+      "flow_releaseTime": 6.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 280.0,
+      "flow_filterRes": 0.02,
+      "flow_filtEnvAmount": 0.05,
+      "flow_ampAttack": 6.0,
+      "flow_ampDecay": 5.0,
+      "flow_ampSustain": 0.94,
+      "flow_ampRelease": 22.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.002,
+      "flow_lfo1Depth": 0.04,
+      "flow_lfo2Rate": 0.001,
+      "flow_lfo2Depth": 0.02,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "deep",
+    "hadal",
+    "geological",
+    "maximum",
+    "slow"
+  ],
+  "description": "Maximum vessel size, very slow accumulation. The slowest possible pressure change \u2014 geological."
+}

--- a/Presets/XOceanus/Deep/Overflow_Iron_Chamber.xometa
+++ b/Presets/XOceanus/Deep/Overflow_Iron_Chamber.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Iron Chamber",
+  "mood": "Deep",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.25,
+    "MOVEMENT": 0.07,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.78,
+    "movement": 0.1,
+    "density": 0.42,
+    "space": 0.82,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.7,
+      "flow_accumRate": 0.4,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.75,
+      "flow_strainColor": 0.25,
+      "flow_releaseTime": 3.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 420.0,
+      "flow_filterRes": 0.03,
+      "flow_filtEnvAmount": 0.08,
+      "flow_ampAttack": 3.5,
+      "flow_ampDecay": 3.5,
+      "flow_ampSustain": 0.92,
+      "flow_ampRelease": 16.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.004,
+      "flow_lfo1Depth": 0.07,
+      "flow_lfo2Rate": 0.002,
+      "flow_lfo2Depth": 0.03,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "deep",
+    "iron",
+    "vessel",
+    "massive",
+    "resonant"
+  ],
+  "description": "Medium accumulation, medium threshold, very thick vessel. Massive resonant object that takes significant pressure."
+}

--- a/Presets/XOceanus/Deep/Overflow_Submarine_Pressure.xometa
+++ b/Presets/XOceanus/Deep/Overflow_Submarine_Pressure.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Submarine Pressure",
+  "mood": "Deep",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.8
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.75,
+    "movement": 0.1,
+    "density": 0.45,
+    "space": 0.8,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.85,
+      "flow_accumRate": 0.3,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.8,
+      "flow_strainColor": 0.28,
+      "flow_releaseTime": 4.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 500.0,
+      "flow_filterRes": 0.04,
+      "flow_filtEnvAmount": 0.1,
+      "flow_ampAttack": 3.0,
+      "flow_ampDecay": 3.0,
+      "flow_ampSustain": 0.9,
+      "flow_ampRelease": 14.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.005,
+      "flow_lfo1Depth": 0.08,
+      "flow_lfo2Rate": 0.002,
+      "flow_lfo2Depth": 0.04,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "deep",
+    "submarine",
+    "extreme",
+    "dense",
+    "heavy"
+  ],
+  "description": "Extreme vessel size, high threshold \u2014 deep water pressure requiring enormous force to release."
+}

--- a/Presets/XOceanus/Deep/Overwash_Bathyal_Layer.xometa
+++ b/Presets/XOceanus/Deep/Overwash_Bathyal_Layer.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bathyal Layer",
+  "mood": "Deep",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.1,
+    "MOVEMENT": 0.07,
+    "COUPLING": 0.5,
+    "SPACE": 0.8
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.74,
+    "movement": 0.07,
+    "density": 0.24,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.07,
+      "wash_viscosity": 0.88,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 48.0,
+      "wash_spreadMax": 50.0,
+      "wash_brightness": 0.1,
+      "wash_warmth": 0.74,
+      "wash_ampAttack": 5.0,
+      "wash_ampDecay": 3.0,
+      "wash_ampSustain": 0.92,
+      "wash_ampRelease": 18.0,
+      "wash_filterCutoff": 550.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.08,
+      "wash_filtAttack": 4.5,
+      "wash_filtDecay": 5.0,
+      "wash_filtSustain": 0.91,
+      "wash_filtRelease": 13.0,
+      "wash_lfo1Rate": 0.004,
+      "wash_lfo1Depth": 0.08,
+      "wash_lfo2Rate": 0.002,
+      "wash_lfo2Depth": 0.04,
+      "wash_stereoWidth": 0.5,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "bathyal",
+    "mesopelagic",
+    "six-harmonic",
+    "slow",
+    "zone"
+  ],
+  "description": "The mesopelagic zone. Six harmonics at slow diffusion \u2014 just enough movement to feel alive, too slow to feel urgent."
+}

--- a/Presets/XOceanus/Deep/Overwash_Deep_Salt.xometa
+++ b/Presets/XOceanus/Deep/Overwash_Deep_Salt.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Deep Salt",
+  "mood": "Deep",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.08,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.78,
+    "movement": 0.08,
+    "density": 0.3,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.08,
+      "wash_viscosity": 0.87,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 42.0,
+      "wash_spreadMax": 65.0,
+      "wash_brightness": 0.08,
+      "wash_warmth": 0.78,
+      "wash_ampAttack": 4.0,
+      "wash_ampDecay": 2.5,
+      "wash_ampSustain": 0.91,
+      "wash_ampRelease": 16.0,
+      "wash_filterCutoff": 480.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.07,
+      "wash_filtAttack": 3.5,
+      "wash_filtDecay": 4.5,
+      "wash_filtSustain": 0.9,
+      "wash_filtRelease": 12.0,
+      "wash_lfo1Rate": 0.005,
+      "wash_lfo1Depth": 0.1,
+      "wash_lfo2Rate": 0.003,
+      "wash_lfo2Depth": 0.05,
+      "wash_stereoWidth": 0.55,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "salt",
+    "deep",
+    "mineral",
+    "dissolved",
+    "warmth"
+  ],
+  "description": "Eight harmonics, high viscosity, deep warmth \u2014 the mineral quality of deep ocean water. Nothing sharp, everything dissolved."
+}

--- a/Presets/XOceanus/Deep/Overwash_Hadal_Diffusion.xometa
+++ b/Presets/XOceanus/Deep/Overwash_Hadal_Diffusion.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Hadal Diffusion",
+  "mood": "Deep",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.05,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.5,
+    "SPACE": 0.88
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.05,
+    "warmth": 0.8,
+    "movement": 0.04,
+    "density": 0.15,
+    "space": 0.88,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.04,
+      "wash_viscosity": 0.96,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 90.0,
+      "wash_spreadMax": 60.0,
+      "wash_brightness": 0.05,
+      "wash_warmth": 0.8,
+      "wash_ampAttack": 8.0,
+      "wash_ampDecay": 4.0,
+      "wash_ampSustain": 0.95,
+      "wash_ampRelease": 25.0,
+      "wash_filterCutoff": 350.0,
+      "wash_filterRes": 0.03,
+      "wash_filtEnvAmount": 0.05,
+      "wash_filtAttack": 6.0,
+      "wash_filtDecay": 6.0,
+      "wash_filtSustain": 0.95,
+      "wash_filtRelease": 16.0,
+      "wash_lfo1Rate": 0.002,
+      "wash_lfo1Depth": 0.05,
+      "wash_lfo2Rate": 0.001,
+      "wash_lfo2Depth": 0.02,
+      "wash_stereoWidth": 0.45,
+      "wash_level": 0.68,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "hadal",
+    "deep",
+    "extreme",
+    "slow",
+    "abyssal"
+  ],
+  "description": "Four harmonics at extreme viscosity \u2014 spread maxes at 60Hz over a 90-second arc. The deepest oceanic zone, where sound travels sideways."
+}

--- a/Presets/XOceanus/Deep/Overwash_Pelagic_Current.xometa
+++ b/Presets/XOceanus/Deep/Overwash_Pelagic_Current.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pelagic Current",
+  "mood": "Deep",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.5,
+    "SPACE": 0.7
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.65,
+    "movement": 0.15,
+    "density": 0.28,
+    "space": 0.7,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.13,
+      "wash_viscosity": 0.76,
+      "wash_harmonics": 5,
+      "wash_diffusionTime": 28.0,
+      "wash_spreadMax": 70.0,
+      "wash_brightness": 0.2,
+      "wash_warmth": 0.65,
+      "wash_ampAttack": 3.0,
+      "wash_ampDecay": 2.0,
+      "wash_ampSustain": 0.88,
+      "wash_ampRelease": 12.0,
+      "wash_filterCutoff": 750.0,
+      "wash_filterRes": 0.06,
+      "wash_filtEnvAmount": 0.14,
+      "wash_filtAttack": 2.5,
+      "wash_filtDecay": 3.5,
+      "wash_filtSustain": 0.82,
+      "wash_filtRelease": 8.0,
+      "wash_lfo1Rate": 0.008,
+      "wash_lfo1Depth": 0.16,
+      "wash_lfo2Rate": 0.015,
+      "wash_lfo2Depth": 0.12,
+      "wash_stereoWidth": 0.58,
+      "wash_level": 0.72,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "pelagic",
+    "current",
+    "ocean",
+    "movement",
+    "flow"
+  ],
+  "description": "Mid-range diffusion with a faster-moving second LFO \u2014 like a current through still water, directional and slow."
+}

--- a/Presets/XOceanus/Deep/Overwash_Tidal_Silt.xometa
+++ b/Presets/XOceanus/Deep/Overwash_Tidal_Silt.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tidal Silt",
+  "mood": "Deep",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.06,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.5,
+    "SPACE": 0.82
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.76,
+    "movement": 0.06,
+    "density": 0.18,
+    "space": 0.82,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.06,
+      "wash_viscosity": 0.9,
+      "wash_harmonics": 3,
+      "wash_diffusionTime": 55.0,
+      "wash_spreadMax": 45.0,
+      "wash_brightness": 0.06,
+      "wash_warmth": 0.76,
+      "wash_ampAttack": 6.0,
+      "wash_ampDecay": 3.5,
+      "wash_ampSustain": 0.93,
+      "wash_ampRelease": 20.0,
+      "wash_filterCutoff": 450.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.07,
+      "wash_filtAttack": 5.0,
+      "wash_filtDecay": 5.0,
+      "wash_filtSustain": 0.92,
+      "wash_filtRelease": 14.0,
+      "wash_lfo1Rate": 0.003,
+      "wash_lfo1Depth": 0.07,
+      "wash_lfo2Rate": 0.002,
+      "wash_lfo2Depth": 0.04,
+      "wash_stereoWidth": 0.42,
+      "wash_level": 0.68,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "silt",
+    "dark",
+    "slow",
+    "oceanic",
+    "sediment"
+  ],
+  "description": "Dark harmonic wash through heavy viscosity \u2014 the spectral content of stirred sediment, barely moving."
+}

--- a/Presets/XOceanus/Deep/Overwash_Trench_Glow.xometa
+++ b/Presets/XOceanus/Deep/Overwash_Trench_Glow.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Trench Glow",
+  "mood": "Deep",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.15,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.78
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.7,
+    "movement": 0.08,
+    "density": 0.22,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.09,
+      "wash_viscosity": 0.84,
+      "wash_harmonics": 5,
+      "wash_diffusionTime": 40.0,
+      "wash_spreadMax": 55.0,
+      "wash_brightness": 0.15,
+      "wash_warmth": 0.7,
+      "wash_ampAttack": 4.5,
+      "wash_ampDecay": 2.5,
+      "wash_ampSustain": 0.92,
+      "wash_ampRelease": 16.0,
+      "wash_filterCutoff": 600.0,
+      "wash_filterRes": 0.05,
+      "wash_filtEnvAmount": 0.1,
+      "wash_filtAttack": 4.0,
+      "wash_filtDecay": 4.5,
+      "wash_filtSustain": 0.9,
+      "wash_filtRelease": 12.0,
+      "wash_lfo1Rate": 0.005,
+      "wash_lfo1Depth": 0.1,
+      "wash_lfo2Rate": 0.003,
+      "wash_lfo2Depth": 0.05,
+      "wash_stereoWidth": 0.52,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "trench",
+    "bioluminescent",
+    "deep",
+    "warmth",
+    "subtle"
+  ],
+  "description": "Bioluminescent quality \u2014 medium harmonics with subtle brightness that barely registers against the deep warmth. A creature making its own light."
+}

--- a/Presets/XOceanus/Deep/Overworn_Brown_Veal_Deep.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Brown_Veal_Deep.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Brown Veal Deep",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.6,
+    "MOVEMENT": 0.09,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.82,
+    "movement": 0.08,
+    "density": 0.45,
+    "space": 0.72,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.12,
+      "worn_heat": 0.55,
+      "worn_richness": 0.6,
+      "worn_maillard": 0.55,
+      "worn_umamiDepth": 0.5,
+      "worn_concentrate": 0.45,
+      "worn_sessionTarget": 30.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 600.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.1,
+      "worn_ampAttack": 3.5,
+      "worn_ampDecay": 3.0,
+      "worn_ampSustain": 0.92,
+      "worn_ampRelease": 14.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.006,
+      "worn_lfo1Depth": 0.09,
+      "worn_lfo2Rate": 0.003,
+      "worn_lfo2Depth": 0.04,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "brown",
+    "rich",
+    "maillard",
+    "evening"
+  ],
+  "description": "Rich brown veal stock, well-reduced. High maillard, deep warmth. A session pad that has been cooking all evening."
+}

--- a/Presets/XOceanus/Deep/Overworn_Cave_Reduction.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Cave_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cave Reduction",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.03,
+    "COUPLING": 0.5,
+    "SPACE": 0.68
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.02,
+    "warmth": 0.84,
+    "movement": 0.03,
+    "density": 0.72,
+    "space": 0.88,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.04,
+      "worn_heat": 0.7,
+      "worn_richness": 0.72,
+      "worn_maillard": 0.78,
+      "worn_umamiDepth": 0.68,
+      "worn_concentrate": 0.62,
+      "worn_sessionTarget": 50.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 320.0,
+      "worn_filterRes": 0.03,
+      "worn_filtEnvAmount": 0.05,
+      "worn_ampAttack": 8.0,
+      "worn_ampDecay": 6.0,
+      "worn_ampSustain": 0.97,
+      "worn_ampRelease": 25.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.002,
+      "worn_lfo1Depth": 0.03,
+      "worn_lfo2Rate": 0.001,
+      "worn_lfo2Depth": 0.01,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "geological",
+    "ancient",
+    "slow",
+    "minimal"
+  ],
+  "description": "Very slow ancient reduction \u2014 as if this stock has been reducing for geological time. Almost no movement."
+}

--- a/Presets/XOceanus/Deep/Overworn_Double_Espresso.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Double_Espresso.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Double Espresso",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.07,
+    "COUPLING": 0.5,
+    "SPACE": 0.6
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.04,
+    "warmth": 0.78,
+    "movement": 0.07,
+    "density": 0.62,
+    "space": 0.75,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.14,
+      "worn_heat": 0.7,
+      "worn_richness": 0.7,
+      "worn_maillard": 0.75,
+      "worn_umamiDepth": 0.6,
+      "worn_concentrate": 0.55,
+      "worn_sessionTarget": 25.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 380.0,
+      "worn_filterRes": 0.04,
+      "worn_filtEnvAmount": 0.08,
+      "worn_ampAttack": 4.0,
+      "worn_ampDecay": 3.5,
+      "worn_ampSustain": 0.93,
+      "worn_ampRelease": 16.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.005,
+      "worn_lfo1Depth": 0.07,
+      "worn_lfo2Rate": 0.003,
+      "worn_lfo2Depth": 0.04,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "dark",
+    "bitter",
+    "concentrated",
+    "espresso"
+  ],
+  "description": "Coffee reduction \u2014 intense, dark, bitter edge from high maillard. The opposite of delicate."
+}

--- a/Presets/XOceanus/Deep/Overworn_Glace_de_Viande.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Glace_de_Viande.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Glace de Viande",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.75,
+    "MOVEMENT": 0.05,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.03,
+    "warmth": 0.9,
+    "movement": 0.06,
+    "density": 0.8,
+    "space": 0.8,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.75,
+      "worn_richness": 0.75,
+      "worn_maillard": 0.8,
+      "worn_umamiDepth": 0.75,
+      "worn_concentrate": 0.7,
+      "worn_sessionTarget": 30.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 300.0,
+      "worn_filterRes": 0.03,
+      "worn_filtEnvAmount": 0.06,
+      "worn_ampAttack": 5.0,
+      "worn_ampDecay": 4.5,
+      "worn_ampSustain": 0.95,
+      "worn_ampRelease": 20.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.004,
+      "worn_lfo1Depth": 0.05,
+      "worn_lfo2Rate": 0.002,
+      "worn_lfo2Depth": 0.03,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "glaze",
+    "maximum",
+    "umami",
+    "intense"
+  ],
+  "description": "The ultimate reduction \u2014 meat glaze. Maximum umami, maximum concentrate, high heat. One tablespoon replaces an entire pot."
+}

--- a/Presets/XOceanus/Deep/Overworn_Jus_Gras.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Jus_Gras.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Jus Gras",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.68,
+    "MOVEMENT": 0.07,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.88,
+    "movement": 0.07,
+    "density": 0.58,
+    "space": 0.78,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.65,
+      "worn_richness": 0.68,
+      "worn_maillard": 0.65,
+      "worn_umamiDepth": 0.58,
+      "worn_concentrate": 0.52,
+      "worn_sessionTarget": 28.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 420.0,
+      "worn_filterRes": 0.04,
+      "worn_filtEnvAmount": 0.08,
+      "worn_ampAttack": 4.5,
+      "worn_ampDecay": 3.8,
+      "worn_ampSustain": 0.93,
+      "worn_ampRelease": 17.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.005,
+      "worn_lfo1Depth": 0.07,
+      "worn_lfo2Rate": 0.002,
+      "worn_lfo2Depth": 0.04,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "fat",
+    "warmth",
+    "jus",
+    "enriched"
+  ],
+  "description": "Fat-enriched reduced jus \u2014 deep warmth from the fat, reduced to essence. Warmth exceeds even standard reduction."
+}

--- a/Presets/XOceanus/Deep/Overworn_Long_Reduction.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Long_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Long Reduction",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.05,
+    "warmth": 0.85,
+    "movement": 0.05,
+    "density": 0.55,
+    "space": 0.8,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.05,
+      "worn_heat": 0.6,
+      "worn_richness": 0.65,
+      "worn_maillard": 0.6,
+      "worn_umamiDepth": 0.55,
+      "worn_concentrate": 0.5,
+      "worn_sessionTarget": 45.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 450.0,
+      "worn_filterRes": 0.04,
+      "worn_filtEnvAmount": 0.08,
+      "worn_ampAttack": 5.0,
+      "worn_ampDecay": 4.0,
+      "worn_ampSustain": 0.94,
+      "worn_ampRelease": 18.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.004,
+      "worn_lfo1Depth": 0.06,
+      "worn_lfo2Rate": 0.002,
+      "worn_lfo2Depth": 0.03,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "long",
+    "slow",
+    "concentrated",
+    "hours"
+  ],
+  "description": "Very slow reduction rate \u2014 the session that runs for hours. Dark and concentrated by the time you notice it changing."
+}

--- a/Presets/XOceanus/Deep/Overworn_Reduced_Dark.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Reduced_Dark.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Reduced Dark",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.5,
+    "SPACE": 0.62
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.04,
+    "warmth": 0.86,
+    "movement": 0.06,
+    "density": 0.62,
+    "space": 0.82,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.68,
+      "worn_richness": 0.7,
+      "worn_maillard": 0.7,
+      "worn_umamiDepth": 0.62,
+      "worn_concentrate": 0.55,
+      "worn_sessionTarget": 32.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 360.0,
+      "worn_filterRes": 0.04,
+      "worn_filtEnvAmount": 0.07,
+      "worn_ampAttack": 5.5,
+      "worn_ampDecay": 4.5,
+      "worn_ampSustain": 0.94,
+      "worn_ampRelease": 19.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.004,
+      "worn_lfo1Depth": 0.06,
+      "worn_lfo2Rate": 0.002,
+      "worn_lfo2Depth": 0.03,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "mid-session",
+    "dark",
+    "already-reduced",
+    "late"
+  ],
+  "description": "Mid-session state \u2014 a preset that begins reduced. warmth high, richness elevated, maillard prominent. The cook who arrived late."
+}

--- a/Presets/XOceanus/Deep/Overworn_Tar_Reduction.xometa
+++ b/Presets/XOceanus/Deep/Overworn_Tar_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tar Reduction",
+  "mood": "Deep",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.5,
+    "SPACE": 0.7
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.02,
+    "warmth": 0.88,
+    "movement": 0.04,
+    "density": 0.75,
+    "space": 0.85,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.8,
+      "worn_richness": 0.8,
+      "worn_maillard": 0.85,
+      "worn_umamiDepth": 0.7,
+      "worn_concentrate": 0.65,
+      "worn_sessionTarget": 35.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 280.0,
+      "worn_filterRes": 0.03,
+      "worn_filtEnvAmount": 0.05,
+      "worn_ampAttack": 6.0,
+      "worn_ampDecay": 5.0,
+      "worn_ampSustain": 0.96,
+      "worn_ampRelease": 22.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.003,
+      "worn_lfo1Depth": 0.04,
+      "worn_lfo2Rate": 0.001,
+      "worn_lfo2Depth": 0.02,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "deep",
+    "maximum",
+    "dark",
+    "extreme",
+    "essence"
+  ],
+  "description": "Maximum reduction \u2014 everything gone but the darkest, most concentrated essence. Near-zero brightness."
+}

--- a/Presets/XOceanus/Deep/Owlfish_Benthic_Stalk.xometa
+++ b/Presets/XOceanus/Deep/Owlfish_Benthic_Stalk.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Benthic Stalk",
+  "mood": "Deep",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Slow stalking across the benthic floor. Low filter (0.25) with drive-style mixtur (0.6), long release (2400ms). Body frequency at 40Hz for sub-bass weight.",
+  "tags": [
+    "deep",
+    "benthic",
+    "stalking",
+    "resonant"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 40.0,
+      "owl_bodyLevel": 0.75,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.25,
+      "owl_filterEnvDepth": 0.6,
+      "owl_filterReso": 0.55,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.0,
+      "owl_grainMix": 0.0,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.5,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.6,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.5,
+      "owl_reverbMix": 0.25,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.55,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 0,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.9,
+      "owl_subLevel2": 0.6,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 50,
+      "owl_ampDecay": 500,
+      "owl_ampSustain": 0.6,
+      "owl_ampRelease": 2400,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.18,
+    "warmth": 0.62,
+    "movement": 0.1,
+    "density": 0.55,
+    "space": 0.88,
+    "aggression": 0.25
+  },
+  "macros": {
+    "CHARACTER": 0.55,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.0,
+    "SPACE": 0.88
+  }
+}

--- a/Presets/XOceanus/Entangled/Obiont/Cooperation_Theorem.xometa
+++ b/Presets/XOceanus/Entangled/Obiont/Cooperation_Theorem.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Cooperation Theorem",
+  "mood": "Entangled",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 184 \u2014 the traffic rule. Cells move forward until blocked. At medium density (0.58) and evolution (6Hz), traffic jams emerge and dissolve organically. Coupling macro exposes traffic density as modulation output.",
+  "tags": [
+    "entangled",
+    "traffic",
+    "flow",
+    "rule-184",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 184,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 6.0,
+      "obnt_gridDensity": 0.58,
+      "obnt_chaos": 0.08,
+      "obnt_projection": 0.5,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 3800.0,
+      "obnt_filterResonance": 0.38,
+      "obnt_attack": 0.01,
+      "obnt_decay": 0.5,
+      "obnt_sustain": 0.55,
+      "obnt_release": 1.0,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.5,
+      "obnt_lfo1Depth": 0.22,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.35
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.42,
+    "movement": 0.5,
+    "density": 0.58,
+    "space": 0.55,
+    "aggression": 0.3
+  },
+  "macros": {
+    "CHAOS": 0.16,
+    "EVOLUTION": 0.55,
+    "SPACE": 0.55,
+    "COUPLING": 0.35
+  }
+}

--- a/Presets/XOceanus/Entangled/Obiont/Entangled_Automata.xometa
+++ b/Presets/XOceanus/Entangled/Obiont/Entangled_Automata.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Entangled Automata",
+  "mood": "Entangled",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 110 + ruleMorph sweeping toward Rule 126 \u2014 two of the most complex elementary rules blending into each other. The morph point (0.5) creates a hybrid rule exhibiting behaviors of neither parent. External engine can drive obnt_ruleMorph to navigate the complexity landscape.",
+  "tags": [
+    "entangled",
+    "complex",
+    "morphing",
+    "rule-110",
+    "coupling-ready",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 110,
+      "obnt_ruleMorph": 0.5,
+      "obnt_evolutionRate": 4.5,
+      "obnt_gridDensity": 0.52,
+      "obnt_chaos": 0.1,
+      "obnt_projection": 0.65,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4500.0,
+      "obnt_filterResonance": 0.35,
+      "obnt_attack": 0.05,
+      "obnt_decay": 0.7,
+      "obnt_sustain": 0.65,
+      "obnt_release": 1.5,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.35,
+      "obnt_lfo1Depth": 0.25,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 5,
+      "obnt_modAmt4": 0.4,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.4
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.35,
+    "movement": 0.45,
+    "density": 0.52,
+    "space": 0.6,
+    "aggression": 0.22
+  },
+  "macros": {
+    "CHAOS": 0.2,
+    "EVOLUTION": 0.5,
+    "SPACE": 0.6,
+    "COUPLING": 0.4
+  }
+}

--- a/Presets/XOceanus/Entangled/Obiont/Symbiont_Pair.xometa
+++ b/Presets/XOceanus/Entangled/Obiont/Symbiont_Pair.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Symbiont Pair",
+  "mood": "Entangled",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 30 in 2D mode \u2014 the classic chaotic rule creates spatially entangled patterns. No cell can be understood independently. Used as a coupling source, this engine drives chaotic modulation into any paired engine.",
+  "tags": [
+    "entangled",
+    "chaotic",
+    "symbiotic",
+    "rule-30",
+    "2d",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 1,
+      "obnt_rule": 30,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 8.0,
+      "obnt_gridDensity": 0.5,
+      "obnt_chaos": 0.2,
+      "obnt_projection": 0.7,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4200.0,
+      "obnt_filterResonance": 0.42,
+      "obnt_attack": 0.008,
+      "obnt_decay": 0.45,
+      "obnt_sustain": 0.5,
+      "obnt_release": 1.0,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.8,
+      "obnt_lfo1Depth": 0.3,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.5
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.3,
+    "movement": 0.6,
+    "density": 0.5,
+    "space": 0.55,
+    "aggression": 0.35
+  },
+  "macros": {
+    "CHAOS": 0.4,
+    "EVOLUTION": 0.72,
+    "SPACE": 0.55,
+    "COUPLING": 0.5
+  }
+}

--- a/Presets/XOceanus/Entangled/Osprey_Escort_Formation.xometa
+++ b/Presets/XOceanus/Entangled/Osprey_Escort_Formation.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Escort Formation",
+  "mood": "Entangled",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Two ospreys flying in synchronized escort formation. High sympathyAmount (0.8) links their resonators. COUPLING macro drives synchronization depth.",
+  "tags": [
+    "entangled",
+    "formation",
+    "synchronized",
+    "coupling-ready"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.025,
+      "osprey_ampDecay": 0.5,
+      "osprey_ampSustain": 0.55,
+      "osprey_ampRelease": 1.2,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.7,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.5,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.5,
+      "osprey_macroCoupling": 0.45,
+      "osprey_macroMovement": 0.5,
+      "osprey_macroSpace": 0.55,
+      "osprey_resonatorBright": 0.4,
+      "osprey_resonatorDecay": 2.0,
+      "osprey_seaState": 0.35,
+      "osprey_shore": 0.5,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.8,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.45,
+    "movement": 0.5,
+    "density": 0.52,
+    "space": 0.55,
+    "aggression": 0.3
+  },
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.5,
+    "COUPLING": 0.45,
+    "SPACE": 0.55
+  }
+}

--- a/Presets/XOceanus/Ethereal/Obscura_Glass_Armonica.xometa
+++ b/Presets/XOceanus/Ethereal/Obscura_Glass_Armonica.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Glass Armonica",
+  "mood": "Ethereal",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.2,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.35,
+    "movement": 0.05,
+    "density": 0.38,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.72,
+      "obscura_damping": 0.08,
+      "obscura_nonlinear": 0.28,
+      "obscura_excitePos": 0.3,
+      "obscura_exciteWidth": 0.38,
+      "obscura_scanWidth": 0.6,
+      "obscura_boundary": 1,
+      "obscura_sustain": 0.65,
+      "obscura_ampAttack": 0.5,
+      "obscura_ampDecay": 0.0,
+      "obscura_ampSustain": 1.0,
+      "obscura_ampRelease": 2.0,
+      "obscura_physEnvAttack": 0.8,
+      "obscura_physEnvDecay": 0.0,
+      "obscura_physEnvSustain": 1.0,
+      "obscura_physEnvRelease": 0.6,
+      "obscura_lfo1Rate": 0.08,
+      "obscura_lfo1Depth": 0.18,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.2,
+      "obscura_macroCoupling": 0.2,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "glass",
+    "armonica",
+    "ethereal",
+    "bowed",
+    "odd-harmonic"
+  ],
+  "description": "Glass harmonica (armonica) \u2014 Free boundary produces the hollow, odd-harmonic quality of glass resonating at its free edges. High stiffness because glass is rigid. Moderate nonlinearity captures amplitude-dependent pitch brightening at high bow pressure. Slow physics attack imitates the wet-finger contact building friction."
+}

--- a/Presets/XOceanus/Ethereal/Overcast_Frozen_Moment.xometa
+++ b/Presets/XOceanus/Ethereal/Overcast_Frozen_Moment.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Frozen Moment",
+  "mood": "Ethereal",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.92,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.38,
+    "movement": 0.02,
+    "density": 0.3,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 1.0,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 4,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.85,
+      "cast_purity": 0.92,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.8,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.06,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.85,
+      "cast_ampRelease": 15.0,
+      "cast_lfo1Rate": 0.005,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.002,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "ethereal",
+    "frozen",
+    "moment",
+    "time",
+    "stopped"
+  ],
+  "description": "Maximum freeze rate, instant transition, zero crackle \u2014 the absolute frozen moment. Time stopped."
+}

--- a/Presets/XOceanus/Ethereal/Overcast_Glass_Bell_Array.xometa
+++ b/Presets/XOceanus/Ethereal/Overcast_Glass_Bell_Array.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Glass Bell Array",
+  "mood": "Ethereal",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.98,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.25
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.58,
+    "warmth": 0.32,
+    "movement": 0.02,
+    "density": 0.35,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.9,
+      "cast_crystalSize": 0.25,
+      "cast_numPeaks": 5,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.9,
+      "cast_purity": 0.98,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.8,
+      "cast_filterCutoff": 1600.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 14.0,
+      "cast_lfo1Rate": 0.006,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "ethereal",
+    "glass",
+    "bells",
+    "array",
+    "pure"
+  ],
+  "description": "Small crystal size, very high purity, instant transition. A bank of ringing glass bells, each perfectly formed."
+}

--- a/Presets/XOceanus/Ethereal/Overcast_Ice_Cathedral.xometa
+++ b/Presets/XOceanus/Ethereal/Overcast_Ice_Cathedral.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Ice Cathedral",
+  "mood": "Ethereal",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.95,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.85
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.35,
+    "movement": 0.02,
+    "density": 0.42,
+    "space": 0.82,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.85,
+      "cast_numPeaks": 7,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.88,
+      "cast_purity": 0.95,
+      "cast_crackle": 0.2,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.82,
+      "cast_filterCutoff": 1350.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 14.0,
+      "cast_lfo1Rate": 0.006,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "ethereal",
+    "cathedral",
+    "vast",
+    "wide",
+    "frozen"
+  ],
+  "description": "Large crystal size, maximum purity, wide stereo, high peak count. A vast frozen architectural space."
+}

--- a/Presets/XOceanus/Ethereal/Overcast_Ice_Pillar.xometa
+++ b/Presets/XOceanus/Ethereal/Overcast_Ice_Pillar.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Ice Pillar",
+  "mood": "Ethereal",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.92,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.25
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.3,
+    "movement": 0.02,
+    "density": 0.4,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.88,
+      "cast_crystalSize": 0.25,
+      "cast_numPeaks": 7,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.88,
+      "cast_purity": 0.92,
+      "cast_crackle": 0.2,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.78,
+      "cast_filterCutoff": 1500.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 14.0,
+      "cast_lfo1Rate": 0.006,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "ethereal",
+    "pillar",
+    "tall",
+    "vertical",
+    "narrow"
+  ],
+  "description": "Narrow crystal, high purity, tall peak count. Vertical crystal structures reaching upward."
+}

--- a/Presets/XOceanus/Ethereal/Overcast_Icicle_Choir.xometa
+++ b/Presets/XOceanus/Ethereal/Overcast_Icicle_Choir.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Icicle Choir",
+  "mood": "Ethereal",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.9,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.35,
+    "movement": 0.02,
+    "density": 0.38,
+    "space": 0.82,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.82,
+      "cast_crystalSize": 0.55,
+      "cast_numPeaks": 5,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.82,
+      "cast_purity": 0.9,
+      "cast_crackle": 0.3,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.82,
+      "cast_filterCutoff": 1300.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.84,
+      "cast_ampRelease": 14.0,
+      "cast_lfo1Rate": 0.006,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "ethereal",
+    "choir",
+    "icicle",
+    "multiple",
+    "resonating"
+  ],
+  "description": "Medium crystal size, high purity, crackle transition, wide stereo. Multiple icicles resonating together."
+}

--- a/Presets/XOceanus/Ethereal/Overcast_Stellar_Crystal.xometa
+++ b/Presets/XOceanus/Ethereal/Overcast_Stellar_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Stellar Crystal",
+  "mood": "Ethereal",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 1.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.28,
+    "movement": 0.02,
+    "density": 0.55,
+    "space": 0.85,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.92,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 8,
+      "cast_transition": 1,
+      "cast_latticeSnap": 1.0,
+      "cast_purity": 1.0,
+      "cast_crackle": 0.2,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.85,
+      "cast_filterCutoff": 1700.0,
+      "cast_filterRes": 0.08,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.83,
+      "cast_ampRelease": 15.0,
+      "cast_lfo1Rate": 0.005,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.002,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "ethereal",
+    "stellar",
+    "cosmic",
+    "maximum",
+    "pure"
+  ],
+  "description": "Maximum everything crystalline \u2014 peak count, purity, lattice, wide stereo. Cosmic crystalline structure."
+}

--- a/Presets/XOceanus/Flux/Obscura_Bowed_Steel_Bar.xometa
+++ b/Presets/XOceanus/Flux/Obscura_Bowed_Steel_Bar.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bowed Steel Bar",
+  "mood": "Flux",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.1,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.58,
+    "warmth": 0.45,
+    "movement": 0.15,
+    "density": 0.48,
+    "space": 0.62,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.75,
+      "obscura_damping": 0.1,
+      "obscura_nonlinear": 0.28,
+      "obscura_excitePos": 0.3,
+      "obscura_exciteWidth": 0.2,
+      "obscura_scanWidth": 0.4,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.55,
+      "obscura_ampAttack": 0.2,
+      "obscura_ampDecay": 0.0,
+      "obscura_ampSustain": 1.0,
+      "obscura_ampRelease": 1.5,
+      "obscura_physEnvAttack": 0.3,
+      "obscura_physEnvDecay": 0.0,
+      "obscura_physEnvSustain": 1.0,
+      "obscura_physEnvRelease": 0.8,
+      "obscura_lfo1Rate": 0.06,
+      "obscura_lfo1Depth": 0.12,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.25,
+      "obscura_lfo2Depth": 0.3,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.2,
+      "obscura_macroMovement": 0.1,
+      "obscura_macroCoupling": 0.1,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "bowed",
+    "steel",
+    "bar",
+    "metallic",
+    "flux"
+  ],
+  "description": "Bowed steel bar \u2014 Fixed boundary, high stiffness. Moderate nonlinearity: louder bowing flattens pitch slightly and then raises it as the steel is stressed. LFO2 at 0.25Hz modulates excitation position, shifting which modes are driven \u2014 creates the characteristic 'wobble' of bowed bar instruments as bow contact position varies naturally."
+}

--- a/Presets/XOceanus/Flux/Obscura_Chaos_Chain.xometa
+++ b/Presets/XOceanus/Flux/Obscura_Chaos_Chain.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Chaos Chain",
+  "mood": "Flux",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.0,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.38,
+    "movement": 0.38,
+    "density": 0.65,
+    "space": 0.52,
+    "aggression": 0.1
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.9,
+      "obscura_damping": 0.12,
+      "obscura_nonlinear": 0.72,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.38,
+      "obscura_scanWidth": 0.4,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.35,
+      "obscura_ampAttack": 0.18,
+      "obscura_ampDecay": 0.15,
+      "obscura_ampSustain": 0.82,
+      "obscura_ampRelease": 2.0,
+      "obscura_physEnvAttack": 0.25,
+      "obscura_physEnvDecay": 0.18,
+      "obscura_physEnvSustain": 0.75,
+      "obscura_physEnvRelease": 1.0,
+      "obscura_lfo1Rate": 0.38,
+      "obscura_lfo1Depth": 0.32,
+      "obscura_lfo1Shape": 4,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 4,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 2,
+      "obscura_macroCharacter": 0.4,
+      "obscura_macroMovement": 0.2,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "chaos",
+    "random",
+    "stochastic",
+    "extreme",
+    "flux"
+  ],
+  "description": "Chaotic mass-spring chain \u2014 Periodic boundary, maximum stiffness, high nonlinearity, random chain initialization. No two notes sound the same (S&H LFO1 adds stochastic scan width variation). The system is in a far-from-equilibrium state where tiny differences in initial conditions produce macroscopically different evolution \u2014 sensitivity to initial conditions embedded in physical simulation."
+}

--- a/Presets/XOceanus/Flux/Oceanic_Rip_Current.xometa
+++ b/Presets/XOceanus/Flux/Oceanic_Rip_Current.xometa
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "name": "Rip Current",
+  "mood": "Flux",
+  "engines": [
+    "Oceanic"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Rip current \u2014 fast, narrow, dangerous. Low separation (0.2) slams the swarm together, high scatter (0.65) and low damping (0.1) let the current run unchecked. Waveform 1 (saw). Percussive envelope.",
+  "tags": [
+    "flux",
+    "rip",
+    "energetic",
+    "dangerous"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Oceanic": {
+      "ocean_alignment": 0.8,
+      "ocean_cohesion": 0.7,
+      "ocean_scatter": 0.65,
+      "ocean_separation": 0.2,
+      "ocean_damping": 0.1,
+      "ocean_tether": 0.2,
+      "ocean_subflocks": 4,
+      "ocean_waveform": 1,
+      "ocean_voiceMode": 1,
+      "ocean_glide": 0.0,
+      "ocean_ampAttack": 0.005,
+      "ocean_ampDecay": 0.3,
+      "ocean_ampSustain": 0.5,
+      "ocean_ampRelease": 0.8,
+      "ocean_swarmEnvAttack": 0.01,
+      "ocean_swarmEnvDecay": 0.2,
+      "ocean_swarmEnvSustain": 0.4,
+      "ocean_swarmEnvRelease": 0.6,
+      "ocean_lfo1Rate": 1.5,
+      "ocean_lfo1Depth": 0.45,
+      "ocean_lfo1Shape": 1,
+      "ocean_lfo2Rate": 2.5,
+      "ocean_lfo2Depth": 0.3,
+      "ocean_lfo2Shape": 2,
+      "ocean_macroCharacter": 0.78,
+      "ocean_macroMovement": 0.82,
+      "ocean_macroCoupling": 0.0,
+      "ocean_macroSpace": 0.35
+    }
+  },
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.3,
+    "movement": 0.82,
+    "density": 0.65,
+    "space": 0.35,
+    "aggression": 0.55
+  },
+  "macros": {
+    "CHARACTER": 0.78,
+    "MOVEMENT": 0.82,
+    "COUPLING": 0.0,
+    "SPACE": 0.35
+  }
+}

--- a/Presets/XOceanus/Flux/Osmosis_Cascade_Gate.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Cascade_Gate.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cascade Gate",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.38,
+    "COUPLING": 0.58,
+    "SPACE": 0.08
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.5,
+    "movement": 0.38,
+    "density": 0.35,
+    "space": 0.58,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.58,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.82,
+      "osmo_memory": 0.08,
+      "osmo_filterEnvAmt": 0.42,
+      "osmo_lfo1Rate": 0.1,
+      "osmo_lfo1Depth": 0.38,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.38,
+      "osmo_macroCoupling": 0.58,
+      "osmo_macroSpace": 0.08
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "cascade",
+    "rapid",
+    "pass-through",
+    "events",
+    "membrane"
+  ],
+  "description": "Medium permeability, fast reactivity, short memory \u2014 rapid cascade of pass-through events."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Dynamic_Pore.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Dynamic_Pore.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Dynamic Pore",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.44,
+    "MOVEMENT": 0.42,
+    "COUPLING": 0.55,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.52,
+    "movement": 0.42,
+    "density": 0.32,
+    "space": 0.58,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.55,
+      "osmo_selectivity": 0.55,
+      "osmo_reactivity": 0.9,
+      "osmo_memory": 0.1,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.15,
+      "osmo_lfo1Depth": 0.42,
+      "osmo_macroCharacter": 0.44000000000000006,
+      "osmo_macroMovement": 0.42,
+      "osmo_macroCoupling": 0.55,
+      "osmo_macroSpace": 0.1
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "dynamic",
+    "pore",
+    "energy",
+    "reactive",
+    "fast"
+  ],
+  "description": "Fast reactivity, medium permeability, fast LFO \u2014 the pore that opens and closes with signal energy."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Oscillating_Gate.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Oscillating_Gate.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Oscillating Gate",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.45,
+    "COUPLING": 0.55,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.52,
+    "movement": 0.4,
+    "density": 0.35,
+    "space": 0.58,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.55,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.65,
+      "osmo_memory": 0.2,
+      "osmo_filterEnvAmt": 0.45,
+      "osmo_lfo1Rate": 0.12,
+      "osmo_lfo1Depth": 0.45,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.45,
+      "osmo_macroCoupling": 0.55,
+      "osmo_macroSpace": 0.2
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "oscillating",
+    "rhythmic",
+    "breathing",
+    "LFO",
+    "gate"
+  ],
+  "description": "LFO modulates the coupling signal \u2014 the membrane breathes open and closed rhythmically."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Permeable_Rush.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Permeable_Rush.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Permeable Rush",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.24,
+    "MOVEMENT": 0.4,
+    "COUPLING": 1.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.48,
+    "movement": 0.45,
+    "density": 0.42,
+    "space": 0.5,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 1.0,
+      "osmo_selectivity": 0.3,
+      "osmo_reactivity": 1.0,
+      "osmo_memory": 0.1,
+      "osmo_filterEnvAmt": 0.5,
+      "osmo_lfo1Rate": 0.1,
+      "osmo_lfo1Depth": 0.4,
+      "osmo_macroCharacter": 0.24,
+      "osmo_macroMovement": 0.4,
+      "osmo_macroCoupling": 1.0,
+      "osmo_macroSpace": 0.1
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "open",
+    "reactive",
+    "maximum",
+    "coupling",
+    "dynamic"
+  ],
+  "description": "Maximum permeability, maximum reactivity \u2014 the membrane is fully open and highly responsive."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Pulse_Gate.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Pulse_Gate.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pulse Gate",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.5,
+    "COUPLING": 0.6,
+    "SPACE": 0.15
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.5,
+    "movement": 0.45,
+    "density": 0.38,
+    "space": 0.55,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.6,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.75,
+      "osmo_memory": 0.15,
+      "osmo_filterEnvAmt": 0.45,
+      "osmo_lfo1Rate": 0.2,
+      "osmo_lfo1Depth": 0.5,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.5,
+      "osmo_macroCoupling": 0.6,
+      "osmo_macroSpace": 0.15
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "pulse",
+    "flutter",
+    "fast",
+    "LFO",
+    "gate"
+  ],
+  "description": "Fast LFO creates pulsing gate effect \u2014 the membrane flutters."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Selective_Burst.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Selective_Burst.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Selective Burst",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.32,
+    "COUPLING": 0.52,
+    "SPACE": 0.15
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.48,
+    "movement": 0.32,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.52,
+      "osmo_selectivity": 0.88,
+      "osmo_reactivity": 0.88,
+      "osmo_memory": 0.15,
+      "osmo_filterEnvAmt": 0.42,
+      "osmo_lfo1Rate": 0.08,
+      "osmo_lfo1Depth": 0.32,
+      "osmo_macroCharacter": 0.7040000000000001,
+      "osmo_macroMovement": 0.32,
+      "osmo_macroCoupling": 0.52,
+      "osmo_macroSpace": 0.15
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "selective",
+    "burst",
+    "instant",
+    "specific",
+    "reactive"
+  ],
+  "description": "High selectivity, fast reactivity \u2014 the membrane is very picky but responds instantly when triggered."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Swell_Membrane.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Swell_Membrane.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Swell Membrane",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.38,
+    "COUPLING": 0.52,
+    "SPACE": 0.35
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.58,
+    "movement": 0.25,
+    "density": 0.3,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.52,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.45,
+      "osmo_memory": 0.35,
+      "osmo_filterEnvAmt": 0.38,
+      "osmo_lfo1Rate": 0.04,
+      "osmo_lfo1Depth": 0.38,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.38,
+      "osmo_macroCoupling": 0.52,
+      "osmo_macroSpace": 0.35
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "swell",
+    "slow",
+    "LFO",
+    "open",
+    "close"
+  ],
+  "description": "Slow LFO with wide depth \u2014 the membrane swells open and closes slowly."
+}

--- a/Presets/XOceanus/Flux/Osmosis_Tremolo_Gate.xometa
+++ b/Presets/XOceanus/Flux/Osmosis_Tremolo_Gate.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tremolo Gate",
+  "mood": "Flux",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.36,
+    "MOVEMENT": 0.55,
+    "COUPLING": 0.58,
+    "SPACE": 0.12
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.5,
+    "movement": 0.48,
+    "density": 0.38,
+    "space": 0.55,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.58,
+      "osmo_selectivity": 0.45,
+      "osmo_reactivity": 0.8,
+      "osmo_memory": 0.12,
+      "osmo_filterEnvAmt": 0.45,
+      "osmo_lfo1Rate": 0.25,
+      "osmo_lfo1Depth": 0.55,
+      "osmo_macroCharacter": 0.36000000000000004,
+      "osmo_macroMovement": 0.55,
+      "osmo_macroCoupling": 0.58,
+      "osmo_macroSpace": 0.12
+    }
+  },
+  "tags": [
+    "osmosis",
+    "flux",
+    "tremolo",
+    "fast",
+    "depth",
+    "gating",
+    "pulsing"
+  ],
+  "description": "Fast LFO at high depth \u2014 creates tremolo-like gating effect through the membrane."
+}

--- a/Presets/XOceanus/Flux/Osprey_Strike_and_Lift.xometa
+++ b/Presets/XOceanus/Flux/Osprey_Strike_and_Lift.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Strike and Lift",
+  "mood": "Flux",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Strike and immediately lift away. Maximum sea state (0.9), high foam (0.75), fast swell period (4.0). Bright filterTilt (0.75) catches the spray.",
+  "tags": [
+    "flux",
+    "strike",
+    "hunting",
+    "fast"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.001,
+      "osprey_ampDecay": 0.2,
+      "osprey_ampSustain": 0.35,
+      "osprey_ampRelease": 0.6,
+      "osprey_brine": 0.45,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.75,
+      "osprey_foam": 0.75,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.85,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.88,
+      "osprey_macroSpace": 0.35,
+      "osprey_resonatorBright": 0.75,
+      "osprey_resonatorDecay": 2.0,
+      "osprey_seaState": 0.9,
+      "osprey_shore": 0.65,
+      "osprey_swellPeriod": 4.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.75,
+    "warmth": 0.25,
+    "movement": 0.88,
+    "density": 0.5,
+    "space": 0.35,
+    "aggression": 0.72
+  },
+  "macros": {
+    "CHARACTER": 0.85,
+    "MOVEMENT": 0.88,
+    "COUPLING": 0.0,
+    "SPACE": 0.35
+  }
+}

--- a/Presets/XOceanus/Flux/Overcast_Crackle_Storm.xometa
+++ b/Presets/XOceanus/Flux/Overcast_Crackle_Storm.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Crackle Storm",
+  "mood": "Flux",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.42,
+    "movement": 0.15,
+    "density": 0.42,
+    "space": 0.55,
+    "aggression": 0.1
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.88,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 6,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.65,
+      "cast_purity": 0.7,
+      "cast_crackle": 1.0,
+      "cast_shatterGap": 0.08,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1300.0,
+      "cast_filterRes": 0.09,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.78,
+      "cast_ampRelease": 8.0,
+      "cast_lfo1Rate": 0.014,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.007,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "flux",
+    "storm",
+    "crackle",
+    "ice",
+    "rapid"
+  ],
+  "description": "Maximum crackle, shatter transition, fast freeze rate \u2014 the sound of a rapid ice storm."
+}

--- a/Presets/XOceanus/Flux/Overcast_Eighth_Crystal.xometa
+++ b/Presets/XOceanus/Flux/Overcast_Eighth_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Eighth Crystal",
+  "mood": "Flux",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.75,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.45,
+    "movement": 0.2,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.07
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.78,
+      "cast_crystalSize": 0.45,
+      "cast_numPeaks": 5,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.72,
+      "cast_purity": 0.75,
+      "cast_crackle": 0.7,
+      "cast_shatterGap": 0.125,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.08,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.79,
+      "cast_ampRelease": 9.0,
+      "cast_lfo1Rate": 0.014,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.007,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "flux",
+    "rhythm",
+    "eighth",
+    "shatter",
+    "rapid"
+  ],
+  "description": "Shatter gap 125ms \u2014 eighth-note rate at 120bpm. Rapid rhythmic re-freeze."
+}

--- a/Presets/XOceanus/Flux/Overcast_Glacial_Burst.xometa
+++ b/Presets/XOceanus/Flux/Overcast_Glacial_Burst.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Glacial Burst",
+  "mood": "Flux",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.44,
+    "warmth": 0.5,
+    "movement": 0.12,
+    "density": 0.32,
+    "space": 0.62,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.72,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 4,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.72,
+      "cast_purity": 0.8,
+      "cast_crackle": 0.5,
+      "cast_shatterGap": 0.4,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.82,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "flux",
+    "glacial",
+    "long",
+    "burst",
+    "geological"
+  ],
+  "description": "Long shatter gap 400ms \u2014 crystal forms for extended time, then sudden burst. Geological event."
+}

--- a/Presets/XOceanus/Flux/Overcast_Quarter_Crystal.xometa
+++ b/Presets/XOceanus/Flux/Overcast_Quarter_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Quarter Crystal",
+  "mood": "Flux",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.78,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.48,
+    "movement": 0.15,
+    "density": 0.35,
+    "space": 0.6,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.75,
+      "cast_crystalSize": 0.48,
+      "cast_numPeaks": 5,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.7,
+      "cast_purity": 0.78,
+      "cast_crackle": 0.6,
+      "cast_shatterGap": 0.25,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.8,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.012,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.006,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "flux",
+    "rhythm",
+    "quarter",
+    "shatter",
+    "120bpm"
+  ],
+  "description": "Shatter gap 250ms \u2014 crystals reform at quarter-note rate at 120bpm. Rhythmic crystallization."
+}

--- a/Presets/XOceanus/Flux/Overcast_Shatter_Cascade.xometa
+++ b/Presets/XOceanus/Flux/Overcast_Shatter_Cascade.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Shatter Cascade",
+  "mood": "Flux",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.44,
+    "movement": 0.18,
+    "density": 0.4,
+    "space": 0.55,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.8,
+      "cast_crystalSize": 0.48,
+      "cast_numPeaks": 5,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.68,
+      "cast_purity": 0.72,
+      "cast_crackle": 0.9,
+      "cast_shatterGap": 0.12,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.08,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.79,
+      "cast_ampRelease": 9.0,
+      "cast_lfo1Rate": 0.013,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.006,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "flux",
+    "cascade",
+    "breaking",
+    "ice",
+    "sheet"
+  ],
+  "description": "Multiple shatter events \u2014 medium gap, high crackle. The ice sheet breaking up."
+}

--- a/Presets/XOceanus/Flux/Overcast_Triplet_Crystal.xometa
+++ b/Presets/XOceanus/Flux/Overcast_Triplet_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Triplet Crystal",
+  "mood": "Flux",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.76,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.47
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.47,
+    "movement": 0.18,
+    "density": 0.36,
+    "space": 0.59,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.76,
+      "cast_crystalSize": 0.47,
+      "cast_numPeaks": 5,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.71,
+      "cast_purity": 0.76,
+      "cast_crackle": 0.65,
+      "cast_shatterGap": 0.167,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1150.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.79,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.013,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.006,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "flux",
+    "rhythm",
+    "triplet",
+    "shatter",
+    "three"
+  ],
+  "description": "Shatter gap 167ms \u2014 triplet-note rate at 120bpm. The crystal pulses in three."
+}

--- a/Presets/XOceanus/Flux/Overflow_Catastrophe_Mode.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Catastrophe_Mode.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Catastrophe Mode",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.25,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.5,
+    "movement": 0.3,
+    "density": 0.45,
+    "space": 0.52,
+    "aggression": 0.12
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.6,
+      "flow_accumRate": 0.6,
+      "flow_valveType": 1,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.5,
+      "flow_releaseTime": 0.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1200.0,
+      "flow_filterRes": 0.08,
+      "flow_filtEnvAmount": 0.2,
+      "flow_ampAttack": 0.3,
+      "flow_ampDecay": 1.0,
+      "flow_ampSustain": 0.75,
+      "flow_ampRelease": 4.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.02,
+      "flow_lfo1Depth": 0.25,
+      "flow_lfo2Rate": 0.01,
+      "flow_lfo2Depth": 0.12,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "catastrophic",
+    "explosive",
+    "event",
+    "dramatic"
+  ],
+  "description": "Explosive valve type \u2014 when pressure releases, all voices duck. Catastrophic event preset."
+}

--- a/Presets/XOceanus/Flux/Overflow_Gradual_Drift.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Gradual_Drift.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Gradual Drift",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.16,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.62,
+    "movement": 0.2,
+    "density": 0.38,
+    "space": 0.6,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.65,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.55,
+      "flow_strainColor": 0.4,
+      "flow_releaseTime": 4.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 950.0,
+      "flow_filterRes": 0.06,
+      "flow_filtEnvAmount": 0.16,
+      "flow_ampAttack": 1.0,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.82,
+      "flow_ampRelease": 7.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.013,
+      "flow_lfo1Depth": 0.16,
+      "flow_lfo2Rate": 0.006,
+      "flow_lfo2Depth": 0.08,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "gradual",
+    "tire",
+    "slow-leak",
+    "drift"
+  ],
+  "description": "Gradual valve, fast accumulation, long release \u2014 the pressure releases slowly like a tire losing air."
+}

--- a/Presets/XOceanus/Flux/Overflow_Polychordal_Strain.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Polychordal_Strain.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Polychordal Strain",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.48,
+    "movement": 0.22,
+    "density": 0.45,
+    "space": 0.55,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.58,
+      "flow_accumRate": 0.55,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.52,
+      "flow_strainColor": 0.65,
+      "flow_releaseTime": 1.8,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1200.0,
+      "flow_filterRes": 0.08,
+      "flow_filtEnvAmount": 0.2,
+      "flow_ampAttack": 1.2,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.8,
+      "flow_ampRelease": 7.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.014,
+      "flow_lfo1Depth": 0.18,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.09,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "polychordal",
+    "strain",
+    "timbre",
+    "tension"
+  ],
+  "description": "High strain color \u2014 the pad's timbre is maximally affected by accumulated pressure. Strain is audible in the timbre."
+}

--- a/Presets/XOceanus/Flux/Overflow_Pressure_Build.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Pressure_Build.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pressure Build",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.48,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.55,
+    "movement": 0.35,
+    "density": 0.48,
+    "space": 0.5,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.45,
+      "flow_accumRate": 0.95,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.48,
+      "flow_strainColor": 0.48,
+      "flow_releaseTime": 1.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1200.0,
+      "flow_filterRes": 0.08,
+      "flow_filtEnvAmount": 0.2,
+      "flow_ampAttack": 0.5,
+      "flow_ampDecay": 1.2,
+      "flow_ampSustain": 0.78,
+      "flow_ampRelease": 5.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.018,
+      "flow_lfo1Depth": 0.22,
+      "flow_lfo2Rate": 0.009,
+      "flow_lfo2Depth": 0.11,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "maximum",
+    "instant",
+    "pressure",
+    "build"
+  ],
+  "description": "Maximum accumulation rate \u2014 pressure builds almost instantly with any playing density."
+}

--- a/Presets/XOceanus/Flux/Overflow_Pressure_Dance.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Pressure_Dance.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pressure Dance",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.58,
+    "movement": 0.28,
+    "density": 0.42,
+    "space": 0.55,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.45,
+      "flow_accumRate": 0.7,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.45,
+      "flow_releaseTime": 1.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1100.0,
+      "flow_filterRes": 0.07,
+      "flow_filtEnvAmount": 0.18,
+      "flow_ampAttack": 0.8,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.8,
+      "flow_ampRelease": 6.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.016,
+      "flow_lfo1Depth": 0.2,
+      "flow_lfo2Rate": 0.008,
+      "flow_lfo2Depth": 0.1,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "dance",
+    "frequent",
+    "conversation",
+    "dynamic"
+  ],
+  "description": "Medium threshold, fast accumulation \u2014 triggers frequently. The pad is in constant pressure conversation with the player."
+}

--- a/Presets/XOceanus/Flux/Overflow_Steam_Jet.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Steam_Jet.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Steam Jet",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.6,
+    "MOVEMENT": 0.25,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.68,
+    "warmth": 0.38,
+    "movement": 0.28,
+    "density": 0.42,
+    "space": 0.52,
+    "aggression": 0.1
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.5,
+      "flow_accumRate": 0.65,
+      "flow_valveType": 2,
+      "flow_vesselSize": 0.45,
+      "flow_strainColor": 0.6,
+      "flow_releaseTime": 0.4,
+      "flow_whistlePitch": 1.0,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1600.0,
+      "flow_filterRes": 0.1,
+      "flow_filtEnvAmount": 0.25,
+      "flow_ampAttack": 0.5,
+      "flow_ampDecay": 1.2,
+      "flow_ampSustain": 0.72,
+      "flow_ampRelease": 4.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.02,
+      "flow_lfo1Depth": 0.25,
+      "flow_lfo2Rate": 0.01,
+      "flow_lfo2Depth": 0.12,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "steam",
+    "jet",
+    "explosive",
+    "high"
+  ],
+  "description": "Explosive release at high whistle pitch \u2014 steam jets at the top of the range."
+}

--- a/Presets/XOceanus/Flux/Overflow_Tension_Arc.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Tension_Arc.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tension Arc",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.48,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.52,
+    "movement": 0.18,
+    "density": 0.42,
+    "space": 0.58,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.75,
+      "flow_accumRate": 0.35,
+      "flow_valveType": 1,
+      "flow_vesselSize": 0.52,
+      "flow_strainColor": 0.48,
+      "flow_releaseTime": 0.6,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1100.0,
+      "flow_filterRes": 0.07,
+      "flow_filtEnvAmount": 0.18,
+      "flow_ampAttack": 1.5,
+      "flow_ampDecay": 2.0,
+      "flow_ampSustain": 0.82,
+      "flow_ampRelease": 8.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.01,
+      "flow_lfo1Depth": 0.14,
+      "flow_lfo2Rate": 0.005,
+      "flow_lfo2Depth": 0.07,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "arc",
+    "tension",
+    "buildup",
+    "explosive"
+  ],
+  "description": "The arc of pressure \u2014 slow accumulation, high threshold, explosive when it finally blows."
+}

--- a/Presets/XOceanus/Flux/Overflow_Whistle_Mode.xometa
+++ b/Presets/XOceanus/Flux/Overflow_Whistle_Mode.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Whistle Mode",
+  "mood": "Flux",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.55,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.45,
+    "movement": 0.25,
+    "density": 0.38,
+    "space": 0.55,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.5,
+      "flow_valveType": 2,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.55,
+      "flow_releaseTime": 1.0,
+      "flow_whistlePitch": 0.8,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1400.0,
+      "flow_filterRes": 0.09,
+      "flow_filtEnvAmount": 0.22,
+      "flow_ampAttack": 1.0,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.78,
+      "flow_ampRelease": 6.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.016,
+      "flow_lfo1Depth": 0.2,
+      "flow_lfo2Rate": 0.008,
+      "flow_lfo2Depth": 0.1,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "flux",
+    "whistle",
+    "burst",
+    "high",
+    "valve"
+  ],
+  "description": "Whistle valve type \u2014 when pressure releases, a high-pitch whistle burst above the carrier."
+}

--- a/Presets/XOceanus/Flux/Overwash_Boundary_Dissolve.xometa
+++ b/Presets/XOceanus/Flux/Overwash_Boundary_Dissolve.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Boundary Dissolve",
+  "mood": "Flux",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.58,
+    "movement": 0.22,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.18,
+      "wash_viscosity": 0.6,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 18.0,
+      "wash_spreadMax": 95.0,
+      "wash_brightness": 0.35,
+      "wash_warmth": 0.58,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.83,
+      "wash_ampRelease": 8.0,
+      "wash_filterCutoff": 1100.0,
+      "wash_filterRes": 0.07,
+      "wash_filtEnvAmount": 0.18,
+      "wash_filtAttack": 1.0,
+      "wash_filtDecay": 2.5,
+      "wash_filtSustain": 0.75,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.014,
+      "wash_lfo1Depth": 0.2,
+      "wash_lfo2Rate": 0.007,
+      "wash_lfo2Depth": 0.1,
+      "wash_stereoWidth": 0.68,
+      "wash_level": 0.75,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "dissolve",
+    "blur",
+    "spectral",
+    "smear",
+    "medium"
+  ],
+  "description": "Medium harmonics at low-medium viscosity \u2014 spectral boundaries blur quickly. What was two pitches becomes one smear."
+}

--- a/Presets/XOceanus/Flux/Overwash_Gradient_Motion.xometa
+++ b/Presets/XOceanus/Flux/Overwash_Gradient_Motion.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Gradient Motion",
+  "mood": "Flux",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.3,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.55,
+    "movement": 0.3,
+    "density": 0.4,
+    "space": 0.52,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.15,
+      "wash_viscosity": 0.65,
+      "wash_harmonics": 7,
+      "wash_diffusionTime": 20.0,
+      "wash_spreadMax": 110.0,
+      "wash_brightness": 0.4,
+      "wash_warmth": 0.55,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.82,
+      "wash_ampRelease": 8.0,
+      "wash_filterCutoff": 1300.0,
+      "wash_filterRes": 0.08,
+      "wash_filtEnvAmount": 0.2,
+      "wash_filtAttack": 1.0,
+      "wash_filtDecay": 2.5,
+      "wash_filtSustain": 0.74,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.01,
+      "wash_lfo1Depth": 0.25,
+      "wash_lfo2Rate": 0.02,
+      "wash_lfo2Depth": 0.18,
+      "wash_stereoWidth": 0.7,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "gradient",
+    "motion",
+    "evolving",
+    "LFO",
+    "arc"
+  ],
+  "description": "A slow-to-fast diffusion arc: starts viscous and speeds up via LFO2 modulation. Evolution from still to moving."
+}

--- a/Presets/XOceanus/Flux/Overwash_Rate_Study.xometa
+++ b/Presets/XOceanus/Flux/Overwash_Rate_Study.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Rate Study",
+  "mood": "Flux",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.48,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.52,
+    "movement": 0.28,
+    "density": 0.42,
+    "space": 0.55,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.22,
+      "wash_viscosity": 0.55,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 15.0,
+      "wash_spreadMax": 120.0,
+      "wash_brightness": 0.48,
+      "wash_warmth": 0.52,
+      "wash_ampAttack": 1.0,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.82,
+      "wash_ampRelease": 8.0,
+      "wash_filterCutoff": 1600.0,
+      "wash_filterRes": 0.09,
+      "wash_filtEnvAmount": 0.22,
+      "wash_filtAttack": 1.0,
+      "wash_filtDecay": 2.0,
+      "wash_filtSustain": 0.72,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.018,
+      "wash_lfo1Depth": 0.24,
+      "wash_lfo2Rate": 0.009,
+      "wash_lfo2Depth": 0.12,
+      "wash_stereoWidth": 0.72,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "rate",
+    "fast",
+    "study",
+    "breathing",
+    "evolution"
+  ],
+  "description": "Fast diffusion at medium viscosity \u2014 the harmonics arrive quickly, settle into spread, and breathe with a 15-second LFO cycle."
+}

--- a/Presets/XOceanus/Flux/Overwash_Spectral_Fan.xometa
+++ b/Presets/XOceanus/Flux/Overwash_Spectral_Fan.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Spectral Fan",
+  "mood": "Flux",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.42,
+    "movement": 0.35,
+    "density": 0.55,
+    "space": 0.5,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.28,
+      "wash_viscosity": 0.4,
+      "wash_harmonics": 16,
+      "wash_diffusionTime": 10.0,
+      "wash_spreadMax": 180.0,
+      "wash_brightness": 0.72,
+      "wash_warmth": 0.42,
+      "wash_ampAttack": 0.5,
+      "wash_ampDecay": 1.0,
+      "wash_ampSustain": 0.8,
+      "wash_ampRelease": 6.0,
+      "wash_filterCutoff": 2400.0,
+      "wash_filterRes": 0.12,
+      "wash_filtEnvAmount": 0.3,
+      "wash_filtAttack": 0.5,
+      "wash_filtDecay": 1.5,
+      "wash_filtSustain": 0.7,
+      "wash_filtRelease": 4.0,
+      "wash_lfo1Rate": 0.025,
+      "wash_lfo1Depth": 0.28,
+      "wash_lfo2Rate": 0.012,
+      "wash_lfo2Depth": 0.15,
+      "wash_stereoWidth": 0.8,
+      "wash_level": 0.78,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "spectral",
+    "fan",
+    "bright",
+    "wide",
+    "16-harmonic"
+  ],
+  "description": "Low viscosity, 16 harmonics \u2014 the diffusion fans rapidly outward. Maximum harmonic count, wide spread. All the colors released at once."
+}

--- a/Presets/XOceanus/Flux/Overwash_Tide_Lift.xometa
+++ b/Presets/XOceanus/Flux/Overwash_Tide_Lift.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tide Lift",
+  "mood": "Flux",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.58,
+    "movement": 0.2,
+    "density": 0.4,
+    "space": 0.55,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.17,
+      "wash_viscosity": 0.65,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 22.0,
+      "wash_spreadMax": 100.0,
+      "wash_brightness": 0.45,
+      "wash_warmth": 0.58,
+      "wash_ampAttack": 2.0,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.84,
+      "wash_ampRelease": 9.0,
+      "wash_filterCutoff": 800.0,
+      "wash_filterRes": 0.07,
+      "wash_filtEnvAmount": 0.35,
+      "wash_filtAttack": 3.0,
+      "wash_filtDecay": 2.0,
+      "wash_filtSustain": 0.72,
+      "wash_filtRelease": 6.0,
+      "wash_lfo1Rate": 0.012,
+      "wash_lfo1Depth": 0.2,
+      "wash_lfo2Rate": 0.006,
+      "wash_lfo2Depth": 0.1,
+      "wash_stereoWidth": 0.68,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "tide",
+    "lift",
+    "swell",
+    "bloom",
+    "filter-arc"
+  ],
+  "description": "Rising diffusion arc \u2014 filter envelope opens slowly as harmonics spread, creating a swell-and-bloom character."
+}

--- a/Presets/XOceanus/Flux/Overwash_Warm_Current.xometa
+++ b/Presets/XOceanus/Flux/Overwash_Warm_Current.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Warm Current",
+  "mood": "Flux",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.25,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.72,
+    "movement": 0.25,
+    "density": 0.35,
+    "space": 0.55,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.2,
+      "wash_viscosity": 0.62,
+      "wash_harmonics": 5,
+      "wash_diffusionTime": 12.0,
+      "wash_spreadMax": 80.0,
+      "wash_brightness": 0.28,
+      "wash_warmth": 0.72,
+      "wash_ampAttack": 1.0,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.85,
+      "wash_ampRelease": 7.0,
+      "wash_filterCutoff": 900.0,
+      "wash_filterRes": 0.06,
+      "wash_filtEnvAmount": 0.15,
+      "wash_filtAttack": 0.8,
+      "wash_filtDecay": 2.0,
+      "wash_filtSustain": 0.78,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.016,
+      "wash_lfo1Depth": 0.22,
+      "wash_lfo2Rate": 0.008,
+      "wash_lfo2Depth": 0.11,
+      "wash_stereoWidth": 0.65,
+      "wash_level": 0.75,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "warm",
+    "current",
+    "fast",
+    "thermal",
+    "flux"
+  ],
+  "description": "Rapid warm diffusion \u2014 high warmth, fast rate, medium spread. A thermal current moving through cool water."
+}

--- a/Presets/XOceanus/Flux/Overworn_Flash_Reduction.xometa
+++ b/Presets/XOceanus/Flux/Overworn_Flash_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Flash Reduction",
+  "mood": "Flux",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.7,
+    "movement": 0.28,
+    "density": 0.5,
+    "space": 0.5,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.35,
+      "worn_heat": 0.65,
+      "worn_richness": 0.65,
+      "worn_maillard": 0.45,
+      "worn_umamiDepth": 0.52,
+      "worn_concentrate": 0.48,
+      "worn_sessionTarget": 8.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 700.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.16,
+      "worn_ampAttack": 0.8,
+      "worn_ampDecay": 1.5,
+      "worn_ampSustain": 0.8,
+      "worn_ampRelease": 6.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.02,
+      "worn_lfo1Depth": 0.22,
+      "worn_lfo2Rate": 0.01,
+      "worn_lfo2Depth": 0.11,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "flux",
+    "flash",
+    "maximum",
+    "fast",
+    "extreme"
+  ],
+  "description": "Maximum reduction rate \u2014 the fastest possible. Goes from fresh to concentrated within one phrase."
+}

--- a/Presets/XOceanus/Flux/Overworn_Foam_Reduction.xometa
+++ b/Presets/XOceanus/Flux/Overworn_Foam_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Foam Reduction",
+  "mood": "Flux",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.38
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.58,
+    "movement": 0.22,
+    "density": 0.38,
+    "space": 0.55,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.16,
+      "worn_heat": 0.48,
+      "worn_richness": 0.5,
+      "worn_maillard": 0.28,
+      "worn_umamiDepth": 0.38,
+      "worn_concentrate": 0.32,
+      "worn_sessionTarget": 15.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1000.0,
+      "worn_filterRes": 0.07,
+      "worn_filtEnvAmount": 0.15,
+      "worn_ampAttack": 1.2,
+      "worn_ampDecay": 2.0,
+      "worn_ampSustain": 0.82,
+      "worn_ampRelease": 7.5,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.016,
+      "worn_lfo1Depth": 0.2,
+      "worn_lfo2Rate": 0.008,
+      "worn_lfo2Depth": 0.1,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "flux",
+    "foam",
+    "active",
+    "skimming",
+    "stirring"
+  ],
+  "description": "Medium-fast reduction with active LFOs \u2014 the active foam on the surface of a reducing stock, skimmed and stirring."
+}

--- a/Presets/XOceanus/Flux/Overworn_Rapid_Concentrate.xometa
+++ b/Presets/XOceanus/Flux/Overworn_Rapid_Concentrate.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Rapid Concentrate",
+  "mood": "Flux",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.58,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.68,
+    "movement": 0.22,
+    "density": 0.42,
+    "space": 0.52,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.25,
+      "worn_heat": 0.55,
+      "worn_richness": 0.58,
+      "worn_maillard": 0.35,
+      "worn_umamiDepth": 0.45,
+      "worn_concentrate": 0.4,
+      "worn_sessionTarget": 10.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 800.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.15,
+      "worn_ampAttack": 1.0,
+      "worn_ampDecay": 1.8,
+      "worn_ampSustain": 0.82,
+      "worn_ampRelease": 7.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.016,
+      "worn_lfo1Depth": 0.18,
+      "worn_lfo2Rate": 0.008,
+      "worn_lfo2Depth": 0.09,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "flux",
+    "rapid",
+    "fast",
+    "pressure",
+    "concentrate"
+  ],
+  "description": "Very fast reduction rate \u2014 the pressure cooker scenario. Flavors concentrate in minutes, not hours."
+}

--- a/Presets/XOceanus/Flux/Overworn_Reduction_Race.xometa
+++ b/Presets/XOceanus/Flux/Overworn_Reduction_Race.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Reduction Race",
+  "mood": "Flux",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.58,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.65,
+    "movement": 0.3,
+    "density": 0.42,
+    "space": 0.52,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.18,
+      "worn_heat": 0.6,
+      "worn_richness": 0.58,
+      "worn_maillard": 0.35,
+      "worn_umamiDepth": 0.45,
+      "worn_concentrate": 0.38,
+      "worn_sessionTarget": 14.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 850.0,
+      "worn_filterRes": 0.07,
+      "worn_filtEnvAmount": 0.16,
+      "worn_ampAttack": 1.2,
+      "worn_ampDecay": 1.8,
+      "worn_ampSustain": 0.82,
+      "worn_ampRelease": 7.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.022,
+      "worn_lfo1Depth": 0.22,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.16,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "flux",
+    "multiple",
+    "racing",
+    "LFO",
+    "chaos"
+  ],
+  "description": "Three reduction rates competing \u2014 LFO1 and LFO2 at different speeds, high heat. The cook watching multiple pots."
+}

--- a/Presets/XOceanus/Flux/Overworn_Turbulent_Broth.xometa
+++ b/Presets/XOceanus/Flux/Overworn_Turbulent_Broth.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Turbulent Broth",
+  "mood": "Flux",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.62,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.65,
+    "movement": 0.25,
+    "density": 0.45,
+    "space": 0.52,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.2,
+      "worn_heat": 0.75,
+      "worn_richness": 0.62,
+      "worn_maillard": 0.4,
+      "worn_umamiDepth": 0.48,
+      "worn_concentrate": 0.42,
+      "worn_sessionTarget": 12.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 900.0,
+      "worn_filterRes": 0.07,
+      "worn_filtEnvAmount": 0.16,
+      "worn_ampAttack": 1.0,
+      "worn_ampDecay": 1.8,
+      "worn_ampSustain": 0.8,
+      "worn_ampRelease": 6.5,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.018,
+      "worn_lfo1Depth": 0.2,
+      "worn_lfo2Rate": 0.009,
+      "worn_lfo2Depth": 0.1,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "flux",
+    "turbulent",
+    "boiling",
+    "heat",
+    "rapid"
+  ],
+  "description": "High heat, fast reduction, rapid LFO \u2014 the boiling scenario rather than the simmer."
+}

--- a/Presets/XOceanus/Flux/Overworn_Volatile_Loss.xometa
+++ b/Presets/XOceanus/Flux/Overworn_Volatile_Loss.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Volatile Loss",
+  "mood": "Flux",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.6,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.68,
+    "movement": 0.2,
+    "density": 0.45,
+    "space": 0.55,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.2,
+      "worn_heat": 0.58,
+      "worn_richness": 0.6,
+      "worn_maillard": 0.4,
+      "worn_umamiDepth": 0.48,
+      "worn_concentrate": 0.42,
+      "worn_sessionTarget": 12.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 750.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 1.5,
+      "worn_ampDecay": 2.0,
+      "worn_ampSustain": 0.82,
+      "worn_ampRelease": 8.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.015,
+      "worn_lfo1Depth": 0.18,
+      "worn_lfo2Rate": 0.007,
+      "worn_lfo2Depth": 0.09,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "flux",
+    "volatile",
+    "evaporating",
+    "losing",
+    "arc"
+  ],
+  "description": "The aromatics evaporating \u2014 high reduction rate, elevated filter cutoff losing content rapidly. What remains when brightness is gone."
+}

--- a/Presets/XOceanus/Flux/Owlfish_Strike_Shimmer.xometa
+++ b/Presets/XOceanus/Flux/Owlfish_Strike_Shimmer.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Strike Shimmer",
+  "mood": "Flux",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Owlfish strikes at prey \u2014 instant attack, snapping filter envelope, bright shimmer. Grain added (grainMix 0.35) for texture on the tail. High filter cutoff (0.88).",
+  "tags": [
+    "flux",
+    "strike",
+    "percussive",
+    "bright"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 70.0,
+      "owl_bodyLevel": 0.55,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.88,
+      "owl_filterEnvDepth": 0.72,
+      "owl_filterReso": 0.45,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.45,
+      "owl_grainMix": 0.35,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.3,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.5,
+      "owl_reverbMix": 0.2,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.35,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.8,
+      "owl_subLevel2": 0.6,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 3,
+      "owl_ampDecay": 150,
+      "owl_ampSustain": 0.0,
+      "owl_ampRelease": 250,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.78,
+    "warmth": 0.25,
+    "movement": 0.75,
+    "density": 0.45,
+    "space": 0.35,
+    "aggression": 0.6
+  },
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.75,
+    "COUPLING": 0.0,
+    "SPACE": 0.35
+  }
+}

--- a/Presets/XOceanus/Foundation/Obscura_Rosewood_Bar.xometa
+++ b/Presets/XOceanus/Foundation/Obscura_Rosewood_Bar.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Rosewood Bar",
+  "mood": "Foundation",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.58,
+    "movement": 0.04,
+    "density": 0.28,
+    "space": 0.55,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.35,
+      "obscura_damping": 0.38,
+      "obscura_nonlinear": 0.04,
+      "obscura_excitePos": 0.35,
+      "obscura_exciteWidth": 0.18,
+      "obscura_scanWidth": 0.42,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.45,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 0.55,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.45,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 0.55,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 3,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.2,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "marimba",
+    "rosewood",
+    "bar",
+    "struck",
+    "wood"
+  ],
+  "description": "Rosewood marimba bar \u2014 Fixed boundary (anchored at nodal mounts), low stiffness (soft wood), near-zero nonlinearity. Short decay from moderate damping. The excite position at 0.35 from one end places the mallet near an antinode of the 2nd partial, brightening the attack."
+}

--- a/Presets/XOceanus/Foundation/Obscura_Stiff_Piano_String.xometa
+++ b/Presets/XOceanus/Foundation/Obscura_Stiff_Piano_String.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Stiff Piano String",
+  "mood": "Foundation",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.1,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.6,
+    "movement": 0.04,
+    "density": 0.42,
+    "space": 0.6,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.52,
+      "obscura_damping": 0.14,
+      "obscura_nonlinear": 0.32,
+      "obscura_excitePos": 0.12,
+      "obscura_exciteWidth": 0.15,
+      "obscura_scanWidth": 0.45,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.2,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.3,
+      "obscura_ampSustain": 0.7,
+      "obscura_ampRelease": 2.5,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.3,
+      "obscura_physEnvSustain": 0.7,
+      "obscura_physEnvRelease": 1.5,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.1,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.1,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "piano",
+    "string",
+    "stiff",
+    "inharmonic",
+    "classical"
+  ],
+  "description": "Piano string \u2014 Fixed boundary, medium stiffness. The nonlinearity captures the measured stiffness-induced inharmonicity of real piano strings: upper partials are progressively sharper than harmonic ratios. Excite at 0.12 from one end (hammer strike position \u2014 the 1/7\u20131/8 range suppresses certain harmonics). Medium bowing sustain for sustain pedal behavior."
+}

--- a/Presets/XOceanus/Foundation/Obscura_Tibetan_Bowl.xometa
+++ b/Presets/XOceanus/Foundation/Obscura_Tibetan_Bowl.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tibetan Bowl",
+  "mood": "Foundation",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.3,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.68,
+    "warmth": 0.45,
+    "movement": 0.08,
+    "density": 0.55,
+    "space": 0.65,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.85,
+      "obscura_damping": 0.18,
+      "obscura_nonlinear": 0.42,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.22,
+      "obscura_scanWidth": 0.3,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.01,
+      "obscura_ampDecay": 0.5,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 5.5,
+      "obscura_physEnvAttack": 0.01,
+      "obscura_physEnvDecay": 0.5,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 5.5,
+      "obscura_lfo1Rate": 0.04,
+      "obscura_lfo1Depth": 0.08,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.3,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.1,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "bell",
+    "bowl",
+    "tibetan",
+    "metal",
+    "struck"
+  ],
+  "description": "Standing wave modes of a singing bowl \u2014 circular chain (Periodic boundary) at high stiffness. The hammer strike loads all modes; they decay at different rates producing the characteristic beating. Nonlinearity creates the pitch-dip characteristic of real bowl metal."
+}

--- a/Presets/XOceanus/Foundation/Obscura_Tongue_Drum.xometa
+++ b/Presets/XOceanus/Foundation/Obscura_Tongue_Drum.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tongue Drum",
+  "mood": "Foundation",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.1,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.55,
+    "movement": 0.04,
+    "density": 0.38,
+    "space": 0.62,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.62,
+      "obscura_damping": 0.22,
+      "obscura_nonlinear": 0.18,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.45,
+      "obscura_scanWidth": 0.38,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.008,
+      "obscura_ampDecay": 0.4,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 2.5,
+      "obscura_physEnvAttack": 0.008,
+      "obscura_physEnvDecay": 0.4,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 2.5,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.1,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.1,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "tongue-drum",
+    "steel",
+    "struck",
+    "warm",
+    "inharmonic"
+  ],
+  "description": "Steel tongue drum \u2014 Fixed boundary (tongues anchored at base). Medium-high stiffness from hardened steel. The tongue shape produces a distinct inharmonicity from irregular geometry \u2014 captured here by slight nonlinearity. Wide excitation width (tongue has area, not a point). Short sustain=0 for pure impulse."
+}

--- a/Presets/XOceanus/Foundation/Oceanic_Shore_Pulse.xometa
+++ b/Presets/XOceanus/Foundation/Oceanic_Shore_Pulse.xometa
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "name": "Shore Pulse",
+  "mood": "Foundation",
+  "engines": [
+    "Oceanic"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Rhythmic shore pulse \u2014 the foundational Oceanic sound. Alignment 0.5 and cohesion 0.45 keep the swarm loosely bonded. Scatter 0.25 allows gentle spray. Two subflocks with waveform 0 (sine). Solid warm foundation.",
+  "tags": [
+    "foundation",
+    "shore",
+    "wave",
+    "rhythmic"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Oceanic": {
+      "ocean_alignment": 0.5,
+      "ocean_cohesion": 0.45,
+      "ocean_scatter": 0.25,
+      "ocean_separation": 0.35,
+      "ocean_damping": 0.3,
+      "ocean_tether": 0.4,
+      "ocean_subflocks": 2,
+      "ocean_waveform": 0,
+      "ocean_voiceMode": 1,
+      "ocean_glide": 0.0,
+      "ocean_ampAttack": 0.06,
+      "ocean_ampDecay": 0.5,
+      "ocean_ampSustain": 0.65,
+      "ocean_ampRelease": 1.2,
+      "ocean_swarmEnvAttack": 0.08,
+      "ocean_swarmEnvDecay": 0.4,
+      "ocean_swarmEnvSustain": 0.6,
+      "ocean_swarmEnvRelease": 1.0,
+      "ocean_lfo1Rate": 0.08,
+      "ocean_lfo1Depth": 0.35,
+      "ocean_lfo1Shape": 0,
+      "ocean_lfo2Rate": 0.12,
+      "ocean_lfo2Depth": 0.15,
+      "ocean_lfo2Shape": 0,
+      "ocean_macroCharacter": 0.5,
+      "ocean_macroMovement": 0.45,
+      "ocean_macroCoupling": 0.0,
+      "ocean_macroSpace": 0.6
+    }
+  },
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.55,
+    "movement": 0.42,
+    "density": 0.5,
+    "space": 0.62,
+    "aggression": 0.22
+  },
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.45,
+    "COUPLING": 0.0,
+    "SPACE": 0.6
+  }
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Closed_Membrane.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Closed_Membrane.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Closed Membrane",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.05,
+    "SPACE": 0.6
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.6,
+    "movement": 0.05,
+    "density": 0.2,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.05,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.4,
+      "osmo_memory": 0.6,
+      "osmo_filterEnvAmt": 0.2,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.05,
+      "osmo_macroSpace": 0.6
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "closed",
+    "sealed",
+    "coupling",
+    "minimal"
+  ],
+  "description": "Near-zero permeability \u2014 the membrane is almost sealed. Minimal pass-through."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Fast_Reactivity.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Fast_Reactivity.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Fast Reactivity",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.32,
+    "COUPLING": 0.55,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.52,
+    "movement": 0.35,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.55,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 1.0,
+      "osmo_memory": 0.2,
+      "osmo_filterEnvAmt": 0.42,
+      "osmo_lfo1Rate": 0.08,
+      "osmo_lfo1Depth": 0.32,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.32,
+      "osmo_macroCoupling": 0.55,
+      "osmo_macroSpace": 0.2
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "fast",
+    "reactive",
+    "coupling",
+    "instant"
+  ],
+  "description": "Maximum reactivity \u2014 the membrane responds instantly to signal changes."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_High_Selectivity.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_High_Selectivity.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "High Selectivity",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.4
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.55,
+    "movement": 0.15,
+    "density": 0.28,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.5,
+      "osmo_selectivity": 1.0,
+      "osmo_reactivity": 0.5,
+      "osmo_memory": 0.4,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.04,
+      "osmo_lfo1Depth": 0.2,
+      "osmo_macroCharacter": 0.8,
+      "osmo_macroMovement": 0.2,
+      "osmo_macroCoupling": 0.5,
+      "osmo_macroSpace": 0.4
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "selective",
+    "filter",
+    "coupling",
+    "specific"
+  ],
+  "description": "Maximum selectivity \u2014 the membrane filters aggressively. Only specific frequencies pass."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Long_Memory.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Long_Memory.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Long Memory",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 1.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.65,
+    "movement": 0.08,
+    "density": 0.28,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.5,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.3,
+      "osmo_memory": 1.0,
+      "osmo_filterEnvAmt": 0.28,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.1,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.1,
+      "osmo_macroCoupling": 0.5,
+      "osmo_macroSpace": 1.0
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "memory",
+    "long",
+    "holding",
+    "coupling"
+  ],
+  "description": "Maximum memory \u2014 the membrane holds its state for a very long time after signal changes."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Low_Selectivity.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Low_Selectivity.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Low Selectivity",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.04,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.55,
+    "SPACE": 0.35
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.55,
+    "movement": 0.18,
+    "density": 0.32,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.55,
+      "osmo_selectivity": 0.05,
+      "osmo_reactivity": 0.5,
+      "osmo_memory": 0.35,
+      "osmo_filterEnvAmt": 0.3,
+      "osmo_lfo1Rate": 0.05,
+      "osmo_lfo1Depth": 0.22,
+      "osmo_macroCharacter": 0.04000000000000001,
+      "osmo_macroMovement": 0.22,
+      "osmo_macroCoupling": 0.55,
+      "osmo_macroSpace": 0.35
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "broadband",
+    "neutral",
+    "coupling",
+    "equal"
+  ],
+  "description": "Near-zero selectivity \u2014 broadband membrane. Everything passes with equal weight."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Neutral_Gate.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Neutral_Gate.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Neutral Gate",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.4
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.58,
+    "movement": 0.18,
+    "density": 0.28,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.5,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.5,
+      "osmo_memory": 0.4,
+      "osmo_filterEnvAmt": 0.35,
+      "osmo_lfo1Rate": 0.04,
+      "osmo_lfo1Depth": 0.18,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.18,
+      "osmo_macroCoupling": 0.5,
+      "osmo_macroSpace": 0.4
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "neutral",
+    "balanced",
+    "default",
+    "coupling"
+  ],
+  "description": "All parameters at balanced midpoints \u2014 the default membrane."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Open_Membrane.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Open_Membrane.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Open Membrane",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.3,
+    "COUPLING": 0.95,
+    "SPACE": 0.3
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.55,
+    "movement": 0.25,
+    "density": 0.38,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.95,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.6,
+      "osmo_memory": 0.3,
+      "osmo_filterEnvAmt": 0.45,
+      "osmo_lfo1Rate": 0.06,
+      "osmo_lfo1Depth": 0.3,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.3,
+      "osmo_macroCoupling": 0.95,
+      "osmo_macroSpace": 0.3
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "open",
+    "coupling",
+    "permeability",
+    "analysis"
+  ],
+  "description": "Permeability at maximum \u2014 the membrane is nearly open. Everything passes through freely."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Porous_Rock.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Porous_Rock.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Porous Rock",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.1,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.38,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.2,
+    "warmth": 0.65,
+    "movement": 0.1,
+    "density": 0.3,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.38,
+      "osmo_selectivity": 0.12,
+      "osmo_reactivity": 0.25,
+      "osmo_memory": 0.55,
+      "osmo_filterEnvAmt": 0.28,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.12,
+      "osmo_macroCharacter": 0.096,
+      "osmo_macroMovement": 0.12,
+      "osmo_macroCoupling": 0.38,
+      "osmo_macroSpace": 0.55
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "porous",
+    "rock",
+    "geological",
+    "slow",
+    "coupling"
+  ],
+  "description": "Low selectivity, medium permeability \u2014 like water through porous sandstone."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Short_Memory.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Short_Memory.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Short Memory",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.55,
+    "SPACE": 0.05
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.52,
+    "movement": 0.28,
+    "density": 0.32,
+    "space": 0.55,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.55,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.65,
+      "osmo_memory": 0.05,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.07,
+      "osmo_lfo1Depth": 0.28,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.28,
+      "osmo_macroCoupling": 0.55,
+      "osmo_macroSpace": 0.05
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "instant",
+    "realtime",
+    "coupling",
+    "immediate"
+  ],
+  "description": "Minimum memory \u2014 the membrane forgets immediately. Real-time only."
+}

--- a/Presets/XOceanus/Foundation/Osmosis_Slow_Reactivity.xometa
+++ b/Presets/XOceanus/Foundation/Osmosis_Slow_Reactivity.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Slow Reactivity",
+  "mood": "Foundation",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.55,
+    "SPACE": 0.7
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.62,
+    "movement": 0.05,
+    "density": 0.25,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.55,
+      "osmo_selectivity": 0.5,
+      "osmo_reactivity": 0.05,
+      "osmo_memory": 0.7,
+      "osmo_filterEnvAmt": 0.3,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.4,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.55,
+      "osmo_macroSpace": 0.7
+    }
+  },
+  "tags": [
+    "osmosis",
+    "membrane",
+    "slow",
+    "glacial",
+    "coupling",
+    "patient"
+  ],
+  "description": "Near-zero reactivity \u2014 the membrane responds glacially slowly."
+}

--- a/Presets/XOceanus/Foundation/Osprey_Shore_Blend_Root.xometa
+++ b/Presets/XOceanus/Foundation/Osprey_Shore_Blend_Root.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Shore Blend Root",
+  "mood": "Foundation",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Osprey at the shore \u2014 balanced shore (0.5) blend of water and air. Moderate sea state (0.35), gentle foam (0.15). Solid foundation tone with resonator.",
+  "tags": [
+    "foundation",
+    "shore",
+    "balanced",
+    "warm"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.04,
+      "osprey_ampDecay": 0.6,
+      "osprey_ampSustain": 0.62,
+      "osprey_ampRelease": 1.2,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.5,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.45,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.35,
+      "osprey_macroSpace": 0.55,
+      "osprey_resonatorBright": 0.45,
+      "osprey_resonatorDecay": 2.5,
+      "osprey_seaState": 0.35,
+      "osprey_shore": 0.5,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.52,
+    "movement": 0.35,
+    "density": 0.48,
+    "space": 0.55,
+    "aggression": 0.28
+  },
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.0,
+    "SPACE": 0.55
+  }
+}

--- a/Presets/XOceanus/Foundation/Overcast_Crackle_Crystal.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_Crackle_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Crackle Crystal",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.5,
+    "movement": 0.04,
+    "density": 0.38,
+    "space": 0.6,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.75,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 5,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.65,
+      "cast_purity": 0.7,
+      "cast_crackle": 0.6,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.83,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "crackle",
+    "texture",
+    "forming",
+    "ice"
+  ],
+  "description": "Transition 1 \u2014 the ice-forming crackle is present. Crystal forms with audible texture."
+}

--- a/Presets/XOceanus/Foundation/Overcast_High_Peak_Count.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_High_Peak_Count.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "High Peak Count",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.45,
+    "movement": 0.03,
+    "density": 0.55,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.78,
+      "cast_crystalSize": 0.55,
+      "cast_numPeaks": 8,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.75,
+      "cast_purity": 0.72,
+      "cast_crackle": 0.4,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1400.0,
+      "cast_filterRes": 0.08,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.83,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "dense",
+    "complex",
+    "peaks",
+    "harmonic"
+  ],
+  "description": "Maximum peaks \u2014 crystals with many harmonic peaks. Dense and complex spectral structure."
+}

--- a/Presets/XOceanus/Foundation/Overcast_High_Purity.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_High_Purity.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "High Purity",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 1.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.52,
+    "movement": 0.02,
+    "density": 0.32,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.82,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 4,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.85,
+      "cast_purity": 1.0,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.06,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.85,
+      "cast_ampRelease": 11.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "pure",
+    "flawless",
+    "clean",
+    "perfect"
+  ],
+  "description": "Maximum purity \u2014 the crystal is perfectly clean, no impurity. Flawless spectral snapshot."
+}

--- a/Presets/XOceanus/Foundation/Overcast_Instant_Crystal.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_Instant_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Instant Crystal",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.75,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.52,
+    "movement": 0.02,
+    "density": 0.35,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.8,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 5,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.7,
+      "cast_purity": 0.75,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.85,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "instant",
+    "clean",
+    "flash",
+    "crystal"
+  ],
+  "description": "Transition 0 \u2014 flash freeze with no crackle. The crystal exists the moment the note is played."
+}

--- a/Presets/XOceanus/Foundation/Overcast_Lattice_Max.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_Lattice_Max.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Lattice Max",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.78,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.55,
+    "movement": 0.02,
+    "density": 0.3,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 5,
+      "cast_transition": 0,
+      "cast_latticeSnap": 1.0,
+      "cast_purity": 0.78,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1000.0,
+      "cast_filterRes": 0.06,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.85,
+      "cast_ampRelease": 11.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "lattice",
+    "ordered",
+    "harmonic",
+    "precise"
+  ],
+  "description": "Maximum lattice snap \u2014 partials snapped to exact harmonic ratios. Maximum crystalline order."
+}

--- a/Presets/XOceanus/Foundation/Overcast_Low_Peak_Count.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_Low_Peak_Count.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Low Peak Count",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.25,
+    "warmth": 0.62,
+    "movement": 0.02,
+    "density": 0.15,
+    "space": 0.7,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.82,
+      "cast_crystalSize": 0.48,
+      "cast_numPeaks": 2,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.8,
+      "cast_purity": 0.8,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.62,
+      "cast_filterCutoff": 800.0,
+      "cast_filterRes": 0.05,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.87,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "sparse",
+    "fundamental",
+    "clean",
+    "minimal"
+  ],
+  "description": "Minimum peaks \u2014 sparse crystal structure. Almost pure fundamental, minimal harmonics."
+}

--- a/Presets/XOceanus/Foundation/Overcast_Low_Purity.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_Low_Purity.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Low Purity",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.5,
+    "movement": 0.04,
+    "density": 0.38,
+    "space": 0.6,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.72,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 5,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.55,
+      "cast_purity": 0.2,
+      "cast_crackle": 0.8,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1200.0,
+      "cast_filterRes": 0.08,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.82,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "impure",
+    "rough",
+    "noisy",
+    "crystal"
+  ],
+  "description": "Minimum purity \u2014 the crystal is impure, noisy at the edges. Rough crystal formation."
+}

--- a/Presets/XOceanus/Foundation/Overcast_Shatter_Start.xometa
+++ b/Presets/XOceanus/Foundation/Overcast_Shatter_Start.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Shatter Start",
+  "mood": "Foundation",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.52,
+    "movement": 0.08,
+    "density": 0.32,
+    "space": 0.62,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.7,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 4,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.6,
+      "cast_purity": 0.72,
+      "cast_crackle": 0.5,
+      "cast_shatterGap": 0.05,
+      "cast_stereoWidth": 0.65,
+      "cast_filterCutoff": 1100.0,
+      "cast_filterRes": 0.07,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.82,
+      "cast_ampRelease": 8.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "foundation",
+    "shatter",
+    "rhythm",
+    "brief",
+    "reform"
+  ],
+  "description": "Transition 2, short gap \u2014 brief silence then new crystal. Rhythmic at short durations."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Fast_Accumulation.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Fast_Accumulation.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Fast Accumulation",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.58,
+    "movement": 0.28,
+    "density": 0.4,
+    "space": 0.55,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.5,
+      "flow_accumRate": 0.8,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.42,
+      "flow_releaseTime": 1.2,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1100.0,
+      "flow_filterRes": 0.07,
+      "flow_filtEnvAmount": 0.18,
+      "flow_ampAttack": 0.8,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.8,
+      "flow_ampRelease": 6.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.015,
+      "flow_lfo1Depth": 0.18,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.09,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "fast",
+    "rapid",
+    "reactive",
+    "quick"
+  ],
+  "description": "Rapid accumulation \u2014 a few notes of any velocity triggers the valve."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Gentle_Release.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Gentle_Release.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Gentle Release",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.65,
+    "movement": 0.14,
+    "density": 0.32,
+    "space": 0.65,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.4,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.58,
+      "flow_strainColor": 0.35,
+      "flow_releaseTime": 5.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 900.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.14,
+      "flow_ampAttack": 1.5,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.85,
+      "flow_ampRelease": 9.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.009,
+      "flow_lfo1Depth": 0.12,
+      "flow_lfo2Rate": 0.004,
+      "flow_lfo2Depth": 0.06,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "gentle",
+    "slow-release",
+    "graceful",
+    "calm"
+  ],
+  "description": "Long release time \u2014 when the valve opens, the release is slow and gentle. No drama."
+}

--- a/Presets/XOceanus/Foundation/Overflow_High_Threshold.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_High_Threshold.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "High Threshold",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.6
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.58,
+    "movement": 0.15,
+    "density": 0.35,
+    "space": 0.65,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.88,
+      "flow_accumRate": 0.3,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.6,
+      "flow_strainColor": 0.35,
+      "flow_releaseTime": 2.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 900.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.14,
+      "flow_ampAttack": 2.0,
+      "flow_ampDecay": 2.0,
+      "flow_ampSustain": 0.85,
+      "flow_ampRelease": 9.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.008,
+      "flow_lfo1Depth": 0.12,
+      "flow_lfo2Rate": 0.004,
+      "flow_lfo2Depth": 0.06,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "stubborn",
+    "high-threshold",
+    "aggressive",
+    "stoic"
+  ],
+  "description": "Stubborn valve \u2014 very high threshold, requires sustained aggressive playing. The pressure cooker that needs real force."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Interval_Study.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Interval_Study.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Interval Study",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.58,
+    "movement": 0.2,
+    "density": 0.38,
+    "space": 0.6,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.6,
+      "flow_accumRate": 0.55,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.55,
+      "flow_strainColor": 0.45,
+      "flow_releaseTime": 2.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1000.0,
+      "flow_filterRes": 0.06,
+      "flow_filtEnvAmount": 0.16,
+      "flow_ampAttack": 1.5,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.83,
+      "flow_ampRelease": 8.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.011,
+      "flow_lfo1Depth": 0.15,
+      "flow_lfo2Rate": 0.005,
+      "flow_lfo2Depth": 0.08,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "dissonance",
+    "interval",
+    "chromatic",
+    "tension"
+  ],
+  "description": "Dissonant interval accumulation \u2014 minor 2nds and tritones build pressure faster. Chromatic playing triggers more."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Low_Threshold.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Low_Threshold.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Low Threshold",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.16,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.62,
+    "movement": 0.25,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.25,
+      "flow_accumRate": 0.6,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.4,
+      "flow_releaseTime": 1.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1000.0,
+      "flow_filterRes": 0.06,
+      "flow_filtEnvAmount": 0.18,
+      "flow_ampAttack": 1.0,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.82,
+      "flow_ampRelease": 7.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.012,
+      "flow_lfo1Depth": 0.16,
+      "flow_lfo2Rate": 0.006,
+      "flow_lfo2Depth": 0.08,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "sensitive",
+    "hair-trigger",
+    "gentle",
+    "reactive"
+  ],
+  "description": "Hair-trigger valve \u2014 very low threshold, accumulation builds quickly. Even gentle playing triggers events."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Medium_Vessel.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Medium_Vessel.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Medium Vessel",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.38,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.6,
+    "movement": 0.18,
+    "density": 0.35,
+    "space": 0.6,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.45,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.55,
+      "flow_strainColor": 0.38,
+      "flow_releaseTime": 2.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 950.0,
+      "flow_filterRes": 0.06,
+      "flow_filtEnvAmount": 0.15,
+      "flow_ampAttack": 1.5,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.83,
+      "flow_ampRelease": 8.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.01,
+      "flow_lfo1Depth": 0.14,
+      "flow_lfo2Rate": 0.005,
+      "flow_lfo2Depth": 0.07,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "balanced",
+    "medium",
+    "default",
+    "centered"
+  ],
+  "description": "Balanced vessel \u2014 medium threshold, medium accumulation. The default pressure cooker scenario."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Quick_Release.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Quick_Release.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Quick Release",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.55,
+    "movement": 0.22,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.5,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.42,
+      "flow_releaseTime": 0.3,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1100.0,
+      "flow_filterRes": 0.07,
+      "flow_filtEnvAmount": 0.18,
+      "flow_ampAttack": 0.5,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.8,
+      "flow_ampRelease": 5.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.014,
+      "flow_lfo1Depth": 0.18,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.09,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "quick",
+    "percussive",
+    "snap",
+    "sharp"
+  ],
+  "description": "Short release time \u2014 valve opens and slams shut immediately. Percussive release event."
+}

--- a/Presets/XOceanus/Foundation/Overflow_Slow_Accumulation.xometa
+++ b/Presets/XOceanus/Foundation/Overflow_Slow_Accumulation.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Slow Accumulation",
+  "mood": "Foundation",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.32,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.25,
+    "warmth": 0.65,
+    "movement": 0.12,
+    "density": 0.3,
+    "space": 0.68,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.6,
+      "flow_accumRate": 0.2,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.58,
+      "flow_strainColor": 0.32,
+      "flow_releaseTime": 2.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 850.0,
+      "flow_filterRes": 0.05,
+      "flow_filtEnvAmount": 0.12,
+      "flow_ampAttack": 2.0,
+      "flow_ampDecay": 2.0,
+      "flow_ampSustain": 0.86,
+      "flow_ampRelease": 9.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.007,
+      "flow_lfo1Depth": 0.1,
+      "flow_lfo2Rate": 0.004,
+      "flow_lfo2Depth": 0.05,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "foundation",
+    "slow",
+    "patient",
+    "geological",
+    "patient"
+  ],
+  "description": "Slow accumulation rate \u2014 pressure builds with the patience of a geological process."
+}

--- a/Presets/XOceanus/Foundation/Overwash_Bright_Foundation.xometa
+++ b/Presets/XOceanus/Foundation/Overwash_Bright_Foundation.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bright Foundation",
+  "mood": "Foundation",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.55,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.5,
+    "movement": 0.18,
+    "density": 0.4,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.18,
+      "wash_viscosity": 0.62,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 16.0,
+      "wash_spreadMax": 100.0,
+      "wash_brightness": 0.55,
+      "wash_warmth": 0.5,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.82,
+      "wash_ampRelease": 8.0,
+      "wash_filterCutoff": 1500.0,
+      "wash_filterRes": 0.08,
+      "wash_filtEnvAmount": 0.2,
+      "wash_filtAttack": 1.5,
+      "wash_filtDecay": 2.5,
+      "wash_filtSustain": 0.74,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.012,
+      "wash_lfo1Depth": 0.18,
+      "wash_lfo2Rate": 0.006,
+      "wash_lfo2Depth": 0.09,
+      "wash_stereoWidth": 0.68,
+      "wash_level": 0.75,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "foundation",
+    "bright",
+    "medium",
+    "starting",
+    "eight-harmonic"
+  ],
+  "description": "Medium-high brightness, medium warmth. Eight harmonics at moderate diffusion \u2014 the starting point for brighter pad work."
+}

--- a/Presets/XOceanus/Foundation/Overwash_Diffusion_Start.xometa
+++ b/Presets/XOceanus/Foundation/Overwash_Diffusion_Start.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Diffusion Start",
+  "mood": "Foundation",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.3,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.5,
+    "SPACE": 0.6
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.6,
+    "movement": 0.15,
+    "density": 0.3,
+    "space": 0.6,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.15,
+      "wash_viscosity": 0.7,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 20.0,
+      "wash_spreadMax": 80.0,
+      "wash_brightness": 0.3,
+      "wash_warmth": 0.6,
+      "wash_ampAttack": 2.0,
+      "wash_ampDecay": 2.0,
+      "wash_ampSustain": 0.85,
+      "wash_ampRelease": 10.0,
+      "wash_filterCutoff": 1000.0,
+      "wash_filterRes": 0.06,
+      "wash_filtEnvAmount": 0.15,
+      "wash_filtAttack": 2.0,
+      "wash_filtDecay": 3.0,
+      "wash_filtSustain": 0.78,
+      "wash_filtRelease": 6.0,
+      "wash_lfo1Rate": 0.01,
+      "wash_lfo1Depth": 0.15,
+      "wash_lfo2Rate": 0.005,
+      "wash_lfo2Depth": 0.08,
+      "wash_stereoWidth": 0.62,
+      "wash_level": 0.75,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "foundation",
+    "pedagogical",
+    "medium",
+    "starting",
+    "clean"
+  ],
+  "description": "A clean demonstration preset \u2014 medium everything, pedagogically clear. The fundamental diffusion behavior, unadorned."
+}

--- a/Presets/XOceanus/Foundation/Overwash_Root_Diffusion.xometa
+++ b/Presets/XOceanus/Foundation/Overwash_Root_Diffusion.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Root Diffusion",
+  "mood": "Foundation",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.12,
+    "MOVEMENT": 0.07,
+    "COUPLING": 0.5,
+    "SPACE": 0.7
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.12,
+    "warmth": 0.8,
+    "movement": 0.07,
+    "density": 0.18,
+    "space": 0.7,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.07,
+      "wash_viscosity": 0.88,
+      "wash_harmonics": 3,
+      "wash_diffusionTime": 45.0,
+      "wash_spreadMax": 50.0,
+      "wash_brightness": 0.12,
+      "wash_warmth": 0.8,
+      "wash_ampAttack": 4.0,
+      "wash_ampDecay": 3.0,
+      "wash_ampSustain": 0.93,
+      "wash_ampRelease": 16.0,
+      "wash_filterCutoff": 550.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.07,
+      "wash_filtAttack": 3.5,
+      "wash_filtDecay": 4.5,
+      "wash_filtSustain": 0.92,
+      "wash_filtRelease": 11.0,
+      "wash_lfo1Rate": 0.004,
+      "wash_lfo1Depth": 0.08,
+      "wash_lfo2Rate": 0.002,
+      "wash_lfo2Depth": 0.04,
+      "wash_stereoWidth": 0.52,
+      "wash_level": 0.72,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "foundation",
+    "root",
+    "strong",
+    "warm",
+    "grounding"
+  ],
+  "description": "Low harmonics, strong warmth, slow diffusion \u2014 the root identity of the Overwash engine, before ornamentation."
+}

--- a/Presets/XOceanus/Foundation/Overwash_Warmth_Foundation.xometa
+++ b/Presets/XOceanus/Foundation/Overwash_Warmth_Foundation.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Warmth Foundation",
+  "mood": "Foundation",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.1,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.5,
+    "SPACE": 0.72
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.88,
+    "movement": 0.08,
+    "density": 0.2,
+    "space": 0.72,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.08,
+      "wash_viscosity": 0.85,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 40.0,
+      "wash_spreadMax": 55.0,
+      "wash_brightness": 0.1,
+      "wash_warmth": 0.88,
+      "wash_ampAttack": 3.5,
+      "wash_ampDecay": 2.5,
+      "wash_ampSustain": 0.92,
+      "wash_ampRelease": 15.0,
+      "wash_filterCutoff": 600.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.08,
+      "wash_filtAttack": 3.0,
+      "wash_filtDecay": 4.0,
+      "wash_filtSustain": 0.9,
+      "wash_filtRelease": 10.0,
+      "wash_lfo1Rate": 0.005,
+      "wash_lfo1Depth": 0.1,
+      "wash_lfo2Rate": 0.003,
+      "wash_lfo2Depth": 0.05,
+      "wash_stereoWidth": 0.58,
+      "wash_level": 0.74,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "foundation",
+    "warm",
+    "minimal",
+    "slow",
+    "identity"
+  ],
+  "description": "Maximum warmth, minimum brightness \u2014 the foundational warm pad identity. 4 harmonics, slow diffusion, high viscosity."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Chicken_Stock.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Chicken_Stock.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Chicken Stock",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.3
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.65,
+    "movement": 0.12,
+    "density": 0.28,
+    "space": 0.6,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.3,
+      "worn_richness": 0.42,
+      "worn_maillard": 0.15,
+      "worn_umamiDepth": 0.3,
+      "worn_concentrate": 0.25,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1200.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.15,
+      "worn_ampAttack": 1.5,
+      "worn_ampDecay": 2.0,
+      "worn_ampSustain": 0.85,
+      "worn_ampRelease": 9.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.01,
+      "worn_lfo1Depth": 0.12,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "light",
+    "fresh",
+    "stock",
+    "reduction"
+  ],
+  "description": "Light-flavored stock \u2014 fresh, clean session start. Low reduction rate, medium heat. The foundation before flavor concentrates."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Clear_Broth.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Clear_Broth.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Clear Broth",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.3,
+    "MOVEMENT": 0.09,
+    "COUPLING": 0.5,
+    "SPACE": 0.25
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.55,
+    "movement": 0.1,
+    "density": 0.2,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.07,
+      "worn_heat": 0.25,
+      "worn_richness": 0.3,
+      "worn_maillard": 0.05,
+      "worn_umamiDepth": 0.25,
+      "worn_concentrate": 0.18,
+      "worn_sessionTarget": 22.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1400.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.12,
+      "worn_ampAttack": 2.0,
+      "worn_ampDecay": 2.5,
+      "worn_ampSustain": 0.84,
+      "worn_ampRelease": 9.5,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.008,
+      "worn_lfo1Depth": 0.09,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.04,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "clear",
+    "transparent",
+    "clean",
+    "consomme"
+  ],
+  "description": "Maximum clarity \u2014 minimum maillard, minimum concentrate. Clean and transparent like consomm\u00e9 before it reduces."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Court_Bouillon.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Court_Bouillon.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Court Bouillon",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.14,
+    "COUPLING": 0.5,
+    "SPACE": 0.28
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.52,
+    "movement": 0.15,
+    "density": 0.3,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.12,
+      "worn_heat": 0.35,
+      "worn_richness": 0.4,
+      "worn_maillard": 0.12,
+      "worn_umamiDepth": 0.28,
+      "worn_concentrate": 0.28,
+      "worn_sessionTarget": 18.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1600.0,
+      "worn_filterRes": 0.08,
+      "worn_filtEnvAmount": 0.18,
+      "worn_ampAttack": 1.5,
+      "worn_ampDecay": 2.0,
+      "worn_ampSustain": 0.83,
+      "worn_ampRelease": 8.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.012,
+      "worn_lfo1Depth": 0.14,
+      "worn_lfo2Rate": 0.006,
+      "worn_lfo2Depth": 0.07,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "aromatic",
+    "acidic",
+    "bright",
+    "bouillon"
+  ],
+  "description": "Aromatic acidic stock \u2014 bright and clean at the start. Medium reduction rate, elevated brightness because of acidity."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Fish_Fumet.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Fish_Fumet.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Fish Fumet",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.38,
+    "MOVEMENT": 0.15,
+    "COUPLING": 0.5,
+    "SPACE": 0.28
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.4,
+    "warmth": 0.58,
+    "movement": 0.18,
+    "density": 0.3,
+    "space": 0.55,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.16,
+      "worn_heat": 0.38,
+      "worn_richness": 0.38,
+      "worn_maillard": 0.2,
+      "worn_umamiDepth": 0.28,
+      "worn_concentrate": 0.3,
+      "worn_sessionTarget": 15.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1400.0,
+      "worn_filterRes": 0.07,
+      "worn_filtEnvAmount": 0.18,
+      "worn_ampAttack": 1.2,
+      "worn_ampDecay": 1.8,
+      "worn_ampSustain": 0.82,
+      "worn_ampRelease": 7.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.014,
+      "worn_lfo1Depth": 0.15,
+      "worn_lfo2Rate": 0.007,
+      "worn_lfo2Depth": 0.07,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "delicate",
+    "quick",
+    "fumet",
+    "concentrate"
+  ],
+  "description": "Delicate fish stock \u2014 quick reduction rate, light body. The fastest of the reduction pads; this one concentrates before the session is halfway done."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Pot_Liquor.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Pot_Liquor.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pot Liquor",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.5,
+    "SPACE": 0.42
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.72,
+    "movement": 0.12,
+    "density": 0.32,
+    "space": 0.6,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.35,
+      "worn_richness": 0.45,
+      "worn_maillard": 0.18,
+      "worn_umamiDepth": 0.42,
+      "worn_concentrate": 0.28,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 900.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 2.0,
+      "worn_ampDecay": 2.5,
+      "worn_ampSustain": 0.88,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.009,
+      "worn_lfo1Depth": 0.12,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "southern",
+    "rich",
+    "vegetable",
+    "grounding"
+  ],
+  "description": "Southern US pot liquor \u2014 rich, salty, vegetable-steeped. Higher umami depth from the start, warm and grounding."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Second_Stock.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Second_Stock.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Second Stock",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.28,
+    "MOVEMENT": 0.09,
+    "COUPLING": 0.5,
+    "SPACE": 0.28
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.25,
+    "warmth": 0.6,
+    "movement": 0.09,
+    "density": 0.22,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.07,
+      "worn_heat": 0.22,
+      "worn_richness": 0.28,
+      "worn_maillard": 0.08,
+      "worn_umamiDepth": 0.28,
+      "worn_concentrate": 0.18,
+      "worn_sessionTarget": 22.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1000.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.1,
+      "worn_ampAttack": 2.2,
+      "worn_ampDecay": 2.8,
+      "worn_ampSustain": 0.85,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.007,
+      "worn_lfo1Depth": 0.09,
+      "worn_lfo2Rate": 0.003,
+      "worn_lfo2Depth": 0.05,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "second",
+    "delicate",
+    "remouillage",
+    "wisdom"
+  ],
+  "description": "Remouillage \u2014 a second stock made from bones already used. Lighter, more delicate, slightly less body. The afterthought that contains wisdom."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Stock_Pot.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Stock_Pot.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Stock Pot",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.38,
+    "MOVEMENT": 0.11,
+    "COUPLING": 0.5,
+    "SPACE": 0.32
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.62,
+    "movement": 0.12,
+    "density": 0.28,
+    "space": 0.62,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.3,
+      "worn_richness": 0.38,
+      "worn_maillard": 0.12,
+      "worn_umamiDepth": 0.32,
+      "worn_concentrate": 0.24,
+      "worn_sessionTarget": 20.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1100.0,
+      "worn_filterRes": 0.06,
+      "worn_filtEnvAmount": 0.14,
+      "worn_ampAttack": 1.8,
+      "worn_ampDecay": 2.2,
+      "worn_ampSustain": 0.85,
+      "worn_ampRelease": 9.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.009,
+      "worn_lfo1Depth": 0.11,
+      "worn_lfo2Rate": 0.005,
+      "worn_lfo2Depth": 0.06,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "neutral",
+    "medium",
+    "starting",
+    "reliable"
+  ],
+  "description": "The neutral foundational stock \u2014 medium everything. Designed as a reliable starting point before the session shapes it."
+}

--- a/Presets/XOceanus/Foundation/Overworn_Veal_White.xometa
+++ b/Presets/XOceanus/Foundation/Overworn_Veal_White.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Veal White",
+  "mood": "Foundation",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.35,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.32
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.62,
+    "movement": 0.1,
+    "density": 0.25,
+    "space": 0.65,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.28,
+      "worn_richness": 0.35,
+      "worn_maillard": 0.08,
+      "worn_umamiDepth": 0.32,
+      "worn_concentrate": 0.22,
+      "worn_sessionTarget": 25.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 1100.0,
+      "worn_filterRes": 0.05,
+      "worn_filtEnvAmount": 0.12,
+      "worn_ampAttack": 2.0,
+      "worn_ampDecay": 2.5,
+      "worn_ampSustain": 0.86,
+      "worn_ampRelease": 10.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.008,
+      "worn_lfo1Depth": 0.1,
+      "worn_lfo2Rate": 0.004,
+      "worn_lfo2Depth": 0.05,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "foundation",
+    "neutral",
+    "clean",
+    "veal",
+    "receiving"
+  ],
+  "description": "White veal stock \u2014 neutral, clean, capable of receiving anything. Low maillard, medium heat. The artist's blank vellum."
+}

--- a/Presets/XOceanus/Foundation/Owlfish_Reef_Bass.xometa
+++ b/Presets/XOceanus/Foundation/Owlfish_Reef_Bass.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Reef Bass",
+  "mood": "Foundation",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Owlfish hovering over the reef base. Warm fundamental with body freq at 55Hz and strong sub stack. Moderate filter cutoff (0.45) with smooth amp envelope.",
+  "tags": [
+    "foundation",
+    "bass",
+    "warm",
+    "reef"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 55.0,
+      "owl_bodyLevel": 0.65,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.45,
+      "owl_filterEnvDepth": 0.5,
+      "owl_filterReso": 0.3,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.0,
+      "owl_grainMix": 0.0,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.5,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.5,
+      "owl_reverbMix": 0.15,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.4,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.9,
+      "owl_subLevel2": 0.72,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 15,
+      "owl_ampDecay": 400,
+      "owl_ampSustain": 0.65,
+      "owl_ampRelease": 800,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.35,
+    "warmth": 0.65,
+    "movement": 0.3,
+    "density": 0.55,
+    "space": 0.5,
+    "aggression": 0.3
+  },
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.3,
+    "COUPLING": 0.0,
+    "SPACE": 0.5
+  }
+}

--- a/Presets/XOceanus/Kinetic/Obiont/Actin_Filament.xometa
+++ b/Presets/XOceanus/Kinetic/Obiont/Actin_Filament.xometa
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "name": "Actin Filament",
+  "mood": "Kinetic",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 30 at maximum evolution (30Hz). Chaotic rule at high speed produces a blur exceeding perception of individual patterns. Dense noise-like behavior with bright spectral content. Narrow projection (0.1) focuses all the chaos into a sharp noise band.",
+  "tags": [
+    "kinetic",
+    "fast",
+    "chaotic",
+    "rule-30",
+    "noise",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 30,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 30.0,
+      "obnt_gridDensity": 0.5,
+      "obnt_chaos": 0.25,
+      "obnt_projection": 0.1,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 7000.0,
+      "obnt_filterResonance": 0.55,
+      "obnt_attack": 0.001,
+      "obnt_decay": 0.15,
+      "obnt_sustain": 0.0,
+      "obnt_release": 0.2,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 8.0,
+      "obnt_lfo1Depth": 0.3,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.88,
+    "warmth": 0.15,
+    "movement": 0.95,
+    "density": 0.45,
+    "space": 0.25,
+    "aggression": 0.78
+  },
+  "macros": {
+    "CHAOS": 0.5,
+    "EVOLUTION": 0.98,
+    "SPACE": 0.25,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Kinetic/Obiont/Myosin_Motor.xometa
+++ b/Presets/XOceanus/Kinetic/Obiont/Myosin_Motor.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Myosin Motor",
+  "mood": "Kinetic",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 150 at fast evolution (20Hz) \u2014 symmetric XOR produces motor-like rhythmic pulsing. Each generation's population count oscillates predictably. At 20Hz this becomes audible as a carrier frequency \u2014 a cellular engine running at full RPM.",
+  "tags": [
+    "kinetic",
+    "motor",
+    "rhythmic",
+    "rule-150",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 150,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 20.0,
+      "obnt_gridDensity": 0.45,
+      "obnt_chaos": 0.06,
+      "obnt_projection": 0.25,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4500.0,
+      "obnt_filterResonance": 0.5,
+      "obnt_attack": 0.002,
+      "obnt_decay": 0.12,
+      "obnt_sustain": 0.0,
+      "obnt_release": 0.18,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 5.0,
+      "obnt_lfo1Depth": 0.25,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.75,
+    "warmth": 0.2,
+    "movement": 0.92,
+    "density": 0.42,
+    "space": 0.3,
+    "aggression": 0.68
+  },
+  "macros": {
+    "CHAOS": 0.12,
+    "EVOLUTION": 0.95,
+    "SPACE": 0.3,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Kinetic/Origami_Wet_Fold_Burst.xometa
+++ b/Presets/XOceanus/Kinetic/Origami_Wet_Fold_Burst.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "name": "Wet Fold Burst",
+  "mood": "Kinetic",
+  "engines": [
+    "Origami"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Fresh wet paper folds crack and snap at maximum depth. Fast fold rate via LFO1 (3.0Hz) and high foldCount (8) produces a flutter \u2014 the paper still deciding its final shape. Operation 2 (pleat) for sharp accordion edges. Percussive amp envelope.",
+  "tags": [
+    "kinetic",
+    "percussive",
+    "crisp",
+    "bright"
+  ],
+  "macroLabels": [
+    "FOLD",
+    "MOTION",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Origami": {
+      "origami_foldPoint": 0.3,
+      "origami_foldDepth": 0.88,
+      "origami_foldCount": 8,
+      "origami_operation": 2,
+      "origami_freeze": 0.0,
+      "origami_foldEnvAttack": 0.003,
+      "origami_foldEnvDecay": 0.15,
+      "origami_foldEnvSustain": 0.0,
+      "origami_foldEnvRelease": 0.3,
+      "origami_ampAttack": 0.003,
+      "origami_ampDecay": 0.2,
+      "origami_ampSustain": 0.0,
+      "origami_ampRelease": 0.35,
+      "origami_level": 0.85,
+      "origami_glide": 0.0,
+      "origami_lfo1Rate": 3.0,
+      "origami_lfo1Depth": 0.45,
+      "origami_lfo1Shape": 2,
+      "origami_lfo2Rate": 1.5,
+      "origami_lfo2Depth": 0.3,
+      "origami_lfo2Shape": 3,
+      "origami_macroFold": 0.85,
+      "origami_macroMotion": 0.88,
+      "origami_macroCoupling": 0.0,
+      "origami_macroSpace": 0.28
+    }
+  },
+  "dna": {
+    "brightness": 0.8,
+    "warmth": 0.18,
+    "movement": 0.85,
+    "density": 0.55,
+    "space": 0.28,
+    "aggression": 0.65
+  },
+  "macros": {
+    "FOLD": 0.85,
+    "MOTION": 0.88,
+    "COUPLING": 0.0,
+    "SPACE": 0.28
+  }
+}

--- a/Presets/XOceanus/Kinetic/Osprey_Hover_Lock.xometa
+++ b/Presets/XOceanus/Kinetic/Osprey_Hover_Lock.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Hover Lock",
+  "mood": "Kinetic",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Hovering in place \u2014 high sea state (0.7) turbulence, rapid swell period (2.0) for wingbeat. High foam (0.55), medium hull compression. Constant kinetic energy output.",
+  "tags": [
+    "kinetic",
+    "hovering",
+    "energetic",
+    "precise"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.01,
+      "osprey_ampDecay": 0.15,
+      "osprey_ampSustain": 0.55,
+      "osprey_ampRelease": 0.3,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.6,
+      "osprey_foam": 0.55,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.55,
+      "osprey_macroCharacter": 0.65,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.82,
+      "osprey_macroSpace": 0.4,
+      "osprey_resonatorBright": 0.4,
+      "osprey_resonatorDecay": 2.0,
+      "osprey_seaState": 0.7,
+      "osprey_shore": 0.55,
+      "osprey_swellPeriod": 2.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.3,
+    "movement": 0.82,
+    "density": 0.5,
+    "space": 0.4,
+    "aggression": 0.55
+  },
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.82,
+    "COUPLING": 0.0,
+    "SPACE": 0.4
+  }
+}

--- a/Presets/XOceanus/Luminous/Obscura_Bronze_Bell.xometa
+++ b/Presets/XOceanus/Luminous/Obscura_Bronze_Bell.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bronze Bell",
+  "mood": "Luminous",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.2,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.48,
+    "movement": 0.06,
+    "density": 0.48,
+    "space": 0.7,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.78,
+      "obscura_damping": 0.14,
+      "obscura_nonlinear": 0.38,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.32,
+      "obscura_scanWidth": 0.45,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.01,
+      "obscura_ampDecay": 0.45,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 6.0,
+      "obscura_physEnvAttack": 0.01,
+      "obscura_physEnvDecay": 0.45,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 6.0,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 3,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.2,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.1,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "bell",
+    "bronze",
+    "church",
+    "inharmonic",
+    "luminous"
+  ],
+  "description": "Small church bell \u2014 Periodic boundary (circular topology of thick bronze casting). Medium-high stiffness. Moderate nonlinearity for inharmonic partials. Wide aperture scanner (scanWidth=0.45) blurs some high-frequency detail as would distance from the bell. Poly8 for chords."
+}

--- a/Presets/XOceanus/Luminous/Osprey_Dawn_Patrol.xometa
+++ b/Presets/XOceanus/Luminous/Osprey_Dawn_Patrol.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Dawn Patrol",
+  "mood": "Luminous",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "First flight of dawn \u2014 warm early morning light. Shore 0.45 (coastal), low sea state (0.2), warm filterTilt (0.45). Long resonatorDecay (3.5). Open sky ahead.",
+  "tags": [
+    "luminous",
+    "dawn",
+    "morning",
+    "warm"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.08,
+      "osprey_ampDecay": 0.7,
+      "osprey_ampSustain": 0.65,
+      "osprey_ampRelease": 2.0,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.45,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.15,
+      "osprey_harborVerb": 0.4,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.5,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.3,
+      "osprey_macroSpace": 0.72,
+      "osprey_resonatorBright": 0.5,
+      "osprey_resonatorDecay": 3.5,
+      "osprey_seaState": 0.2,
+      "osprey_shore": 0.45,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.52,
+    "movement": 0.3,
+    "density": 0.42,
+    "space": 0.72,
+    "aggression": 0.18
+  },
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.3,
+    "COUPLING": 0.0,
+    "SPACE": 0.72
+  }
+}

--- a/Presets/XOceanus/Organic/Obscura_Bone_Flute.xometa
+++ b/Presets/XOceanus/Organic/Obscura_Bone_Flute.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Bone Flute",
+  "mood": "Organic",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.3,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.5,
+    "movement": 0.06,
+    "density": 0.28,
+    "space": 0.68,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.32,
+      "obscura_damping": 0.1,
+      "obscura_nonlinear": 0.02,
+      "obscura_excitePos": 0.02,
+      "obscura_exciteWidth": 0.12,
+      "obscura_scanWidth": 0.5,
+      "obscura_boundary": 1,
+      "obscura_sustain": 0.8,
+      "obscura_ampAttack": 0.2,
+      "obscura_ampDecay": 0.0,
+      "obscura_ampSustain": 1.0,
+      "obscura_ampRelease": 1.2,
+      "obscura_physEnvAttack": 0.15,
+      "obscura_physEnvDecay": 0.0,
+      "obscura_physEnvSustain": 1.0,
+      "obscura_physEnvRelease": 0.8,
+      "obscura_lfo1Rate": 0.05,
+      "obscura_lfo1Depth": 0.1,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 1,
+      "obscura_glide": 0.08,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.1,
+      "obscura_macroCoupling": 0.3,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "flute",
+    "bone",
+    "breath",
+    "organic",
+    "pipe"
+  ],
+  "description": "Open-bore bone flute \u2014 Free boundary produces the odd-harmonic pipe character. Low stiffness (open air column). Nearly zero nonlinearity (air is linear at small amplitudes). Bowing with full physics sustain simulates constant breath pressure. Excite near the mouthpiece position (0.02 from one end) drives the fundamental strongly."
+}

--- a/Presets/XOceanus/Organic/Obscura_Tabla_Membrane.xometa
+++ b/Presets/XOceanus/Organic/Obscura_Tabla_Membrane.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tabla Membrane",
+  "mood": "Organic",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.2
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.6,
+    "movement": 0.06,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.03
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.38,
+      "obscura_damping": 0.3,
+      "obscura_nonlinear": 0.22,
+      "obscura_excitePos": 0.55,
+      "obscura_exciteWidth": 0.35,
+      "obscura_scanWidth": 0.45,
+      "obscura_boundary": 0,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.4,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 1.2,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.4,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 1.2,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 3,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.2,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "tabla",
+    "membrane",
+    "drum",
+    "organic",
+    "indian"
+  ],
+  "description": "Tabla goatskin membrane \u2014 Fixed boundary (rim-mounted), medium-low stiffness. The specific dholak/tabla membrane is characterized by its loaded center (the 'syahi' black paste adding mass and thus harmonic complexity). Moderate nonlinearity from membrane stretching. Wide excitation (fingertip area). Poly8 for the characteristic 'na', 'ta', 'din' finger positions."
+}

--- a/Presets/XOceanus/Organic/Obscura_Vowel_Column.xometa
+++ b/Presets/XOceanus/Organic/Obscura_Vowel_Column.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Vowel Column",
+  "mood": "Organic",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.2,
+    "SPACE": 0.0
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.62,
+    "movement": 0.15,
+    "density": 0.35,
+    "space": 0.58,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.28,
+      "obscura_damping": 0.15,
+      "obscura_nonlinear": 0.08,
+      "obscura_excitePos": 0.3,
+      "obscura_exciteWidth": 0.3,
+      "obscura_scanWidth": 0.55,
+      "obscura_boundary": 1,
+      "obscura_sustain": 0.72,
+      "obscura_ampAttack": 0.08,
+      "obscura_ampDecay": 0.0,
+      "obscura_ampSustain": 1.0,
+      "obscura_ampRelease": 1.0,
+      "obscura_physEnvAttack": 0.12,
+      "obscura_physEnvDecay": 0.0,
+      "obscura_physEnvSustain": 1.0,
+      "obscura_physEnvRelease": 0.7,
+      "obscura_lfo1Rate": 0.06,
+      "obscura_lfo1Depth": 0.1,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.18,
+      "obscura_lfo2Depth": 0.38,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 1,
+      "obscura_glide": 0.12,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.2,
+      "obscura_macroCoupling": 0.2,
+      "obscura_macroSpace": 0.0,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "vocal",
+    "throat",
+    "formant",
+    "organic",
+    "voice"
+  ],
+  "description": "Vocal tract as chain resonance \u2014 Free boundary (open-ended tube approximation). Low stiffness (air column). Slow LFO2 sweeps excitation position, simulating tongue position changing the effective tube length and filtering. Bowed (constant breath-driven). The result is formant-like resonances shifting with LFO2. Not a sampled voice \u2014 pure physics."
+}

--- a/Presets/XOceanus/Organic/Osmosis_Cell_Wall.xometa
+++ b/Presets/XOceanus/Organic/Osmosis_Cell_Wall.xometa
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cell Wall",
+  "mood": "Organic",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.66,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.45,
+    "SPACE": 0.65
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.62,
+    "movement": 0.12,
+    "density": 0.3,
+    "space": 0.7,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.45,
+      "osmo_selectivity": 0.82,
+      "osmo_reactivity": 0.35,
+      "osmo_memory": 0.65,
+      "osmo_filterEnvAmt": 0.32,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.12,
+      "osmo_macroCharacter": 0.656,
+      "osmo_macroMovement": 0.12,
+      "osmo_macroCoupling": 0.45,
+      "osmo_macroSpace": 0.65
+    }
+  },
+  "tags": [
+    "osmosis",
+    "organic",
+    "cell",
+    "biological",
+    "selective",
+    "chemical"
+  ],
+  "description": "Biological cell membrane \u2014 medium permeability, high selectivity (chemically specific), long memory."
+}

--- a/Presets/XOceanus/Organic/Osmosis_Gill_Membrane.xometa
+++ b/Presets/XOceanus/Organic/Osmosis_Gill_Membrane.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Gill Membrane",
+  "mood": "Organic",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.38,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.8,
+    "SPACE": 0.25
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.58,
+    "movement": 0.22,
+    "density": 0.32,
+    "space": 0.62,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.8,
+      "osmo_selectivity": 0.48,
+      "osmo_reactivity": 0.65,
+      "osmo_memory": 0.25,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.06,
+      "osmo_lfo1Depth": 0.28,
+      "osmo_macroCharacter": 0.384,
+      "osmo_macroMovement": 0.28,
+      "osmo_macroCoupling": 0.8,
+      "osmo_macroSpace": 0.25
+    }
+  },
+  "tags": [
+    "osmosis",
+    "organic",
+    "gill",
+    "fish",
+    "oxygen",
+    "permeable",
+    "efficient"
+  ],
+  "description": "Fish gill membrane \u2014 high permeability (must extract oxygen efficiently), medium selectivity."
+}

--- a/Presets/XOceanus/Organic/Osmosis_Lung_Membrane.xometa
+++ b/Presets/XOceanus/Organic/Osmosis_Lung_Membrane.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Lung Membrane",
+  "mood": "Organic",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.32,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.8,
+    "SPACE": 0.08
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.55,
+    "movement": 0.32,
+    "density": 0.3,
+    "space": 0.62,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.8,
+      "osmo_selectivity": 0.4,
+      "osmo_reactivity": 0.9,
+      "osmo_memory": 0.08,
+      "osmo_filterEnvAmt": 0.4,
+      "osmo_lfo1Rate": 0.09,
+      "osmo_lfo1Depth": 0.35,
+      "osmo_macroCharacter": 0.32000000000000006,
+      "osmo_macroMovement": 0.35,
+      "osmo_macroCoupling": 0.8,
+      "osmo_macroSpace": 0.08
+    }
+  },
+  "tags": [
+    "osmosis",
+    "organic",
+    "lung",
+    "alveolar",
+    "fast",
+    "reactive",
+    "breath"
+  ],
+  "description": "Alveolar membrane \u2014 high permeability, fast reactivity, short memory. The lungs respond instantly to breath needs."
+}

--- a/Presets/XOceanus/Organic/Osmosis_Root_Membrane.xometa
+++ b/Presets/XOceanus/Organic/Osmosis_Root_Membrane.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Root Membrane",
+  "mood": "Organic",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.08,
+    "COUPLING": 0.25,
+    "SPACE": 0.72
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.68,
+    "movement": 0.08,
+    "density": 0.22,
+    "space": 0.75,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.25,
+      "osmo_selectivity": 0.88,
+      "osmo_reactivity": 0.22,
+      "osmo_memory": 0.72,
+      "osmo_filterEnvAmt": 0.22,
+      "osmo_lfo1Rate": 0.02,
+      "osmo_lfo1Depth": 0.08,
+      "osmo_macroCharacter": 0.7040000000000001,
+      "osmo_macroMovement": 0.08,
+      "osmo_macroCoupling": 0.25,
+      "osmo_macroSpace": 0.72
+    }
+  },
+  "tags": [
+    "osmosis",
+    "organic",
+    "root",
+    "plant",
+    "ions",
+    "selective",
+    "specific"
+  ],
+  "description": "Plant root membrane \u2014 low permeability, high selectivity. Only specific ions pass."
+}

--- a/Presets/XOceanus/Organic/Osmosis_Skin_Layer.xometa
+++ b/Presets/XOceanus/Organic/Osmosis_Skin_Layer.xometa
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Skin Layer",
+  "mood": "Organic",
+  "engines": [
+    "Osmosis"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.35,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.65,
+    "movement": 0.1,
+    "density": 0.28,
+    "space": 0.7,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Osmosis": {
+      "osmo_permeability": 0.35,
+      "osmo_selectivity": 0.62,
+      "osmo_reactivity": 0.28,
+      "osmo_memory": 0.55,
+      "osmo_filterEnvAmt": 0.28,
+      "osmo_lfo1Rate": 0.03,
+      "osmo_lfo1Depth": 0.1,
+      "osmo_macroCharacter": 0.496,
+      "osmo_macroMovement": 0.1,
+      "osmo_macroCoupling": 0.35,
+      "osmo_macroSpace": 0.55
+    }
+  },
+  "tags": [
+    "osmosis",
+    "organic",
+    "skin",
+    "biological",
+    "slow",
+    "exchange",
+    "body"
+  ],
+  "description": "Biological skin \u2014 medium selectivity, slow reactivity, medium memory. The slow exchange across the body boundary."
+}

--- a/Presets/XOceanus/Organic/Osprey_Wing_Flap_Rhythm.xometa
+++ b/Presets/XOceanus/Organic/Osprey_Wing_Flap_Rhythm.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Wing Flap Rhythm",
+  "mood": "Organic",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Regular wing flap rhythm during level flight. Swell period 0.31 approximates wingbeat. Medium sea state (0.35), natural foam (0.2), organic sympathyAmount (0.5).",
+  "tags": [
+    "organic",
+    "rhythmic",
+    "wingbeat",
+    "natural"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.008,
+      "osprey_ampDecay": 0.25,
+      "osprey_ampSustain": 0.3,
+      "osprey_ampRelease": 0.5,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.5,
+      "osprey_foam": 0.2,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.5,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.65,
+      "osprey_macroSpace": 0.5,
+      "osprey_resonatorBright": 0.4,
+      "osprey_resonatorDecay": 2.0,
+      "osprey_seaState": 0.35,
+      "osprey_shore": 0.4,
+      "osprey_swellPeriod": 0.31,
+      "osprey_sympathyAmount": 0.5,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.48,
+    "movement": 0.65,
+    "density": 0.45,
+    "space": 0.5,
+    "aggression": 0.35
+  },
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.65,
+    "COUPLING": 0.0,
+    "SPACE": 0.5
+  }
+}

--- a/Presets/XOceanus/Organic/Owlfish_Camouflage_Pulse.xometa
+++ b/Presets/XOceanus/Organic/Owlfish_Camouflage_Pulse.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Camouflage Pulse",
+  "mood": "Organic",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Owlfish using chromatophores to blend. Mid-range (filterCutoff 0.5), feeding (0.4) adds organic texture variation. Portamento (0.08) for smooth pitch movement.",
+  "tags": [
+    "organic",
+    "camouflage",
+    "pulsing",
+    "natural"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 75.0,
+      "owl_bodyLevel": 0.5,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.4,
+      "owl_filterCutoff": 0.5,
+      "owl_filterEnvDepth": 0.4,
+      "owl_filterReso": 0.35,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.0,
+      "owl_grainMix": 0.0,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.5,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.08,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.5,
+      "owl_reverbMix": 0.22,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.45,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.8,
+      "owl_subLevel2": 0.6,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 20,
+      "owl_ampDecay": 350,
+      "owl_ampSustain": 0.55,
+      "owl_ampRelease": 900,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.5,
+    "movement": 0.4,
+    "density": 0.5,
+    "space": 0.55,
+    "aggression": 0.28
+  },
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.4,
+    "COUPLING": 0.0,
+    "SPACE": 0.55
+  }
+}

--- a/Presets/XOceanus/Prism/Obiont/Diffraction_Grate.xometa
+++ b/Presets/XOceanus/Prism/Obiont/Diffraction_Grate.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Diffraction Grate",
+  "mood": "Prism",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 169 \u2014 diagonal striping patterns. At 15Hz the stripes become frequency combs. Narrow projection (0.2) keeps the comb tight. Resonant filter (0.65) amplifies each tooth as it passes through the scanning range.",
+  "tags": [
+    "prism",
+    "comb",
+    "spectral",
+    "rule-169",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 169,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 15.0,
+      "obnt_gridDensity": 0.55,
+      "obnt_chaos": 0.12,
+      "obnt_projection": 0.2,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 3200.0,
+      "obnt_filterResonance": 0.65,
+      "obnt_attack": 0.002,
+      "obnt_decay": 0.2,
+      "obnt_sustain": 0.4,
+      "obnt_release": 0.6,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 4.0,
+      "obnt_lfo1Depth": 0.4,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.25,
+    "movement": 0.82,
+    "density": 0.48,
+    "space": 0.4,
+    "aggression": 0.42
+  },
+  "macros": {
+    "CHAOS": 0.24,
+    "EVOLUTION": 0.88,
+    "SPACE": 0.4,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Prism/Obiont/Eigenstate_Bloom.xometa
+++ b/Presets/XOceanus/Prism/Obiont/Eigenstate_Bloom.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Eigenstate Bloom",
+  "mood": "Prism",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 60 \u2014 complement of Rule 90, produces offset Sierpinski. ruleMorph 0.5 sweeps between 60 and 90, creating eigenstate interference \u2014 spectral nodes that appear and disappear. Bright, crystalline, impossible to predict.",
+  "tags": [
+    "prism",
+    "crystalline",
+    "eigenstate",
+    "rule-60",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 60,
+      "obnt_ruleMorph": 0.5,
+      "obnt_evolutionRate": 6.0,
+      "obnt_gridDensity": 0.52,
+      "obnt_chaos": 0.1,
+      "obnt_projection": 0.78,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 6500.0,
+      "obnt_filterResonance": 0.4,
+      "obnt_attack": 0.01,
+      "obnt_decay": 0.5,
+      "obnt_sustain": 0.6,
+      "obnt_release": 1.2,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.8,
+      "obnt_lfo1Depth": 0.3,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.85,
+    "warmth": 0.22,
+    "movement": 0.52,
+    "density": 0.45,
+    "space": 0.6,
+    "aggression": 0.28
+  },
+  "macros": {
+    "CHAOS": 0.2,
+    "EVOLUTION": 0.58,
+    "SPACE": 0.6,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Prism/Obiont/Refraction_Index.xometa
+++ b/Presets/XOceanus/Prism/Obiont/Refraction_Index.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Refraction Index",
+  "mood": "Prism",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 45 \u2014 chaotic rule producing pseudo-random but structured output. High projection (0.9) spreads the pattern across the full pitch range. Filter resonance (0.55) catches the bright cells. Cellular light through an uneven prism.",
+  "tags": [
+    "prism",
+    "glittering",
+    "scatter",
+    "rule-45",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 45,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 8.0,
+      "obnt_gridDensity": 0.48,
+      "obnt_chaos": 0.15,
+      "obnt_projection": 0.9,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 5000.0,
+      "obnt_filterResonance": 0.55,
+      "obnt_attack": 0.003,
+      "obnt_decay": 0.3,
+      "obnt_sustain": 0.5,
+      "obnt_release": 0.8,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 1.2,
+      "obnt_lfo1Depth": 0.35,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.82,
+    "warmth": 0.3,
+    "movement": 0.65,
+    "density": 0.4,
+    "space": 0.55,
+    "aggression": 0.35
+  },
+  "macros": {
+    "CHAOS": 0.3,
+    "EVOLUTION": 0.72,
+    "SPACE": 0.55,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Prism/Obiont/Spectral_Seed.xometa
+++ b/Presets/XOceanus/Prism/Obiont/Spectral_Seed.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Spectral Seed",
+  "mood": "Prism",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 105 \u2014 complement of Rule 150. Mirror-symmetric patterns grow outward from each note's seed. High grid density (0.8) ensures the mirrors always clash, producing complex interference at the center. A chord played here becomes a spectral kaleidoscope.",
+  "tags": [
+    "prism",
+    "mirror",
+    "symmetric",
+    "rule-105",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 105,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 5.5,
+      "obnt_gridDensity": 0.8,
+      "obnt_chaos": 0.08,
+      "obnt_projection": 0.65,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 4800.0,
+      "obnt_filterResonance": 0.42,
+      "obnt_attack": 0.008,
+      "obnt_decay": 0.6,
+      "obnt_sustain": 0.65,
+      "obnt_release": 1.5,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.5,
+      "obnt_lfo1Depth": 0.28,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.78,
+    "warmth": 0.28,
+    "movement": 0.48,
+    "density": 0.72,
+    "space": 0.52,
+    "aggression": 0.25
+  },
+  "macros": {
+    "CHAOS": 0.16,
+    "EVOLUTION": 0.52,
+    "SPACE": 0.52,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Prism/Obscura_Cymbal_Shimmer.xometa
+++ b/Presets/XOceanus/Prism/Obscura_Cymbal_Shimmer.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cymbal Shimmer",
+  "mood": "Prism",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.82,
+    "warmth": 0.28,
+    "movement": 0.12,
+    "density": 0.65,
+    "space": 0.65,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.94,
+      "obscura_damping": 0.1,
+      "obscura_nonlinear": 0.82,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.6,
+      "obscura_scanWidth": 0.2,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.005,
+      "obscura_ampDecay": 0.4,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 7.0,
+      "obscura_physEnvAttack": 0.005,
+      "obscura_physEnvDecay": 0.4,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 7.0,
+      "obscura_lfo1Rate": 0.05,
+      "obscura_lfo1Depth": 0.28,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.5,
+      "obscura_macroMovement": 0.2,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.1,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "cymbal",
+    "metal",
+    "shimmer",
+    "inharmonic",
+    "prism"
+  ],
+  "description": "Metal cymbal \u2014 Periodic boundary (circular metal plate). Maximum stiffness (thick brass). Very high nonlinearity: cymbal inharmonicity is extreme and amplitude-dependent. Very wide excitation (whole cymbal surface struck). LFO1 at 0.05Hz modulates scan width for the characteristic slow shimmer of a decaying cymbal. Narrow scanner for maximum brightness."
+}

--- a/Presets/XOceanus/Prism/Oceanic_Bioluminescent_Break.xometa
+++ b/Presets/XOceanus/Prism/Oceanic_Bioluminescent_Break.xometa
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "name": "Bioluminescent Break",
+  "mood": "Prism",
+  "engines": [
+    "Oceanic"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Breaking wave in a bioluminescent bay \u2014 each foam bubble glows. High scatter (0.72) at waveform 0 creates a sparkling spectral top. Subflocks 3 for color separation. Prism-worthy shimmer.",
+  "tags": [
+    "prism",
+    "bioluminescent",
+    "shimmer",
+    "sparkling"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Oceanic": {
+      "ocean_alignment": 0.45,
+      "ocean_cohesion": 0.5,
+      "ocean_scatter": 0.72,
+      "ocean_separation": 0.45,
+      "ocean_damping": 0.25,
+      "ocean_tether": 0.3,
+      "ocean_subflocks": 3,
+      "ocean_waveform": 0,
+      "ocean_voiceMode": 1,
+      "ocean_glide": 0.0,
+      "ocean_ampAttack": 0.01,
+      "ocean_ampDecay": 0.4,
+      "ocean_ampSustain": 0.45,
+      "ocean_ampRelease": 1.0,
+      "ocean_swarmEnvAttack": 0.015,
+      "ocean_swarmEnvDecay": 0.35,
+      "ocean_swarmEnvSustain": 0.4,
+      "ocean_swarmEnvRelease": 0.8,
+      "ocean_lfo1Rate": 0.8,
+      "ocean_lfo1Depth": 0.5,
+      "ocean_lfo1Shape": 0,
+      "ocean_lfo2Rate": 1.2,
+      "ocean_lfo2Depth": 0.35,
+      "ocean_lfo2Shape": 1,
+      "ocean_macroCharacter": 0.72,
+      "ocean_macroMovement": 0.55,
+      "ocean_macroCoupling": 0.0,
+      "ocean_macroSpace": 0.5
+    }
+  },
+  "dna": {
+    "brightness": 0.82,
+    "warmth": 0.25,
+    "movement": 0.55,
+    "density": 0.55,
+    "space": 0.5,
+    "aggression": 0.38
+  },
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.55,
+    "COUPLING": 0.0,
+    "SPACE": 0.5
+  }
+}

--- a/Presets/XOceanus/Prism/Osprey_Iridescent_Dive.xometa
+++ b/Presets/XOceanus/Prism/Osprey_Iridescent_Dive.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Iridescent Dive",
+  "mood": "Prism",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Water spray catching sunlight on dive entry \u2014 prismatic shimmer. High filterTilt (0.85), high resonatorBright (0.8), fast swell period (3.0). Maximum spectral scatter.",
+  "tags": [
+    "prism",
+    "shimmer",
+    "spray",
+    "bright"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.003,
+      "osprey_ampDecay": 0.3,
+      "osprey_ampSustain": 0.5,
+      "osprey_ampRelease": 0.9,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.5,
+      "osprey_filterTilt": 0.85,
+      "osprey_foam": 0.6,
+      "osprey_fog": 0.2,
+      "osprey_harborVerb": 0.35,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.72,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.65,
+      "osprey_macroSpace": 0.45,
+      "osprey_resonatorBright": 0.8,
+      "osprey_resonatorDecay": 2.0,
+      "osprey_seaState": 0.75,
+      "osprey_shore": 0.6,
+      "osprey_swellPeriod": 3.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.82,
+    "warmth": 0.22,
+    "movement": 0.65,
+    "density": 0.45,
+    "space": 0.45,
+    "aggression": 0.55
+  },
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.65,
+    "COUPLING": 0.0,
+    "SPACE": 0.45
+  }
+}

--- a/Presets/XOceanus/Prism/Overcast_Color_Crystal.xometa
+++ b/Presets/XOceanus/Prism/Overcast_Color_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Color Crystal",
+  "mood": "Prism",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.68,
+    "warmth": 0.35,
+    "movement": 0.06,
+    "density": 0.52,
+    "space": 0.58,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.78,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 7,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.75,
+      "cast_purity": 0.8,
+      "cast_crackle": 1.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.72,
+      "cast_filterCutoff": 1800.0,
+      "cast_filterRes": 0.1,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.79,
+      "cast_ampRelease": 9.0,
+      "cast_lfo1Rate": 0.011,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "prism",
+    "maximum",
+    "colorful",
+    "crackle",
+    "formation"
+  ],
+  "description": "Maximum crackle, high purity, many peaks \u2014 the most colorful crystal formation."
+}

--- a/Presets/XOceanus/Prism/Overcast_Crackle_Prism.xometa
+++ b/Presets/XOceanus/Prism/Overcast_Crackle_Prism.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Crackle Prism",
+  "mood": "Prism",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.4,
+    "movement": 0.05,
+    "density": 0.48,
+    "space": 0.6,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.75,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 7,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.7,
+      "cast_purity": 0.72,
+      "cast_crackle": 1.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 1600.0,
+      "cast_filterRes": 0.1,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.8,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.01,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.005,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "prism",
+    "crackle",
+    "colorful",
+    "fracture",
+    "forming"
+  ],
+  "description": "High crackle, high peak count \u2014 the forming crystal fractures in colorful ways."
+}

--- a/Presets/XOceanus/Prism/Overcast_Frozen_Color.xometa
+++ b/Presets/XOceanus/Prism/Overcast_Frozen_Color.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Frozen Color",
+  "mood": "Prism",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.82,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.62,
+    "warmth": 0.4,
+    "movement": 0.03,
+    "density": 0.48,
+    "space": 0.62,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.48,
+      "cast_numPeaks": 6,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.85,
+      "cast_purity": 0.82,
+      "cast_crackle": 0.3,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 1600.0,
+      "cast_filterRes": 0.09,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.82,
+      "cast_ampRelease": 11.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "prism",
+    "bright",
+    "frozen",
+    "instant",
+    "lattice"
+  ],
+  "description": "Instant transition, many peaks, medium crackle, high lattice. Bright frozen color."
+}

--- a/Presets/XOceanus/Prism/Overcast_Prism_Freeze.xometa
+++ b/Presets/XOceanus/Prism/Overcast_Prism_Freeze.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Prism Freeze",
+  "mood": "Prism",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.85,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.65,
+    "warmth": 0.38,
+    "movement": 0.02,
+    "density": 0.48,
+    "space": 0.62,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.82,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 7,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.8,
+      "cast_purity": 0.85,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 1700.0,
+      "cast_filterRes": 0.09,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.82,
+      "cast_ampRelease": 11.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "prism",
+    "bright",
+    "frozen",
+    "colorful",
+    "instant"
+  ],
+  "description": "High brightness from many peaks, instant transition, high purity. The prism frozen in place."
+}

--- a/Presets/XOceanus/Prism/Overcast_Shatter_Prism.xometa
+++ b/Presets/XOceanus/Prism/Overcast_Shatter_Prism.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Shatter Prism",
+  "mood": "Prism",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.78,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.48
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.62,
+    "warmth": 0.38,
+    "movement": 0.1,
+    "density": 0.45,
+    "space": 0.58,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.78,
+      "cast_crystalSize": 0.48,
+      "cast_numPeaks": 6,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.72,
+      "cast_purity": 0.78,
+      "cast_crackle": 0.7,
+      "cast_shatterGap": 0.05,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 1600.0,
+      "cast_filterRes": 0.09,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.79,
+      "cast_ampRelease": 9.0,
+      "cast_lfo1Rate": 0.012,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.006,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "prism",
+    "shatter",
+    "rapid",
+    "rhythm",
+    "colorful"
+  ],
+  "description": "Short shatter gap (50ms) \u2014 crystals reform very quickly, creating rapid rhythmic crystallization."
+}

--- a/Presets/XOceanus/Prism/Overcast_Spectral_Freeze.xometa
+++ b/Presets/XOceanus/Prism/Overcast_Spectral_Freeze.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Spectral Freeze",
+  "mood": "Prism",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.82,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.32,
+    "movement": 0.02,
+    "density": 0.55,
+    "space": 0.6,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 8,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.92,
+      "cast_purity": 0.82,
+      "cast_crackle": 0.3,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.72,
+      "cast_filterCutoff": 1900.0,
+      "cast_filterRes": 0.1,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.81,
+      "cast_ampRelease": 10.0,
+      "cast_lfo1Rate": 0.009,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "prism",
+    "spectral",
+    "locked",
+    "ordered",
+    "bright"
+  ],
+  "description": "Many peaks at very high lattice \u2014 spectral prism locked and ordered."
+}

--- a/Presets/XOceanus/Prism/Overflow_Color_Under_Pressure.xometa
+++ b/Presets/XOceanus/Prism/Overflow_Color_Under_Pressure.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Color Under Pressure",
+  "mood": "Prism",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.17,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.48,
+    "movement": 0.2,
+    "density": 0.42,
+    "space": 0.55,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.58,
+      "flow_accumRate": 0.5,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.52,
+      "flow_strainColor": 0.8,
+      "flow_releaseTime": 2.0,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1300.0,
+      "flow_filterRes": 0.08,
+      "flow_filtEnvAmount": 0.2,
+      "flow_ampAttack": 1.2,
+      "flow_ampDecay": 1.8,
+      "flow_ampSustain": 0.8,
+      "flow_ampRelease": 7.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.013,
+      "flow_lfo1Depth": 0.17,
+      "flow_lfo2Rate": 0.006,
+      "flow_lfo2Depth": 0.09,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "prism",
+    "color",
+    "prismatic",
+    "timbre",
+    "pressure"
+  ],
+  "description": "Strain color at max, medium threshold \u2014 the timbre becomes prismatic under pressure. Color is the consequence."
+}

--- a/Presets/XOceanus/Prism/Overflow_Pressure_Rainbow.xometa
+++ b/Presets/XOceanus/Prism/Overflow_Pressure_Rainbow.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pressure Rainbow",
+  "mood": "Prism",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.19,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.62,
+    "warmth": 0.4,
+    "movement": 0.22,
+    "density": 0.42,
+    "space": 0.55,
+    "aggression": 0.07
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.55,
+      "flow_valveType": 2,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.7,
+      "flow_releaseTime": 1.2,
+      "flow_whistlePitch": 0.9,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1450.0,
+      "flow_filterRes": 0.09,
+      "flow_filtEnvAmount": 0.22,
+      "flow_ampAttack": 1.0,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.78,
+      "flow_ampRelease": 6.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.015,
+      "flow_lfo1Depth": 0.19,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.1,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "prism",
+    "rainbow",
+    "whistle",
+    "colorful",
+    "event"
+  ],
+  "description": "Whistle valve with high strain \u2014 each release event creates a brief high-frequency rainbow. Colorful consequence."
+}

--- a/Presets/XOceanus/Prism/Overflow_Spectral_Strain.xometa
+++ b/Presets/XOceanus/Prism/Overflow_Spectral_Strain.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Spectral Strain",
+  "mood": "Prism",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.72,
+    "MOVEMENT": 0.18,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.6,
+    "warmth": 0.42,
+    "movement": 0.22,
+    "density": 0.4,
+    "space": 0.55,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.6,
+      "flow_accumRate": 0.55,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.72,
+      "flow_releaseTime": 1.5,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1400.0,
+      "flow_filterRes": 0.09,
+      "flow_filtEnvAmount": 0.22,
+      "flow_ampAttack": 1.0,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.78,
+      "flow_ampRelease": 6.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.014,
+      "flow_lfo1Depth": 0.18,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.09,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "prism",
+    "spectral",
+    "bright",
+    "strain",
+    "brightening"
+  ],
+  "description": "High brightness under strain \u2014 each pressure event opens the filter further. Spectral brightening as the player pushes harder."
+}

--- a/Presets/XOceanus/Prism/Overflow_Valve_Colors.xometa
+++ b/Presets/XOceanus/Prism/Overflow_Valve_Colors.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Valve Colors",
+  "mood": "Prism",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.85,
+    "MOVEMENT": 0.19,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.48,
+    "movement": 0.25,
+    "density": 0.4,
+    "space": 0.55,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.48,
+      "flow_accumRate": 0.65,
+      "flow_valveType": 0,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 0.85,
+      "flow_releaseTime": 1.8,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1250.0,
+      "flow_filterRes": 0.08,
+      "flow_filtEnvAmount": 0.2,
+      "flow_ampAttack": 0.8,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.8,
+      "flow_ampRelease": 6.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.015,
+      "flow_lfo1Depth": 0.19,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.09,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "prism",
+    "valve",
+    "colorful",
+    "events",
+    "defining"
+  ],
+  "description": "Medium threshold, fast accumulation, maximum strain color. The valve events define the color."
+}

--- a/Presets/XOceanus/Prism/Overwash_Prism_Diffusion.xometa
+++ b/Presets/XOceanus/Prism/Overwash_Prism_Diffusion.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Prism Diffusion",
+  "mood": "Prism",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.58,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.5,
+    "SPACE": 0.55
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.58,
+    "warmth": 0.45,
+    "movement": 0.28,
+    "density": 0.45,
+    "space": 0.55,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.22,
+      "wash_viscosity": 0.5,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 12.0,
+      "wash_spreadMax": 130.0,
+      "wash_brightness": 0.58,
+      "wash_warmth": 0.45,
+      "wash_ampAttack": 0.8,
+      "wash_ampDecay": 1.2,
+      "wash_ampSustain": 0.8,
+      "wash_ampRelease": 6.0,
+      "wash_filterCutoff": 1800.0,
+      "wash_filterRes": 0.1,
+      "wash_filtEnvAmount": 0.25,
+      "wash_filtAttack": 0.8,
+      "wash_filtDecay": 1.8,
+      "wash_filtSustain": 0.7,
+      "wash_filtRelease": 4.0,
+      "wash_lfo1Rate": 0.018,
+      "wash_lfo1Depth": 0.24,
+      "wash_lfo2Rate": 0.009,
+      "wash_lfo2Depth": 0.12,
+      "wash_stereoWidth": 0.78,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "prism",
+    "colorful",
+    "bright",
+    "fast",
+    "spectrum"
+  ],
+  "description": "Medium-bright, colorful spectral fan \u2014 eight harmonics at fast diffusion, wide spread. The prism breaks the wash into colors."
+}

--- a/Presets/XOceanus/Prism/Overwash_Refraction_Angle.xometa
+++ b/Presets/XOceanus/Prism/Overwash_Refraction_Angle.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Refraction Angle",
+  "mood": "Prism",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.5,
+    "MOVEMENT": 0.25,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.5,
+    "movement": 0.25,
+    "density": 0.4,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.19,
+      "wash_viscosity": 0.58,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 14.0,
+      "wash_spreadMax": 110.0,
+      "wash_brightness": 0.5,
+      "wash_warmth": 0.5,
+      "wash_ampAttack": 1.2,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.82,
+      "wash_ampRelease": 7.0,
+      "wash_filterCutoff": 1400.0,
+      "wash_filterRes": 0.08,
+      "wash_filtEnvAmount": 0.22,
+      "wash_filtAttack": 1.2,
+      "wash_filtDecay": 2.0,
+      "wash_filtSustain": 0.74,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.02,
+      "wash_lfo1Depth": 0.22,
+      "wash_lfo2Rate": 0.005,
+      "wash_lfo2Depth": 0.16,
+      "wash_stereoWidth": 0.72,
+      "wash_level": 0.75,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "refraction",
+    "asymmetric",
+    "bent",
+    "prism",
+    "LFO"
+  ],
+  "description": "Asymmetric diffusion \u2014 LFO1 and LFO2 at different rates create a bent, refracting character. Light at a glass boundary."
+}

--- a/Presets/XOceanus/Prism/Overwash_Spectral_Split.xometa
+++ b/Presets/XOceanus/Prism/Overwash_Spectral_Split.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Spectral Split",
+  "mood": "Prism",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.5,
+    "SPACE": 0.52
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.7,
+    "warmth": 0.38,
+    "movement": 0.35,
+    "density": 0.55,
+    "space": 0.52,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.28,
+      "wash_viscosity": 0.42,
+      "wash_harmonics": 16,
+      "wash_diffusionTime": 8.0,
+      "wash_spreadMax": 200.0,
+      "wash_brightness": 0.7,
+      "wash_warmth": 0.38,
+      "wash_ampAttack": 0.5,
+      "wash_ampDecay": 1.0,
+      "wash_ampSustain": 0.78,
+      "wash_ampRelease": 5.0,
+      "wash_filterCutoff": 2500.0,
+      "wash_filterRes": 0.12,
+      "wash_filtEnvAmount": 0.3,
+      "wash_filtAttack": 0.5,
+      "wash_filtDecay": 1.5,
+      "wash_filtSustain": 0.68,
+      "wash_filtRelease": 3.5,
+      "wash_lfo1Rate": 0.025,
+      "wash_lfo1Depth": 0.28,
+      "wash_lfo2Rate": 0.012,
+      "wash_lfo2Depth": 0.15,
+      "wash_stereoWidth": 0.85,
+      "wash_level": 0.76,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "spectral",
+    "split",
+    "prism",
+    "maximum",
+    "wide"
+  ],
+  "description": "High harmonics at fast diffusion \u2014 the prism at maximum. 16 harmonics spreading to 200Hz maximum."
+}

--- a/Presets/XOceanus/Prism/Overwash_Warm_Prism.xometa
+++ b/Presets/XOceanus/Prism/Overwash_Warm_Prism.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Warm Prism",
+  "mood": "Prism",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.45,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.5,
+    "SPACE": 0.58
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.58,
+    "movement": 0.22,
+    "density": 0.38,
+    "space": 0.58,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.16,
+      "wash_viscosity": 0.62,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 18.0,
+      "wash_spreadMax": 95.0,
+      "wash_brightness": 0.45,
+      "wash_warmth": 0.58,
+      "wash_ampAttack": 1.5,
+      "wash_ampDecay": 1.5,
+      "wash_ampSustain": 0.83,
+      "wash_ampRelease": 8.0,
+      "wash_filterCutoff": 1200.0,
+      "wash_filterRes": 0.07,
+      "wash_filtEnvAmount": 0.2,
+      "wash_filtAttack": 1.5,
+      "wash_filtDecay": 2.5,
+      "wash_filtSustain": 0.76,
+      "wash_filtRelease": 5.0,
+      "wash_lfo1Rate": 0.014,
+      "wash_lfo1Depth": 0.2,
+      "wash_lfo2Rate": 0.007,
+      "wash_lfo2Depth": 0.1,
+      "wash_stereoWidth": 0.7,
+      "wash_level": 0.75,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "prism",
+    "warm",
+    "medium",
+    "colorful",
+    "balanced"
+  ],
+  "description": "Prism character but warm \u2014 medium harmonics, medium diffusion, raised warmth. Color without coldness."
+}

--- a/Presets/XOceanus/Prism/Owlfish_Iridescent_Fin.xometa
+++ b/Presets/XOceanus/Prism/Owlfish_Iridescent_Fin.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Iridescent Fin",
+  "mood": "Prism",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Iridescent fin catching light. High filter (0.82), grain mix (0.5) for spectral shimmer. MorphGlide 0.45 smears harmonics across sub-divisions. Prismatic.",
+  "tags": [
+    "prism",
+    "iridescent",
+    "shimmer",
+    "bright"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 100.0,
+      "owl_bodyLevel": 0.4,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.82,
+      "owl_filterEnvDepth": 0.4,
+      "owl_filterReso": 0.42,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.55,
+      "owl_grainMix": 0.5,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.45,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.45,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.4,
+      "owl_reverbDamp": 0.5,
+      "owl_reverbMix": 0.3,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.5,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.8,
+      "owl_subLevel2": 0.6,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 8,
+      "owl_ampDecay": 280,
+      "owl_ampSustain": 0.6,
+      "owl_ampRelease": 700,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.82,
+    "warmth": 0.25,
+    "movement": 0.6,
+    "density": 0.42,
+    "space": 0.5,
+    "aggression": 0.32
+  },
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.6,
+    "COUPLING": 0.0,
+    "SPACE": 0.5
+  }
+}

--- a/Presets/XOceanus/Shadow/Obiont/Cellular_Hunger.xometa
+++ b/Presets/XOceanus/Shadow/Obiont/Cellular_Hunger.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Cellular Hunger",
+  "mood": "Shadow",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 73 \u2014 sustained local memory that slowly consumes neighbors. 2D mode brings spatial hunger patterns. Resonant filter (0.72) at 1400Hz gives each consumed cell a metallic click-hiss.",
+  "tags": [
+    "shadow",
+    "hungry",
+    "consuming",
+    "rule-73",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 1,
+      "obnt_rule": 73,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 7.0,
+      "obnt_gridDensity": 0.6,
+      "obnt_chaos": 0.12,
+      "obnt_projection": 0.55,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 1400.0,
+      "obnt_filterResonance": 0.72,
+      "obnt_attack": 0.005,
+      "obnt_decay": 0.55,
+      "obnt_sustain": 0.4,
+      "obnt_release": 1.2,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.6,
+      "obnt_lfo1Depth": 0.22,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.3,
+    "movement": 0.55,
+    "density": 0.65,
+    "space": 0.5,
+    "aggression": 0.65
+  },
+  "macros": {
+    "CHAOS": 0.24,
+    "EVOLUTION": 0.52,
+    "SPACE": 0.5,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Shadow/Obiont/Necrosis_Pattern.xometa
+++ b/Presets/XOceanus/Shadow/Obiont/Necrosis_Pattern.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Necrosis Pattern",
+  "mood": "Shadow",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 18 \u2014 the dying edge rule. Active cells collapse inward every generation. Long release (2.4s) lets the decay hiss out. Filter closed (800Hz) with high resonance creates a sub-cave tone. Chaos 0.04 \u2014 near-silent entropy, a pattern that murders itself slowly.",
+  "tags": [
+    "shadow",
+    "dark",
+    "decay",
+    "rule-18",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 18,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 1.2,
+      "obnt_gridDensity": 0.38,
+      "obnt_chaos": 0.04,
+      "obnt_projection": 0.3,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 800.0,
+      "obnt_filterResonance": 0.62,
+      "obnt_attack": 0.08,
+      "obnt_decay": 1.2,
+      "obnt_sustain": 0.3,
+      "obnt_release": 2.4,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.08,
+      "obnt_lfo1Depth": 0.18,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.18,
+    "warmth": 0.35,
+    "movement": 0.22,
+    "density": 0.55,
+    "space": 0.65,
+    "aggression": 0.28
+  },
+  "macros": {
+    "CHAOS": 0.08,
+    "EVOLUTION": 0.24,
+    "SPACE": 0.65,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Shadow/Obiont/Plague_Spreads.xometa
+++ b/Presets/XOceanus/Shadow/Obiont/Plague_Spreads.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Plague Spreads",
+  "mood": "Shadow",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 254 \u2014 all cells alive, maximum density. Chaos injection (0.3) pokes holes in the fabric, creating slow crackle. Filter sweeping low (600Hz) with envelope makes each note feel like a wound opening and closing.",
+  "tags": [
+    "shadow",
+    "dense",
+    "static",
+    "rule-254",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 254,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 2.8,
+      "obnt_gridDensity": 0.95,
+      "obnt_chaos": 0.3,
+      "obnt_projection": 0.6,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 600.0,
+      "obnt_filterResonance": 0.55,
+      "obnt_attack": 0.15,
+      "obnt_decay": 0.8,
+      "obnt_sustain": 0.7,
+      "obnt_release": 1.8,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.12,
+      "obnt_lfo1Depth": 0.3,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.65,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.55,
+    "movement": 0.3,
+    "density": 0.88,
+    "space": 0.45,
+    "aggression": 0.6
+  },
+  "macros": {
+    "CHAOS": 0.6,
+    "EVOLUTION": 0.35,
+    "SPACE": 0.45,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Shadow/Obiont/Rot_Cascade.xometa
+++ b/Presets/XOceanus/Shadow/Obiont/Rot_Cascade.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Rot Cascade",
+  "mood": "Shadow",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 6 \u2014 asymmetric dying. Cells decay rightward like a domino of rot. Fast evolution (12Hz) at low density (0.25) spreads the decay horizontally. Narrow projection (0.15) catches only the dying edge's bright transients.",
+  "tags": [
+    "shadow",
+    "rhythmic",
+    "decay",
+    "rule-6",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 6,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 12.0,
+      "obnt_gridDensity": 0.25,
+      "obnt_chaos": 0.07,
+      "obnt_projection": 0.15,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 2200.0,
+      "obnt_filterResonance": 0.45,
+      "obnt_attack": 0.004,
+      "obnt_decay": 0.22,
+      "obnt_sustain": 0.0,
+      "obnt_release": 0.35,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 3.5,
+      "obnt_lfo1Depth": 0.25,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.2,
+    "movement": 0.78,
+    "density": 0.3,
+    "space": 0.35,
+    "aggression": 0.55
+  },
+  "macros": {
+    "CHAOS": 0.14,
+    "EVOLUTION": 0.85,
+    "SPACE": 0.35,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Shadow/Obiont/Void_Walker.xometa
+++ b/Presets/XOceanus/Shadow/Obiont/Void_Walker.xometa
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "Void Walker",
+  "mood": "Shadow",
+  "engines": [
+    "Obiont"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "pre_seance",
+  "created": "2026-05-09",
+  "description": "Rule 0 \u2014 null rule, all cells die immediately. At high grid density and moderate chaos, noise injection keeps feeding the void. A single held note produces stuttering silence \u2014 flickering existence at the edge of Rule 0's entropy wall.",
+  "tags": [
+    "shadow",
+    "minimalist",
+    "entropy",
+    "rule-0",
+    "pre_seance"
+  ],
+  "pre_seance": true,
+  "macroLabels": [
+    "CHAOS",
+    "EVOLUTION",
+    "SPACE",
+    "COUPLING"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "parameters": {
+    "Obiont": {
+      "obnt_mode": 0,
+      "obnt_rule": 0,
+      "obnt_ruleMorph": 0.0,
+      "obnt_evolutionRate": 22.0,
+      "obnt_gridDensity": 0.72,
+      "obnt_chaos": 0.35,
+      "obnt_projection": 0.45,
+      "obnt_pitchMode": 0,
+      "obnt_filterCutoff": 1800.0,
+      "obnt_filterResonance": 0.5,
+      "obnt_attack": 0.0,
+      "obnt_decay": 0.08,
+      "obnt_sustain": 0.0,
+      "obnt_release": 0.15,
+      "obnt_velSens": 0.7,
+      "obnt_lfo1Rate": 0.3,
+      "obnt_lfo1Depth": 0.4,
+      "obnt_modSrc1": 0,
+      "obnt_modDst1": 4,
+      "obnt_modAmt1": 0.5,
+      "obnt_modSrc2": 2,
+      "obnt_modDst2": 0,
+      "obnt_modAmt2": 0.3,
+      "obnt_modSrc3": 3,
+      "obnt_modDst3": 5,
+      "obnt_modAmt3": 0.2,
+      "obnt_modSrc4": 1,
+      "obnt_modDst4": 1,
+      "obnt_modAmt4": 0.15,
+      "obnt_macroChaos": 0.3,
+      "obnt_macroEvolution": 0.5,
+      "obnt_macroSpace": 0.4,
+      "obnt_macroCoupling": 0.0
+    }
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.15,
+    "movement": 0.62,
+    "density": 0.28,
+    "space": 0.72,
+    "aggression": 0.48
+  },
+  "macros": {
+    "CHAOS": 0.7,
+    "EVOLUTION": 0.95,
+    "SPACE": 0.72,
+    "COUPLING": 0.0
+  }
+}

--- a/Presets/XOceanus/Shadow/Obscura_Gong_Strike.xometa
+++ b/Presets/XOceanus/Shadow/Obscura_Gong_Strike.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Gong Strike",
+  "mood": "Shadow",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.4,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.0,
+    "SPACE": 0.1
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.72,
+    "warmth": 0.42,
+    "movement": 0.12,
+    "density": 0.62,
+    "space": 0.68,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.92,
+      "obscura_damping": 0.12,
+      "obscura_nonlinear": 0.68,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.4,
+      "obscura_scanWidth": 0.35,
+      "obscura_boundary": 2,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.01,
+      "obscura_ampDecay": 0.6,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 8.0,
+      "obscura_physEnvAttack": 0.01,
+      "obscura_physEnvDecay": 0.6,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 8.0,
+      "obscura_lfo1Rate": 0.0,
+      "obscura_lfo1Depth": 0.0,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 3,
+      "obscura_macroCharacter": 0.4,
+      "obscura_macroMovement": 0.0,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.1,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "gong",
+    "bronze",
+    "circular",
+    "bloom",
+    "metal"
+  ],
+  "description": "Chinese gong \u2014 Periodic boundary (circular plate with free edge, wrapped as ring). Very high stiffness from thick bronze. High nonlinearity produces the characteristic upward pitch-sweep after strike: as the plate vibrates, large displacement increases effective stiffness, raising the pitch gradually. Wide excitation width (mallet surface area). This is the physics of the gong's 'bloom'."
+}

--- a/Presets/XOceanus/Shadow/Osprey_Night_Patrol.xometa
+++ b/Presets/XOceanus/Shadow/Osprey_Night_Patrol.xometa
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Night Patrol",
+  "mood": "Shadow",
+  "engines": [
+    "Osprey"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Nocturnal patrol along dark water. Low filterTilt (0.3), medium sea state (0.4), high fog (0.5) for night atmosphere. Patient long release.",
+  "tags": [
+    "shadow",
+    "nocturnal",
+    "patrol",
+    "dark"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Osprey": {
+      "osprey_ampAttack": 0.05,
+      "osprey_ampDecay": 0.8,
+      "osprey_ampSustain": 0.5,
+      "osprey_ampRelease": 2.0,
+      "osprey_brine": 0.1,
+      "osprey_coherence": 0.5,
+      "osprey_depth": 0.4,
+      "osprey_filterTilt": 0.3,
+      "osprey_foam": 0.15,
+      "osprey_fog": 0.5,
+      "osprey_harborVerb": 0.4,
+      "osprey_hull": 0.4,
+      "osprey_macroCharacter": 0.6,
+      "osprey_macroCoupling": 0.0,
+      "osprey_macroMovement": 0.3,
+      "osprey_macroSpace": 0.65,
+      "osprey_resonatorBright": 0.4,
+      "osprey_resonatorDecay": 2.5,
+      "osprey_seaState": 0.4,
+      "osprey_shore": 0.5,
+      "osprey_swellPeriod": 8.0,
+      "osprey_sympathyAmount": 0.35,
+      "osprey_windDir": 0.3
+    }
+  },
+  "dna": {
+    "brightness": 0.3,
+    "warmth": 0.4,
+    "movement": 0.32,
+    "density": 0.5,
+    "space": 0.65,
+    "aggression": 0.45
+  },
+  "macros": {
+    "CHARACTER": 0.6,
+    "MOVEMENT": 0.3,
+    "COUPLING": 0.0,
+    "SPACE": 0.65
+  }
+}

--- a/Presets/XOceanus/Shadow/Overcast_Black_Ice.xometa
+++ b/Presets/XOceanus/Shadow/Overcast_Black_Ice.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Black Ice",
+  "mood": "Shadow",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.95,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.4
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.12,
+    "warmth": 0.4,
+    "movement": 0.02,
+    "density": 0.12,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.88,
+      "cast_crystalSize": 0.4,
+      "cast_numPeaks": 2,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.9,
+      "cast_purity": 0.95,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.68,
+      "cast_filterCutoff": 400.0,
+      "cast_filterRes": 0.04,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.86,
+      "cast_ampRelease": 13.0,
+      "cast_lfo1Rate": 0.006,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "shadow",
+    "black",
+    "dark",
+    "transparent",
+    "treacherous"
+  ],
+  "description": "Minimum brightness from 2 peaks, high lattice. The frozen darkness \u2014 transparent, treacherous."
+}

--- a/Presets/XOceanus/Shadow/Overcast_Dark_Ice_Field.xometa
+++ b/Presets/XOceanus/Shadow/Overcast_Dark_Ice_Field.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Dark Ice Field",
+  "mood": "Shadow",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.9,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.42,
+    "movement": 0.03,
+    "density": 0.15,
+    "space": 0.82,
+    "aggression": 0.01
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.85,
+      "cast_crystalSize": 0.45,
+      "cast_numPeaks": 2,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.85,
+      "cast_purity": 0.9,
+      "cast_crackle": 0.5,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 320.0,
+      "cast_filterRes": 0.03,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.86,
+      "cast_ampRelease": 14.0,
+      "cast_lfo1Rate": 0.005,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.002,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "shadow",
+    "dark",
+    "field",
+    "expanse",
+    "crackle"
+  ],
+  "description": "Very few peaks, minimum brightness, crackle. Dark crystalline expanse with formation noise."
+}

--- a/Presets/XOceanus/Shadow/Overcast_Impure_Dark.xometa
+++ b/Presets/XOceanus/Shadow/Overcast_Impure_Dark.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Impure Dark",
+  "mood": "Shadow",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.15,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.1,
+    "warmth": 0.38,
+    "movement": 0.06,
+    "density": 0.18,
+    "space": 0.78,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.78,
+      "cast_crystalSize": 0.5,
+      "cast_numPeaks": 3,
+      "cast_transition": 1,
+      "cast_latticeSnap": 0.4,
+      "cast_purity": 0.15,
+      "cast_crackle": 1.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.68,
+      "cast_filterCutoff": 380.0,
+      "cast_filterRes": 0.04,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.83,
+      "cast_ampRelease": 12.0,
+      "cast_lfo1Rate": 0.008,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.004,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "shadow",
+    "impure",
+    "dirty",
+    "noisy",
+    "dark"
+  ],
+  "description": "Low purity, low brightness, maximum crackle \u2014 a dark dirty crystal with noisy formation."
+}

--- a/Presets/XOceanus/Shadow/Overcast_Permafrost.xometa
+++ b/Presets/XOceanus/Shadow/Overcast_Permafrost.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Permafrost",
+  "mood": "Shadow",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.95,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.42
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.42,
+    "movement": 0.02,
+    "density": 0.12,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 1.0,
+      "cast_crystalSize": 0.42,
+      "cast_numPeaks": 2,
+      "cast_transition": 0,
+      "cast_latticeSnap": 0.88,
+      "cast_purity": 0.95,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.72,
+      "cast_filterCutoff": 280.0,
+      "cast_filterRes": 0.02,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.87,
+      "cast_ampRelease": 16.0,
+      "cast_lfo1Rate": 0.004,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.002,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "shadow",
+    "permanent",
+    "frozen",
+    "dark",
+    "minimal"
+  ],
+  "description": "Maximum freeze rate, dark tone, minimal peaks. Permanently frozen \u2014 the crystal never thaws."
+}

--- a/Presets/XOceanus/Shadow/Overcast_Shatter_Dark.xometa
+++ b/Presets/XOceanus/Shadow/Overcast_Shatter_Dark.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Shatter Dark",
+  "mood": "Shadow",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.85,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.08,
+    "warmth": 0.4,
+    "movement": 0.08,
+    "density": 0.14,
+    "space": 0.8,
+    "aggression": 0.02
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.82,
+      "cast_crystalSize": 0.45,
+      "cast_numPeaks": 2,
+      "cast_transition": 2,
+      "cast_latticeSnap": 0.78,
+      "cast_purity": 0.85,
+      "cast_crackle": 0.6,
+      "cast_shatterGap": 0.2,
+      "cast_stereoWidth": 0.7,
+      "cast_filterCutoff": 300.0,
+      "cast_filterRes": 0.03,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.83,
+      "cast_ampRelease": 13.0,
+      "cast_lfo1Rate": 0.007,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.003,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "shadow",
+    "shatter",
+    "long",
+    "dark",
+    "reform"
+  ],
+  "description": "Long shatter gap (200ms) with dark peaks \u2014 crystals reform slowly from darkness."
+}

--- a/Presets/XOceanus/Shadow/Overcast_Void_Crystal.xometa
+++ b/Presets/XOceanus/Shadow/Overcast_Void_Crystal.xometa
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Void Crystal",
+  "mood": "Shadow",
+  "engines": [
+    "Overcast"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.98,
+    "MOVEMENT": 0.0,
+    "COUPLING": 0.5,
+    "SPACE": 0.38
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.05,
+    "warmth": 0.35,
+    "movement": 0.02,
+    "density": 0.1,
+    "space": 0.88,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overcast": {
+      "cast_freezeRate": 0.92,
+      "cast_crystalSize": 0.38,
+      "cast_numPeaks": 2,
+      "cast_transition": 0,
+      "cast_latticeSnap": 1.0,
+      "cast_purity": 0.98,
+      "cast_crackle": 0.0,
+      "cast_shatterGap": 0.0,
+      "cast_stereoWidth": 0.72,
+      "cast_filterCutoff": 250.0,
+      "cast_filterRes": 0.02,
+      "cast_ampAttack": 0.01,
+      "cast_ampDecay": 0.5,
+      "cast_ampSustain": 0.87,
+      "cast_ampRelease": 15.0,
+      "cast_lfo1Rate": 0.004,
+      "cast_lfo1Depth": 0.0,
+      "cast_lfo2Rate": 0.002,
+      "cast_lfo2Depth": 0.0,
+      "cast_level": 0.75,
+      "cast_macroCharacter": 0.0,
+      "cast_macroMovement": 0.0,
+      "cast_macroCoupling": 0.5,
+      "cast_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overcast",
+    "pad",
+    "shadow",
+    "void",
+    "silent",
+    "geometry",
+    "minimal"
+  ],
+  "description": "Near-zero brightness, instant transition, maximum lattice. The crystal exists but barely emits. Silent geometry."
+}

--- a/Presets/XOceanus/Shadow/Overflow_Detonation_Mode.xometa
+++ b/Presets/XOceanus/Shadow/Overflow_Detonation_Mode.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Detonation Mode",
+  "mood": "Shadow",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.55,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.5,
+    "SPACE": 0.45
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.45,
+    "warmth": 0.42,
+    "movement": 0.35,
+    "density": 0.52,
+    "space": 0.48,
+    "aggression": 0.15
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.42,
+      "flow_accumRate": 1.0,
+      "flow_valveType": 1,
+      "flow_vesselSize": 0.45,
+      "flow_strainColor": 0.55,
+      "flow_releaseTime": 0.2,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1300.0,
+      "flow_filterRes": 0.09,
+      "flow_filtEnvAmount": 0.22,
+      "flow_ampAttack": 0.3,
+      "flow_ampDecay": 1.2,
+      "flow_ampSustain": 0.72,
+      "flow_ampRelease": 4.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.022,
+      "flow_lfo1Depth": 0.28,
+      "flow_lfo2Rate": 0.011,
+      "flow_lfo2Depth": 0.14,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "shadow",
+    "detonation",
+    "explosive",
+    "maximum",
+    "frequent"
+  ],
+  "description": "Maximum explosive valve, maximum accumulation, medium threshold. Detonation on every few notes."
+}

--- a/Presets/XOceanus/Shadow/Overflow_Maximum_Strain.xometa
+++ b/Presets/XOceanus/Shadow/Overflow_Maximum_Strain.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Maximum Strain",
+  "mood": "Shadow",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 1.0,
+    "MOVEMENT": 0.2,
+    "COUPLING": 0.5,
+    "SPACE": 0.5
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.52,
+    "warmth": 0.38,
+    "movement": 0.22,
+    "density": 0.55,
+    "space": 0.52,
+    "aggression": 0.12
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.55,
+      "flow_accumRate": 0.6,
+      "flow_valveType": 1,
+      "flow_vesselSize": 0.5,
+      "flow_strainColor": 1.0,
+      "flow_releaseTime": 0.4,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1400.0,
+      "flow_filterRes": 0.1,
+      "flow_filtEnvAmount": 0.25,
+      "flow_ampAttack": 0.8,
+      "flow_ampDecay": 1.5,
+      "flow_ampSustain": 0.75,
+      "flow_ampRelease": 5.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.015,
+      "flow_lfo1Depth": 0.2,
+      "flow_lfo2Rate": 0.007,
+      "flow_lfo2Depth": 0.1,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "shadow",
+    "maximum",
+    "strain",
+    "rewritten",
+    "extreme"
+  ],
+  "description": "Maximum strain color \u2014 the pad's timbre is completely rewritten by accumulated pressure. A different instrument under strain."
+}

--- a/Presets/XOceanus/Shadow/Overflow_Overload.xometa
+++ b/Presets/XOceanus/Shadow/Overflow_Overload.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Overload",
+  "mood": "Shadow",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.7,
+    "MOVEMENT": 0.3,
+    "COUPLING": 0.5,
+    "SPACE": 0.4
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.48,
+    "warmth": 0.4,
+    "movement": 0.4,
+    "density": 0.58,
+    "space": 0.45,
+    "aggression": 0.18
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.15,
+      "flow_accumRate": 1.0,
+      "flow_valveType": 1,
+      "flow_vesselSize": 0.4,
+      "flow_strainColor": 0.7,
+      "flow_releaseTime": 0.1,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1500.0,
+      "flow_filterRes": 0.12,
+      "flow_filtEnvAmount": 0.28,
+      "flow_ampAttack": 0.2,
+      "flow_ampDecay": 1.0,
+      "flow_ampSustain": 0.68,
+      "flow_ampRelease": 3.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.025,
+      "flow_lfo1Depth": 0.3,
+      "flow_lfo2Rate": 0.012,
+      "flow_lfo2Depth": 0.15,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "shadow",
+    "overload",
+    "limit",
+    "extreme",
+    "maximum"
+  ],
+  "description": "Everything at maximum \u2014 near-zero threshold, max accumulation, explosive. The system at its limit."
+}

--- a/Presets/XOceanus/Shadow/Overflow_Point_of_Failure.xometa
+++ b/Presets/XOceanus/Shadow/Overflow_Point_of_Failure.xometa
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Point of Failure",
+  "mood": "Shadow",
+  "engines": [
+    "Overflow"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.88,
+    "MOVEMENT": 0.26,
+    "COUPLING": 0.5,
+    "SPACE": 0.42
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.5,
+    "warmth": 0.35,
+    "movement": 0.32,
+    "density": 0.55,
+    "space": 0.48,
+    "aggression": 0.15
+  },
+  "parameters": {
+    "Overflow": {
+      "flow_threshold": 0.35,
+      "flow_accumRate": 0.88,
+      "flow_valveType": 1,
+      "flow_vesselSize": 0.42,
+      "flow_strainColor": 0.88,
+      "flow_releaseTime": 0.3,
+      "flow_whistlePitch": 0.5,
+      "flow_stereoWidth": 0.6,
+      "flow_filterCutoff": 1350.0,
+      "flow_filterRes": 0.1,
+      "flow_filtEnvAmount": 0.24,
+      "flow_ampAttack": 0.5,
+      "flow_ampDecay": 1.2,
+      "flow_ampSustain": 0.72,
+      "flow_ampRelease": 4.0,
+      "flow_filtAttack": 1.5,
+      "flow_filtDecay": 2.5,
+      "flow_filtSustain": 0.78,
+      "flow_filtRelease": 6.0,
+      "flow_lfo1Rate": 0.02,
+      "flow_lfo1Depth": 0.26,
+      "flow_lfo2Rate": 0.01,
+      "flow_lfo2Depth": 0.13,
+      "flow_level": 0.75,
+      "flow_macroCharacter": 0.0,
+      "flow_macroMovement": 0.0,
+      "flow_macroCoupling": 0.5,
+      "flow_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overflow",
+    "pad",
+    "shadow",
+    "failure",
+    "structural",
+    "limit",
+    "extreme"
+  ],
+  "description": "Just below catastrophic \u2014 very high strain, fast accumulation, explosive valve. The instrument at its structural limit."
+}

--- a/Presets/XOceanus/Shadow/Overwash_Dark_Diffusion.xometa
+++ b/Presets/XOceanus/Shadow/Overwash_Dark_Diffusion.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Dark Diffusion",
+  "mood": "Shadow",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.03,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.5,
+    "SPACE": 0.88
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.03,
+    "warmth": 0.85,
+    "movement": 0.04,
+    "density": 0.12,
+    "space": 0.88,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.04,
+      "wash_viscosity": 0.97,
+      "wash_harmonics": 2,
+      "wash_diffusionTime": 80.0,
+      "wash_spreadMax": 25.0,
+      "wash_brightness": 0.03,
+      "wash_warmth": 0.85,
+      "wash_ampAttack": 8.0,
+      "wash_ampDecay": 5.0,
+      "wash_ampSustain": 0.96,
+      "wash_ampRelease": 28.0,
+      "wash_filterCutoff": 280.0,
+      "wash_filterRes": 0.02,
+      "wash_filtEnvAmount": 0.03,
+      "wash_filtAttack": 7.0,
+      "wash_filtDecay": 7.0,
+      "wash_filtSustain": 0.96,
+      "wash_filtRelease": 18.0,
+      "wash_lfo1Rate": 0.002,
+      "wash_lfo1Depth": 0.03,
+      "wash_lfo2Rate": 0.001,
+      "wash_lfo2Depth": 0.01,
+      "wash_stereoWidth": 0.38,
+      "wash_level": 0.66,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "shadow",
+    "dark",
+    "minimal",
+    "warm",
+    "tight"
+  ],
+  "description": "Nearly-zero brightness, maximum warmth, tight spread. The dark end of diffusion \u2014 just the fundamental spreading slowly."
+}

--- a/Presets/XOceanus/Shadow/Overwash_Void_Wash.xometa
+++ b/Presets/XOceanus/Shadow/Overwash_Void_Wash.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Void Wash",
+  "mood": "Shadow",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.01,
+    "MOVEMENT": 0.01,
+    "COUPLING": 0.5,
+    "SPACE": 0.92
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.01,
+    "warmth": 0.8,
+    "movement": 0.01,
+    "density": 0.1,
+    "space": 0.92,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.02,
+      "wash_viscosity": 0.99,
+      "wash_harmonics": 2,
+      "wash_diffusionTime": 100.0,
+      "wash_spreadMax": 15.0,
+      "wash_brightness": 0.01,
+      "wash_warmth": 0.8,
+      "wash_ampAttack": 10.0,
+      "wash_ampDecay": 5.0,
+      "wash_ampSustain": 0.97,
+      "wash_ampRelease": 30.0,
+      "wash_filterCutoff": 220.0,
+      "wash_filterRes": 0.02,
+      "wash_filtEnvAmount": 0.02,
+      "wash_filtAttack": 8.0,
+      "wash_filtDecay": 8.0,
+      "wash_filtSustain": 0.97,
+      "wash_filtRelease": 20.0,
+      "wash_lfo1Rate": 0.001,
+      "wash_lfo1Depth": 0.01,
+      "wash_lfo2Rate": 0.001,
+      "wash_lfo2Depth": 0.01,
+      "wash_stereoWidth": 0.35,
+      "wash_level": 0.62,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "shadow",
+    "void",
+    "still",
+    "withdrawn",
+    "minimal"
+  ],
+  "description": "Zero brightness, zero LFO depth \u2014 almost no movement. The wash at its most withdrawn. Stillness as identity."
+}

--- a/Presets/XOceanus/Shadow/Overworn_Caramel_Dark.xometa
+++ b/Presets/XOceanus/Shadow/Overworn_Caramel_Dark.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Caramel Dark",
+  "mood": "Shadow",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.75,
+    "MOVEMENT": 0.05,
+    "COUPLING": 0.5,
+    "SPACE": 0.65
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.03,
+    "warmth": 0.72,
+    "movement": 0.07,
+    "density": 0.7,
+    "space": 0.78,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.1,
+      "worn_heat": 0.72,
+      "worn_richness": 0.75,
+      "worn_maillard": 0.88,
+      "worn_umamiDepth": 0.65,
+      "worn_concentrate": 0.6,
+      "worn_sessionTarget": 25.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 280.0,
+      "worn_filterRes": 0.03,
+      "worn_filtEnvAmount": 0.06,
+      "worn_ampAttack": 5.0,
+      "worn_ampDecay": 4.5,
+      "worn_ampSustain": 0.95,
+      "worn_ampRelease": 19.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.004,
+      "worn_lfo1Depth": 0.05,
+      "worn_lfo2Rate": 0.002,
+      "worn_lfo2Depth": 0.02,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "shadow",
+    "caramel",
+    "dark",
+    "bitter",
+    "transformed"
+  ],
+  "description": "Caramelized sugar gone dark \u2014 all the richness transformed to bitterness. High maillard, medium heat, medium reduction rate."
+}

--- a/Presets/XOceanus/Shadow/Overworn_Charred_Reduction.xometa
+++ b/Presets/XOceanus/Shadow/Overworn_Charred_Reduction.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Charred Reduction",
+  "mood": "Shadow",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.8,
+    "MOVEMENT": 0.04,
+    "COUPLING": 0.5,
+    "SPACE": 0.75
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.02,
+    "warmth": 0.8,
+    "movement": 0.06,
+    "density": 0.82,
+    "space": 0.8,
+    "aggression": 0.05
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.08,
+      "worn_heat": 0.85,
+      "worn_richness": 0.8,
+      "worn_maillard": 0.95,
+      "worn_umamiDepth": 0.75,
+      "worn_concentrate": 0.72,
+      "worn_sessionTarget": 30.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 250.0,
+      "worn_filterRes": 0.03,
+      "worn_filtEnvAmount": 0.05,
+      "worn_ampAttack": 6.0,
+      "worn_ampDecay": 5.5,
+      "worn_ampSustain": 0.96,
+      "worn_ampRelease": 22.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.003,
+      "worn_lfo1Depth": 0.04,
+      "worn_lfo2Rate": 0.001,
+      "worn_lfo2Depth": 0.02,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "shadow",
+    "charred",
+    "maximum",
+    "dark",
+    "burnt"
+  ],
+  "description": "Beyond maximum reduction \u2014 charred at the bottom of the pot. Maximum maillard, very high heat, near-zero brightness."
+}

--- a/Presets/XOceanus/Shadow/Overworn_Scorched_Pot.xometa
+++ b/Presets/XOceanus/Shadow/Overworn_Scorched_Pot.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Scorched Pot",
+  "mood": "Shadow",
+  "engines": [
+    "Overworn"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.85,
+    "MOVEMENT": 0.03,
+    "COUPLING": 0.5,
+    "SPACE": 0.8
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.01,
+    "warmth": 0.75,
+    "movement": 0.04,
+    "density": 0.9,
+    "space": 0.85,
+    "aggression": 0.06
+  },
+  "parameters": {
+    "Overworn": {
+      "worn_reductionRate": 0.07,
+      "worn_heat": 0.9,
+      "worn_richness": 0.85,
+      "worn_maillard": 1.0,
+      "worn_umamiDepth": 0.8,
+      "worn_concentrate": 0.78,
+      "worn_sessionTarget": 28.0,
+      "worn_sessionAge": 0.0,
+      "worn_stateReset": 0.0,
+      "worn_stereoWidth": 0.65,
+      "worn_filterCutoff": 200.0,
+      "worn_filterRes": 0.02,
+      "worn_filtEnvAmount": 0.04,
+      "worn_ampAttack": 8.0,
+      "worn_ampDecay": 6.0,
+      "worn_ampSustain": 0.97,
+      "worn_ampRelease": 25.0,
+      "worn_filtAttack": 2.0,
+      "worn_filtDecay": 3.0,
+      "worn_filtSustain": 0.8,
+      "worn_filtRelease": 8.0,
+      "worn_lfo1Rate": 0.002,
+      "worn_lfo1Depth": 0.03,
+      "worn_lfo2Rate": 0.001,
+      "worn_lfo2Depth": 0.01,
+      "worn_macroCharacter": 0.0,
+      "worn_macroMovement": 0.0,
+      "worn_macroCoupling": 0.5,
+      "worn_macroSpace": 0.0,
+      "worn_level": 0.75
+    }
+  },
+  "tags": [
+    "overworn",
+    "pad",
+    "shadow",
+    "scorched",
+    "extreme",
+    "burnt",
+    "dark"
+  ],
+  "description": "The pot that has burned \u2014 extreme maillard, maximum concentrate, dark essence only. The cook who forgot."
+}

--- a/Presets/XOceanus/Shadow/Owlfish_Dark_Hover.xometa
+++ b/Presets/XOceanus/Shadow/Owlfish_Dark_Hover.xometa
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "name": "Dark Hover",
+  "mood": "Shadow",
+  "engines": [
+    "Owlfish"
+  ],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "tier": "awakening",
+  "created": "2026-05-09",
+  "description": "Hovering in shadow, barely visible. Mid-filter (0.38) with resonance (0.58), pressure (0.6) adds subtle harmonic snarl. Long release, mid reverb.",
+  "tags": [
+    "shadow",
+    "dark",
+    "hover",
+    "menacing"
+  ],
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "legacy": {
+    "sourceInstrument": null,
+    "sourceCategory": null,
+    "sourcePresetName": null
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "parameters": {
+    "Owlfish": {
+      "owl_bodyFreq": 65.0,
+      "owl_bodyLevel": 0.55,
+      "owl_compAttack": 0.05,
+      "owl_compRatio": 0.3,
+      "owl_compRelease": 0.3,
+      "owl_compThreshold": 0.55,
+      "owl_couplingBus": 0,
+      "owl_couplingLevel": 0.5,
+      "owl_defense": 0.2,
+      "owl_depth": 0.5,
+      "owl_feedRate": 0.0,
+      "owl_feeding": 0.3,
+      "owl_filterCutoff": 0.38,
+      "owl_filterEnvDepth": 0.4,
+      "owl_filterReso": 0.58,
+      "owl_filterTrack": 0.5,
+      "owl_fundWave": 0.2,
+      "owl_grainDensity": 0.0,
+      "owl_grainMix": 0.0,
+      "owl_grainPitch": 0.0,
+      "owl_grainSize": 0.5,
+      "owl_legatoMode": 0,
+      "owl_mixtur": 0.4,
+      "owl_morphGlide": 0.3,
+      "owl_outputLevel": 0.78,
+      "owl_outputPan": 0.0,
+      "owl_portamento": 0.0,
+      "owl_pressure": 0.6,
+      "owl_reverbDamp": 0.62,
+      "owl_reverbMix": 0.28,
+      "owl_reverbPreDelay": 0.05,
+      "owl_reverbSize": 0.5,
+      "owl_subDiv1": 0,
+      "owl_subDiv2": 1,
+      "owl_subDiv3": 2,
+      "owl_subDiv4": 3,
+      "owl_subLevel1": 0.8,
+      "owl_subLevel2": 0.6,
+      "owl_subLevel3": 0.4,
+      "owl_subLevel4": 0.25,
+      "owl_subMix": 0.6,
+      "owl_subWave": 0.1,
+      "owl_velocity": 0.7,
+      "owl_ampAttack": 80,
+      "owl_ampDecay": 400,
+      "owl_ampSustain": 0.55,
+      "owl_ampRelease": 1500,
+      "owl_armorDecay": 0.0,
+      "owl_armorDelay": 0.0,
+      "owl_armorDuck": 0.0,
+      "owl_armorScatter": 0.0,
+      "owl_armorThreshold": 1.0
+    }
+  },
+  "dna": {
+    "brightness": 0.28,
+    "warmth": 0.45,
+    "movement": 0.25,
+    "density": 0.55,
+    "space": 0.6,
+    "aggression": 0.42
+  },
+  "macros": {
+    "CHARACTER": 0.55,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.0,
+    "SPACE": 0.6
+  }
+}

--- a/Presets/XOceanus/Submerged/Obscura_Tension_Wire.xometa
+++ b/Presets/XOceanus/Submerged/Obscura_Tension_Wire.xometa
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Tension Wire",
+  "mood": "Submerged",
+  "engines": [
+    "Obscura"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.0,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.0,
+    "SPACE": 0.3
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.62,
+    "movement": 0.1,
+    "density": 0.28,
+    "space": 0.8,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Obscura": {
+      "obscura_stiffness": 0.12,
+      "obscura_damping": 0.06,
+      "obscura_nonlinear": 0.02,
+      "obscura_excitePos": 0.5,
+      "obscura_exciteWidth": 0.28,
+      "obscura_scanWidth": 0.55,
+      "obscura_boundary": 1,
+      "obscura_sustain": 0.0,
+      "obscura_ampAttack": 0.01,
+      "obscura_ampDecay": 0.5,
+      "obscura_ampSustain": 0.0,
+      "obscura_ampRelease": 8.0,
+      "obscura_physEnvAttack": 0.01,
+      "obscura_physEnvDecay": 0.5,
+      "obscura_physEnvSustain": 0.0,
+      "obscura_physEnvRelease": 8.0,
+      "obscura_lfo1Rate": 0.04,
+      "obscura_lfo1Depth": 0.14,
+      "obscura_lfo1Shape": 0,
+      "obscura_lfo2Rate": 0.0,
+      "obscura_lfo2Depth": 0.0,
+      "obscura_lfo2Shape": 0,
+      "obscura_voiceMode": 2,
+      "obscura_glide": 0.0,
+      "obscura_initShape": 0,
+      "obscura_macroCharacter": 0.0,
+      "obscura_macroMovement": 0.1,
+      "obscura_macroCoupling": 0.0,
+      "obscura_macroSpace": 0.3,
+      "obscura_level": 0.8
+    }
+  },
+  "tags": [
+    "obscura",
+    "physical",
+    "wire",
+    "spring",
+    "tension",
+    "flexible",
+    "submerged"
+  ],
+  "description": "Thin steel spring under low tension \u2014 Free boundary (free ends) with very low stiffness creates extreme flexibility. Almost linear behavior. Long sustain from minimal damping. The fundamental is very low relative to the scan frequency \u2014 creates complex beating patterns as odd harmonics pile up. Slow LFO1 creates gentle width modulation."
+}

--- a/Presets/XOceanus/Submerged/Overwash_Benthic_Warmth.xometa
+++ b/Presets/XOceanus/Submerged/Overwash_Benthic_Warmth.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Benthic Warmth",
+  "mood": "Submerged",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.12,
+    "MOVEMENT": 0.07,
+    "COUPLING": 0.5,
+    "SPACE": 0.76
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.12,
+    "warmth": 0.82,
+    "movement": 0.07,
+    "density": 0.32,
+    "space": 0.76,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.08,
+      "wash_viscosity": 0.88,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 50.0,
+      "wash_spreadMax": 55.0,
+      "wash_brightness": 0.12,
+      "wash_warmth": 0.82,
+      "wash_ampAttack": 4.5,
+      "wash_ampDecay": 3.0,
+      "wash_ampSustain": 0.92,
+      "wash_ampRelease": 17.0,
+      "wash_filterCutoff": 520.0,
+      "wash_filterRes": 0.04,
+      "wash_filtEnvAmount": 0.08,
+      "wash_filtAttack": 4.0,
+      "wash_filtDecay": 5.0,
+      "wash_filtSustain": 0.91,
+      "wash_filtRelease": 12.0,
+      "wash_lfo1Rate": 0.004,
+      "wash_lfo1Depth": 0.09,
+      "wash_lfo2Rate": 0.002,
+      "wash_lfo2Depth": 0.04,
+      "wash_stereoWidth": 0.52,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "benthic",
+    "warm",
+    "dense",
+    "floor",
+    "submerged"
+  ],
+  "description": "Warm benthic floor presence \u2014 thick, warm, dense. Eight harmonics in still water at maximum depth warmth."
+}

--- a/Presets/XOceanus/Submerged/Overwash_Cold_Zone.xometa
+++ b/Presets/XOceanus/Submerged/Overwash_Cold_Zone.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Cold Zone",
+  "mood": "Submerged",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.04,
+    "MOVEMENT": 0.06,
+    "COUPLING": 0.5,
+    "SPACE": 0.85
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.04,
+    "warmth": 0.35,
+    "movement": 0.06,
+    "density": 0.16,
+    "space": 0.85,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.06,
+      "wash_viscosity": 0.91,
+      "wash_harmonics": 6,
+      "wash_diffusionTime": 70.0,
+      "wash_spreadMax": 40.0,
+      "wash_brightness": 0.04,
+      "wash_warmth": 0.35,
+      "wash_ampAttack": 7.0,
+      "wash_ampDecay": 4.0,
+      "wash_ampSustain": 0.94,
+      "wash_ampRelease": 22.0,
+      "wash_filterCutoff": 300.0,
+      "wash_filterRes": 0.03,
+      "wash_filtEnvAmount": 0.04,
+      "wash_filtAttack": 6.0,
+      "wash_filtDecay": 6.0,
+      "wash_filtSustain": 0.94,
+      "wash_filtRelease": 15.0,
+      "wash_lfo1Rate": 0.002,
+      "wash_lfo1Depth": 0.04,
+      "wash_lfo2Rate": 0.001,
+      "wash_lfo2Depth": 0.02,
+      "wash_stereoWidth": 0.42,
+      "wash_level": 0.65,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "cold",
+    "thermocline",
+    "submerged",
+    "dark",
+    "minimal"
+  ],
+  "description": "Very low warmth and brightness \u2014 the cold thermocline. Six harmonics barely moving."
+}

--- a/Presets/XOceanus/Submerged/Overwash_Pressure_Layer.xometa
+++ b/Presets/XOceanus/Submerged/Overwash_Pressure_Layer.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Pressure Layer",
+  "mood": "Submerged",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.06,
+    "MOVEMENT": 0.05,
+    "COUPLING": 0.5,
+    "SPACE": 0.82
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.06,
+    "warmth": 0.78,
+    "movement": 0.05,
+    "density": 0.22,
+    "space": 0.82,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.05,
+      "wash_viscosity": 0.93,
+      "wash_harmonics": 4,
+      "wash_diffusionTime": 65.0,
+      "wash_spreadMax": 35.0,
+      "wash_brightness": 0.06,
+      "wash_warmth": 0.78,
+      "wash_ampAttack": 6.0,
+      "wash_ampDecay": 3.5,
+      "wash_ampSustain": 0.93,
+      "wash_ampRelease": 20.0,
+      "wash_filterCutoff": 420.0,
+      "wash_filterRes": 0.03,
+      "wash_filtEnvAmount": 0.05,
+      "wash_filtAttack": 5.0,
+      "wash_filtDecay": 5.5,
+      "wash_filtSustain": 0.93,
+      "wash_filtRelease": 14.0,
+      "wash_lfo1Rate": 0.003,
+      "wash_lfo1Depth": 0.06,
+      "wash_lfo2Rate": 0.001,
+      "wash_lfo2Depth": 0.03,
+      "wash_stereoWidth": 0.45,
+      "wash_level": 0.68,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "pressure",
+    "submerged",
+    "weight",
+    "thick",
+    "slow"
+  ],
+  "description": "High atmospheric pressure \u2014 thick viscosity, narrow spread, very slow diffusion. The weight of water above."
+}

--- a/Presets/XOceanus/Submerged/Overwash_Submerged_Glow.xometa
+++ b/Presets/XOceanus/Submerged/Overwash_Submerged_Glow.xometa
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "name": "Submerged Glow",
+  "mood": "Submerged",
+  "engines": [
+    "Overwash"
+  ],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "macroLabels": [
+    "CHARACTER",
+    "MOVEMENT",
+    "COUPLING",
+    "SPACE"
+  ],
+  "macros": {
+    "CHARACTER": 0.15,
+    "MOVEMENT": 0.1,
+    "COUPLING": 0.5,
+    "SPACE": 0.78
+  },
+  "coupling": {
+    "pairs": []
+  },
+  "sequencer": null,
+  "dna": {
+    "brightness": 0.15,
+    "warmth": 0.75,
+    "movement": 0.1,
+    "density": 0.28,
+    "space": 0.78,
+    "aggression": 0.0
+  },
+  "parameters": {
+    "Overwash": {
+      "wash_diffusionRate": 0.1,
+      "wash_viscosity": 0.82,
+      "wash_harmonics": 8,
+      "wash_diffusionTime": 35.0,
+      "wash_spreadMax": 70.0,
+      "wash_brightness": 0.15,
+      "wash_warmth": 0.75,
+      "wash_ampAttack": 3.5,
+      "wash_ampDecay": 2.5,
+      "wash_ampSustain": 0.9,
+      "wash_ampRelease": 14.0,
+      "wash_filterCutoff": 650.0,
+      "wash_filterRes": 0.05,
+      "wash_filtEnvAmount": 0.1,
+      "wash_filtAttack": 3.0,
+      "wash_filtDecay": 4.0,
+      "wash_filtSustain": 0.88,
+      "wash_filtRelease": 10.0,
+      "wash_lfo1Rate": 0.006,
+      "wash_lfo1Depth": 0.12,
+      "wash_lfo2Rate": 0.003,
+      "wash_lfo2Depth": 0.06,
+      "wash_stereoWidth": 0.55,
+      "wash_level": 0.7,
+      "wash_interference": 0.0,
+      "wash_macroCharacter": 0.0,
+      "wash_macroMovement": 0.0,
+      "wash_macroCoupling": 0.5,
+      "wash_macroSpace": 0.0
+    }
+  },
+  "tags": [
+    "overwash",
+    "pad",
+    "submerged",
+    "glow",
+    "warm",
+    "bottom",
+    "underwater"
+  ],
+  "description": "Warm glow at the bottom \u2014 eight harmonics in warm water, spread maxes at 70Hz, slow LFOs."
+}


### PR DESCRIPTION
## Summary

264 new factory presets across 11 engines. All verified against real source-code parameter schemas.

### Per-engine counts

| Engine | New | Notes |
|--------|-----|-------|
| Overwash | +38 | Fick diffusion pads — tide/atmosphere/aether/deep/flux/prism/shadow/submerged moods |
| Overworn | +36 | Session-time reduction pads — stock/reduction/broth cooking metaphors |
| Overflow | +35 | Pressure accumulation pads — all 3 valve types (gradual/explosive/whistle) covered |
| Overcast | +40 | Crystallization pads — all 3 transition types + shatter-gap rhythmic series |
| Obscura | +20 | Physical mass-spring presets — EACH models a distinct phenomenon: Tibetan bowl, Rosewood bar, Bowed cello, Glass armonica, Tongue drum, Piano string, Bone flute, Gong strike, Tuning fork, Rubber membrane, Bronze bell, Bowed steel bar, Reed organ pipe, Cymbal shimmer, Mantle resonance, Chaos chain, Tension wire, Glass plate, Vowel column, Tabla membrane |
| Obiont | +25 | ALL carry `pre_seance: true` — covers Shadow/Atmosphere/Prism/Crystalline/Entangled/Kinetic/Deep — rules 0/6/9/18/22/30/33/45/57/60/73/90/105/110/126/150/169/184/193/254 |
| Osmosis | +43 | Membrane-identity presets — Foundation/Deep/Atmosphere/Flux/Organic/Crystalline using verified APVTS params |
| Origami | +2 | Crease Memory (Aether) + Wet Fold Burst (Kinetic) — real param schema (foldPoint/foldDepth/foldCount/operation) |
| Oceanic | +5 | Shore/Pelagic/Thermocline/Rip/Bioluminescent — real boid params (alignment/cohesion/scatter/subflocks) |
| Owlfish | +8 | Foundation→Organic range — real param schema verified from existing presets |
| Osprey | +12 | Full mood range — real param schema verified (brine/coherence/foam/fog/harborVerb/hull) |
| **TOTAL** | **264** | |

### Special notes

**Broth quad**: All 4 engines designed standalone-compelling (BROTH coordinator not wired in XOceanusProcessor.cpp). `wash_interference` kept at 0 (dead code). `worn_warmth` excluded (orphaned param). `flow_` uses hardcoded 44100 sample rate for valve models (known seance finding, v1.1 fix).

**Obiont**: Sentinel verified — all 25 new presets contain `"pre_seance": true` in JSON. New mood coverage: Shadow (5), Atmosphere (5), Prism (4), Crystalline (4), Entangled (3), Kinetic (2), Deep (2).

**Obscura**: Each of 20 presets justified by a distinct physical phenomenon with boundary condition (Fixed/Free/Periodic), stiffness, and nonlinearity settings specific to the material.

**Quick-fills**: Param schemas verified against existing reference presets before writing. Oceanic uses real boid architecture params. Owlfish uses real partials+grain+armor param set. Osprey uses real coastal/weather modeling params.

### Deferred to Day 9
- Oxytocin
- Oddfellow
- Opcode
- Opera

## Test plan

- [ ] Load 5 random Obiont presets — confirm `pre_seance` field present
- [ ] Load 3 Obscura presets across different phenomena — confirm physical diversity
- [ ] Load 1 preset from each Broth engine — confirm standalone compelling without coupling
- [ ] Load 1 Oceanic, Owlfish, Osprey preset — confirm no schema errors
- [ ] Verify preset count delta matches ledger above

🤖 Generated with [Claude Code](https://claude.com/claude-code)