### PR TITLE
feat(presets): Day 9 — Oxytocin floor fill (+8 presets, 43→51)

### DIFF
--- a/Presets/XOceanus/Atmosphere/Oxytocin/Tender_Haze.xometa
+++ b/Presets/XOceanus/Atmosphere/Oxytocin/Tender_Haze.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Tender Haze",
+  "mood": "Atmosphere",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "A soft chemical bloom where affection disperses into the surrounding air. Intimacy rendered as ambient breath — present everywhere, located nowhere.",
+  "tags": ["atmosphere", "soft", "ambient", "tender", "diffuse", "warm"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "Subtle",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.42,
+    "warmth": 0.72,
+    "movement": 0.28,
+    "density": 0.38,
+    "space": 0.78,
+    "aggression": 0.08
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.62,
+      "oxy_passion": 0.35,
+      "oxy_commitment": 0.55,
+      "oxy_warmth_rate": 1.8,
+      "oxy_passion_rate": 0.004,
+      "oxy_commit_rate": 0.6,
+      "oxy_entanglement": 0.42,
+      "oxy_circuit_age": 0.35,
+      "oxy_circuit_noise": 0.08,
+      "oxy_memory_depth": 0.45,
+      "oxy_memory_decay": 3.5,
+      "oxy_topology": 0,
+      "oxy_topology_lock": 0,
+      "oxy_feedback": 0.22,
+      "oxy_cutoff": 3200,
+      "oxy_pitch": 0,
+      "oxy_detune": 4,
+      "oxy_attack": 0.18,
+      "oxy_decay": 0.8,
+      "oxy_sustain": 0.65,
+      "oxy_release": 2.4,
+      "oxy_lfo_rate": 0.12,
+      "oxy_lfo_depth": 0.18,
+      "oxy_lfo_shape": 0,
+      "oxy_lfo2_rate": 0.07,
+      "oxy_lfo2_depth": 0.12,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 4
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.48,
+    "MOVEMENT": 0.28,
+    "COUPLING": 0.42,
+    "SPACE": 0.78
+  }
+}

--- a/Presets/XOceanus/Crystalline/Oxytocin/Glass_Bond.xometa
+++ b/Presets/XOceanus/Crystalline/Oxytocin/Glass_Bond.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Glass Bond",
+  "mood": "Crystalline",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "Attachment rendered in pure lattice structure — the molecular geometry of trust. Each partial a strut in a transparent architecture of devotion.",
+  "tags": ["crystalline", "transparent", "lattice", "bright", "structural", "pure"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "Subtle",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.88,
+    "warmth": 0.28,
+    "movement": 0.22,
+    "density": 0.35,
+    "space": 0.62,
+    "aggression": 0.12
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.45,
+      "oxy_passion": 0.28,
+      "oxy_commitment": 0.92,
+      "oxy_warmth_rate": 0.6,
+      "oxy_passion_rate": 0.002,
+      "oxy_commit_rate": 4.0,
+      "oxy_entanglement": 0.22,
+      "oxy_circuit_age": 0.08,
+      "oxy_circuit_noise": 0.03,
+      "oxy_memory_depth": 0.85,
+      "oxy_memory_decay": 5.0,
+      "oxy_topology": 0,
+      "oxy_topology_lock": 1,
+      "oxy_feedback": 0.08,
+      "oxy_cutoff": 6500,
+      "oxy_pitch": 0,
+      "oxy_detune": 1,
+      "oxy_attack": 0.002,
+      "oxy_decay": 0.35,
+      "oxy_sustain": 0.45,
+      "oxy_release": 1.8,
+      "oxy_lfo_rate": 0.15,
+      "oxy_lfo_depth": 0.08,
+      "oxy_lfo_shape": 0,
+      "oxy_lfo2_rate": 0.22,
+      "oxy_lfo2_depth": 0.05,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 2
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.36,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.22,
+    "SPACE": 0.62
+  }
+}

