### PR TITLE
fix(brand): replace stale fleet counts on press-kit and main page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2443,7 +2443,7 @@ Named for Olokun — the Yoruba orisha of the abyssal deep, keeper of the ocean 
     </div>
     <div class="omnibus-feature reveal">
       <h3>Chord Machine</h3>
-      <p>One note in, four voices out. Every chord tone synthesized through a different engine. House music DNA, open-sourced, distributed across 77 characters.</p>
+      <p>One note in, four voices out. Every chord tone synthesized through a different engine. House music DNA, open-sourced, distributed across <!-- ENGINE_COUNT -->86<!-- /ENGINE_COUNT --> engines.</p>
     </div>
     <div class="omnibus-feature reveal">
       <h3>Sonic DNA</h3>

--- a/site/press-kit/index.html
+++ b/site/press-kit/index.html
@@ -583,7 +583,7 @@ footer {
     <div class="section-heading">About XOceanus</div>
     <p>
       XOceanus is a free, open-source multi-engine synthesizer for macOS by XO_OX Designs.
-      It brings 77 distinct character instruments into a single unified environment — each engine
+      It brings <!-- ENGINE_COUNT -->86<!-- /ENGINE_COUNT --> distinct character instruments into a single unified environment — each engine
       evolved for its own sonic depth, each one a complete form of synthesis with its own
       mythology, accent color, and personality. Where most synthesizers offer one voice,
       XOceanus offers a fleet.
@@ -646,7 +646,7 @@ footer {
       <tbody>
         <tr>
           <th scope="row">Engines</th>
-          <td><strong>76</strong> distinct synthesis engines, each a named aquatic creature with its own DSP architecture and mythology</td>
+          <td><strong><!-- ENGINE_COUNT -->86<!-- /ENGINE_COUNT --></strong> distinct synthesis engines, each a named aquatic creature with its own DSP architecture and mythology</td>
         </tr>
         <tr>
           <th scope="row">Coupling types</th>
@@ -658,7 +658,7 @@ footer {
         </tr>
         <tr>
           <th scope="row">Mood categories</th>
-          <td><strong>8 primary moods</strong> — Foundation, Atmosphere, Entangled, Prism, Flux, Aether, Submerged, Coupling</td>
+          <td><strong>16 mood categories</strong> — Foundation, Atmosphere, Entangled, Prism, Flux, Aether, Family, Submerged, Coupling, Crystalline, Deep, Ethereal, Kinetic, Luminous, Organic, Shadow</td>
         </tr>
         <tr>
           <th scope="row">License</th>
@@ -674,7 +674,7 @@ footer {
         </tr>
         <tr>
           <th scope="row">Expression</th>
-          <td>Velocity-to-timbre in every engine. Aftertouch on 76 of 76. Mod wheel on 72 of 76. 4 macro controls per engine.</td>
+          <td>Velocity-to-timbre in every engine. Aftertouch and mod wheel routing supported across the fleet per D006 doctrine. 4 macro controls per engine.</td>
         </tr>
         <tr>
           <th scope="row">Creator</th>


### PR DESCRIPTION
## Summary
- Replace 76/77 hardcoded fleet counts on `site/press-kit/index.html` (lines 586, 649) with ENGINE_COUNT sentinel form (auto-updates on future fleet changes)
- Expand \"8 primary moods\" → \"16 mood categories\" + full 16-mood list (line 661)
- Update aftertouch/mod-wheel attestation to safe D006 generalization (line 677) — precise per-engine counts for the 86-engine fleet are not in Docs/, so stale \"76 of 76\" removed
- Fix `site/index.html:2446` \"77 characters\" → ENGINE_COUNT sentinel \"86 engines\"

Day 10 Phase 4 sweep V1-blockers P0 + P1. Source: `sweep-day10-2026-05-10.md`.

## Test plan
- [ ] Visual diff confirms ENGINE_COUNT sentinels render \`86\` in browser
- [ ] Mood list shows all 16 entries (Foundation through Shadow)
- [ ] Aftertouch/mod-wheel claim reads: \"Aftertouch and mod wheel routing supported across the fleet per D006 doctrine\"
- [ ] Chord Machine blurb in main page reads \"distributed across 86 engines\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)