### PR TITLE
chore(presets): Obiont pre_seance backfill (25 files)

### DIFF
--- a/Presets/XOceanus/Aether/Obiont/Colony_Evolving.xometa
+++ b/Presets/XOceanus/Aether/Obiont/Colony_Evolving.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.72,
     "SPACE": 0.68,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Deep/Obiont/Abyssal_Colony.xometa
+++ b/Presets/XOceanus/Deep/Obiont/Abyssal_Colony.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.12,
     "SPACE": 0.65,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Deep/Obiont/Void_Emergence.xometa
+++ b/Presets/XOceanus/Deep/Obiont/Void_Emergence.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.32,
     "SPACE": 0.78,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Ethereal/Obiont/Biolumen_Drift.xometa
+++ b/Presets/XOceanus/Ethereal/Obiont/Biolumen_Drift.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.62,
     "SPACE": 0.88,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Ethereal/Obiont/Ghost_Filament.xometa
+++ b/Presets/XOceanus/Ethereal/Obiont/Ghost_Filament.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.55,
     "SPACE": 0.82,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Flux/Obiont/Chaos_Engine.xometa
+++ b/Presets/XOceanus/Flux/Obiont/Chaos_Engine.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.92,
     "SPACE": 0.18,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Flux/Obiont/Spicule_Swarm.xometa
+++ b/Presets/XOceanus/Flux/Obiont/Spicule_Swarm.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.95,
     "SPACE": 0.12,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Automaton_March.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Automaton_March.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.88,
     "SPACE": 0.18,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Cellular_Bass.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Cellular_Bass.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.55,
     "SPACE": 0.18,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Colonial_Root.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Colonial_Root.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.28,
     "SPACE": 0.38,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Conways_Choir.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Conways_Choir.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.48,
     "SPACE": 0.52,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Emergence.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Emergence.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.62,
     "SPACE": 0.45,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Extinction_Event.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Extinction_Event.xometa
@@ -9,7 +9,7 @@
   "version": "1.0.0",
   "tier": "awakening",
   "created": "2026-03-28",
-  "description": "High chaos (Rule 30) held near its tipping point. Medium evolution starts stable, but mod wheel (via LFO depth as proxy) sweeps evolution rate from slow to catastrophic. At max macro EVOLUTION the grid goes berserk \u2014 near maximum chaos, near-extinction, anti-extinction re-seeding fires and the sound jolts back. LFO sweeps filter in long, dramatic arcs. For dramatic builds and controlled collapses. One automated macro, one performance moment.",
+  "description": "High chaos (Rule 30) held near its tipping point. Medium evolution starts stable, but mod wheel (via LFO depth as proxy) sweeps evolution rate from slow to catastrophic. At max macro EVOLUTION the grid goes berserk — near maximum chaos, near-extinction, anti-extinction re-seeding fires and the sound jolts back. LFO sweeps filter in long, dramatic arcs. For dramatic builds and controlled collapses. One automated macro, one performance moment.",
   "tags": [
     "awakening",
     "sweep",
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.55,
     "SPACE": 0.55,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Fibonacci_Drift.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Fibonacci_Drift.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.12,
     "SPACE": 0.88,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Mitosis.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Mitosis.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.82,
     "SPACE": 0.3,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Polyp_Chord.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Polyp_Chord.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.35,
     "SPACE": 0.52,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Primordial_Soup.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Primordial_Soup.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.22,
     "SPACE": 0.65,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Rule_of_Life.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Rule_of_Life.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.68,
     "SPACE": 0.28,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/Siphonophore_Lead.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/Siphonophore_Lead.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.68,
     "SPACE": 0.28,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Foundation/Obiont/The_Last_Cell.xometa
+++ b/Presets/XOceanus/Foundation/Obiont/The_Last_Cell.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.15,
     "SPACE": 0.95,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Kinetic/Obiont/Cell_Division.xometa
+++ b/Presets/XOceanus/Kinetic/Obiont/Cell_Division.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.98,
     "SPACE": 0.1,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Luminous/Obiont/Chromatophore_Bell.xometa
+++ b/Presets/XOceanus/Luminous/Obiont/Chromatophore_Bell.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.55,
     "SPACE": 0.72,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Luminous/Obiont/Luminescent_Bloom.xometa
+++ b/Presets/XOceanus/Luminous/Obiont/Luminescent_Bloom.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.78,
     "SPACE": 0.38,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Organic/Obiont/Amber_Warmth.xometa
+++ b/Presets/XOceanus/Organic/Obiont/Amber_Warmth.xometa
@@ -85,5 +85,6 @@
     "EVOLUTION": 0.38,
     "SPACE": 0.55,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }

--- a/Presets/XOceanus/Organic/Obiont/Zooid_Pulse.xometa
+++ b/Presets/XOceanus/Organic/Obiont/Zooid_Pulse.xometa
@@ -86,5 +86,6 @@
     "EVOLUTION": 0.58,
     "SPACE": 0.48,
     "COUPLING": 0.2
-  }
+  },
+  "pre_seance": true
 }


### PR DESCRIPTION
Backfills pre_seance: true on the 25 pre-existing Obiont presets (Day 8 Session D added the other 25). All 50 Obiont presets now carry the flag for V1.1 re-seance discoverability. JSON validity verified, no schema/content changes beyond the single field add.