--- a/Presets/XOceanus/Deep/Oxytocin/Ancient_Tether.xometa
+++ b/Presets/XOceanus/Deep/Oxytocin/Ancient_Tether.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Ancient Tether",
+  "mood": "Deep",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "The oldest bond in the circuit — a commitment so long-standing it has become geological. Memory depth at maximum, decay arrested at the boundary of permanence.",
+  "tags": ["deep", "ancient", "sustained", "commitment", "slow", "heavy"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "Heavy",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.22,
+    "warmth": 0.82,
+    "movement": 0.12,
+    "density": 0.88,
+    "space": 0.18,
+    "aggression": 0.18
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.92,
+      "oxy_passion": 0.55,
+      "oxy_commitment": 0.98,
+      "oxy_warmth_rate": 3.5,
+      "oxy_passion_rate": 0.001,
+      "oxy_commit_rate": 0.05,
+      "oxy_entanglement": 0.88,
+      "oxy_circuit_age": 0.85,
+      "oxy_circuit_noise": 0.12,
+      "oxy_memory_depth": 0.98,
+      "oxy_memory_decay": 0.2,
+      "oxy_topology": 1,
+      "oxy_topology_lock": 1,
+      "oxy_feedback": 0.35,
+      "oxy_cutoff": 1200,
+      "oxy_pitch": 0,
+      "oxy_detune": 0,
+      "oxy_attack": 0.35,
+      "oxy_decay": 2.0,
+      "oxy_sustain": 0.88,
+      "oxy_release": 5.0,
+      "oxy_lfo_rate": 0.01,
+      "oxy_lfo_depth": 0.12,
+      "oxy_lfo_shape": 1,
+      "oxy_lfo2_rate": 0.008,
+      "oxy_lfo2_depth": 0.08,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 4
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.88,
+    "MOVEMENT": 0.12,
+    "COUPLING": 0.88,
+    "SPACE": 0.18
+  }
+}

--- a/Presets/XOceanus/Ethereal/Oxytocin/Dissolved_Contact.xometa
+++ b/Presets/XOceanus/Ethereal/Oxytocin/Dissolved_Contact.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Dissolved Contact",
+  "mood": "Ethereal",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "Touch at the threshold of sensation — a bond so light it registers only in the chemistry, never in the body. Oxytocin as a ghost signal barely above the noise floor.",
+  "tags": ["ethereal", "ghostly", "delicate", "threshold", "vaporous", "intimate"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.55,
+    "warmth": 0.48,
+    "movement": 0.35,
+    "density": 0.18,
+    "space": 0.88,
+    "aggression": 0.04
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.28,
+      "oxy_passion": 0.15,
+      "oxy_commitment": 0.38,
+      "oxy_warmth_rate": 1.2,
+      "oxy_passion_rate": 0.003,
+      "oxy_commit_rate": 1.5,
+      "oxy_entanglement": 0.18,
+      "oxy_circuit_age": 0.22,
+      "oxy_circuit_noise": 0.05,
+      "oxy_memory_depth": 0.55,
+      "oxy_memory_decay": 6.0,
+      "oxy_topology": 0,
+      "oxy_topology_lock": 0,
+      "oxy_feedback": 0.05,
+      "oxy_cutoff": 4800,
+      "oxy_pitch": 0,
+      "oxy_detune": 6,
+      "oxy_attack": 0.45,
+      "oxy_decay": 1.5,
+      "oxy_sustain": 0.35,
+      "oxy_release": 4.0,
+      "oxy_lfo_rate": 0.08,
+      "oxy_lfo_depth": 0.22,
+      "oxy_lfo_shape": 0,
+      "oxy_lfo2_rate": 0.05,
+      "oxy_lfo2_depth": 0.18,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 4
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.22,
+    "MOVEMENT": 0.35,
+    "COUPLING": 0.18,
+    "SPACE": 0.88
+  }
+}

--- a/Presets/XOceanus/Luminous/Oxytocin/Peak_Bonding.xometa
+++ b/Presets/XOceanus/Luminous/Oxytocin/Peak_Bonding.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Peak Bonding",
+  "mood": "Luminous",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "The flood state — oxytocin at full cascade, every receptor saturated. Warmth expressed as pure luminance, the circuit blazing at peak intimacy capacity.",
+  "tags": ["luminous", "radiant", "peak", "warm", "saturated", "ecstatic"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "Moderate",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.92,
+    "warmth": 0.88,
+    "movement": 0.58,
+    "density": 0.62,
+    "space": 0.48,
+    "aggression": 0.22
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.95,
+      "oxy_passion": 0.88,
+      "oxy_commitment": 0.72,
+      "oxy_warmth_rate": 4.2,
+      "oxy_passion_rate": 0.018,
+      "oxy_commit_rate": 0.35,
+      "oxy_entanglement": 0.65,
+      "oxy_circuit_age": 0.45,
+      "oxy_circuit_noise": 0.1,
+      "oxy_memory_depth": 0.55,
+      "oxy_memory_decay": 2.2,
+      "oxy_topology": 0,
+      "oxy_topology_lock": 0,
+      "oxy_feedback": 0.28,
+      "oxy_cutoff": 5800,
+      "oxy_pitch": 0,
+      "oxy_detune": 3,
+      "oxy_attack": 0.008,
+      "oxy_decay": 0.45,
+      "oxy_sustain": 0.75,
+      "oxy_release": 1.5,
+      "oxy_lfo_rate": 0.28,
+      "oxy_lfo_depth": 0.32,
+      "oxy_lfo_shape": 0,
+      "oxy_lfo2_rate": 0.42,
+      "oxy_lfo2_depth": 0.18,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 3
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.88,
+    "MOVEMENT": 0.58,
+    "COUPLING": 0.65,
+    "SPACE": 0.48
+  }
+}

--- a/Presets/XOceanus/Organic/Oxytocin/Skin_Memory.xometa
+++ b/Presets/XOceanus/Organic/Oxytocin/Skin_Memory.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Skin Memory",
+  "mood": "Organic",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "The body's recall of a touch — tactile memory encoded in neural tissue, replaying without stimulus. Warmth as a biological residue that outlasts the contact.",
+  "tags": ["organic", "tactile", "memory", "biological", "warm", "body"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "Subtle",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.38,
+    "warmth": 0.78,
+    "movement": 0.42,
+    "density": 0.55,
+    "space": 0.38,
+    "aggression": 0.12
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.72,
+      "oxy_passion": 0.48,
+      "oxy_commitment": 0.62,
+      "oxy_warmth_rate": 2.8,
+      "oxy_passion_rate": 0.008,
+      "oxy_commit_rate": 0.8,
+      "oxy_entanglement": 0.55,
+      "oxy_circuit_age": 0.62,
+      "oxy_circuit_noise": 0.22,
+      "oxy_memory_depth": 0.72,
+      "oxy_memory_decay": 2.8,
+      "oxy_topology": 0,
+      "oxy_topology_lock": 0,
+      "oxy_feedback": 0.18,
+      "oxy_cutoff": 2600,
+      "oxy_pitch": 0,
+      "oxy_detune": 5,
+      "oxy_attack": 0.08,
+      "oxy_decay": 0.9,
+      "oxy_sustain": 0.62,
+      "oxy_release": 2.8,
+      "oxy_lfo_rate": 0.18,
+      "oxy_lfo_depth": 0.22,
+      "oxy_lfo_shape": 1,
+      "oxy_lfo2_rate": 0.11,
+      "oxy_lfo2_depth": 0.14,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 4
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.58,
+    "MOVEMENT": 0.42,
+    "COUPLING": 0.55,
+    "SPACE": 0.38
+  }
+}

--- a/Presets/XOceanus/Shadow/Oxytocin/Grief_Signal.xometa
+++ b/Presets/XOceanus/Shadow/Oxytocin/Grief_Signal.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Grief Signal",
+  "mood": "Shadow",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "Oxytocin in its withdrawal phase — the bond chemistry persisting after the source has gone. Longing as a misfiring circuit, warmth searching for a target that no longer exists.",
+  "tags": ["shadow", "grief", "withdrawal", "longing", "dark", "muted"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "None",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.18,
+    "warmth": 0.35,
+    "movement": 0.22,
+    "density": 0.45,
+    "space": 0.55,
+    "aggression": 0.42
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.35,
+      "oxy_passion": 0.72,
+      "oxy_commitment": 0.45,
+      "oxy_warmth_rate": 0.4,
+      "oxy_passion_rate": 0.02,
+      "oxy_commit_rate": 0.12,
+      "oxy_entanglement": 0.28,
+      "oxy_circuit_age": 0.78,
+      "oxy_circuit_noise": 0.35,
+      "oxy_memory_depth": 0.88,
+      "oxy_memory_decay": 0.8,
+      "oxy_topology": 2,
+      "oxy_topology_lock": 0,
+      "oxy_feedback": 0.55,
+      "oxy_cutoff": 1500,
+      "oxy_pitch": 0,
+      "oxy_detune": 8,
+      "oxy_attack": 0.12,
+      "oxy_decay": 0.6,
+      "oxy_sustain": 0.42,
+      "oxy_release": 3.5,
+      "oxy_lfo_rate": 0.04,
+      "oxy_lfo_depth": 0.35,
+      "oxy_lfo_shape": 2,
+      "oxy_lfo2_rate": 0.06,
+      "oxy_lfo2_depth": 0.22,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 2
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.42,
+    "MOVEMENT": 0.22,
+    "COUPLING": 0.28,
+    "SPACE": 0.55
+  }
+}

--- a/Presets/XOceanus/Submerged/Oxytocin/Pressure_Bloom.xometa
+++ b/Presets/XOceanus/Submerged/Oxytocin/Pressure_Bloom.xometa
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "Pressure Bloom",
+  "mood": "Submerged",
+  "engines": ["Oxytocin"],
+  "author": "XO_OX Designs",
+  "version": "1.0.0",
+  "description": "Bonding chemistry under enormous depth — the oxytocin cascade compressed into a single luminous point. Love as a bioluminescent event in total darkness.",
+  "tags": ["submerged", "deep", "pressure", "bioluminescent", "circuit", "dense"],
+  "macroLabels": ["CHARACTER", "MOVEMENT", "COUPLING", "SPACE"],
+  "couplingIntensity": "Moderate",
+  "tempo": null,
+  "dna": {
+    "brightness": 0.32,
+    "warmth": 0.55,
+    "movement": 0.45,
+    "density": 0.82,
+    "space": 0.22,
+    "aggression": 0.35
+  },
+  "parameters": {
+    "Oxytocin": {
+      "oxy_intimacy": 0.78,
+      "oxy_passion": 0.65,
+      "oxy_commitment": 0.88,
+      "oxy_warmth_rate": 2.4,
+      "oxy_passion_rate": 0.012,
+      "oxy_commit_rate": 0.15,
+      "oxy_entanglement": 0.72,
+      "oxy_circuit_age": 0.55,
+      "oxy_circuit_noise": 0.18,
+      "oxy_memory_depth": 0.68,
+      "oxy_memory_decay": 1.8,
+      "oxy_topology": 1,
+      "oxy_topology_lock": 1,
+      "oxy_feedback": 0.48,
+      "oxy_cutoff": 1800,
+      "oxy_pitch": 0,
+      "oxy_detune": 2,
+      "oxy_attack": 0.04,
+      "oxy_decay": 1.2,
+      "oxy_sustain": 0.72,
+      "oxy_release": 3.0,
+      "oxy_lfo_rate": 0.05,
+      "oxy_lfo_depth": 0.28,
+      "oxy_lfo_shape": 1,
+      "oxy_lfo2_rate": 0.09,
+      "oxy_lfo2_depth": 0.15,
+      "oxy_output": 0,
+      "oxy_pan": 0.0,
+      "oxy_voices": 3
+    }
+  },
+  "coupling": { "pairs": [] },
+  "sequencer": null,
+  "macros": {
+    "CHARACTER": 0.65,
+    "MOVEMENT": 0.45,
+    "COUPLING": 0.72,
+    "SPACE": 0.22
+  }
+}


### PR DESCRIPTION
## Summary

- Brings Oxytocin to V1 ≥50 floor (43 → 51 presets, +8)
- 8 new presets across 8 previously zero-coverage moods: Atmosphere, Submerged, Crystalline, Deep, Ethereal, Luminous, Organic, Shadow
- No duplicate names, all valid JSON, all moods from the locked 16-mood enum
- Full `oxy_*` parameter set used throughout (oxy_intimacy, oxy_passion, oxy_commitment, oxy_warmth_rate, oxy_passion_rate, oxy_commit_rate, oxy_entanglement, oxy_circuit_age, oxy_circuit_noise, oxy_memory_depth, oxy_memory_decay, oxy_topology, oxy_topology_lock, oxy_feedback, oxy_cutoff, oxy_pitch, oxy_detune, oxy_attack, oxy_decay, oxy_sustain, oxy_release, oxy_lfo_rate, oxy_lfo_depth, oxy_lfo_shape, oxy_lfo2_rate, oxy_lfo2_depth, oxy_output, oxy_pan, oxy_voices)
- Ground-truth pre-flight count was 43 (Day 7 triage said 42 — stale by 1; corrected inline). Post count = 51.

## Preset Manifest

| Name | Mood | couplingIntensity |
|------|------|-------------------|
| Tender Haze | Atmosphere | Subtle |
| Pressure Bloom | Submerged | Moderate |
| Glass Bond | Crystalline | Subtle |
| Ancient Tether | Deep | Heavy |
| Dissolved Contact | Ethereal | None |
| Peak Bonding | Luminous | Moderate |
| Skin Memory | Organic | Subtle |
| Grief Signal | Shadow | None |

## Test plan

- [ ] Count: `find Presets -path "*Oxytocin*" -name "*.xometa" | wc -l` → 51
- [ ] JSON: `python3 -m json.tool` passes on all 8 new files
- [ ] No name collisions: `find ... | xargs -I {} basename {} .xometa | sort | uniq -d` → empty
- [ ] Mood values all in valid 16-mood enum (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)