### PR TITLE
chore(release): bump version to 1.0.0-beta.1 for V1 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ re-titled when a version is cut.
 
 ## [Unreleased]
 
+*(next development cycle)*
+
+---
+
+## [1.0.0-beta.1] — 2026-05-12
+
+### V1 Ship Campaign (Days 1–11)
+
+- Fleet locked at 74 V1 engines (12 culled to V1.1 per #1543/#1556)
+- ~1,175+ presets added across 27 engines to clear 50-preset floor (Day 8 #1558–#1561)
+- Outwit D001 velocity-to-timbre routing fixed (#1589)
+- Obiont pre_seance metadata backfill (#1562)
+- Press-kit and marketing fleet-count corrections (#1571)
+- A/B compare diff overlay (#1538), Cmd+K palette (#1525), Save As dialog (#1523)
+- Mod visualization wiring (#1532)
+- Ship-blocker bundle: Tooltips sweep, RNG seed sweep, 96kHz buffer fallback, P36 series (#1540)
+- Fleet auval PASS: 44.1k/48k/96k/192k (Day 10)
+- Behavioral smoke: 29/30 PASS (Outwit D001 resolved Day 11)
+
+### Known Limitations
+
+- Code signing: V1 ships unsigned-beta-mode (Apple signing deferred to V1.1, see #1444)
+
 ### Added
 - OBIONT engine (`obnt_` prefix) — Cellular automata oscillator; 1D Wolfram CA spatial projection + cosine readout + 8-voice poly + anti-extinction
 - OKEANOS engine (`okan_` prefix) — Cardamom warmth synth

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Universal binary")
 
 project(XOceanus VERSION 1.0.0 LANGUAGES C CXX)
 
+# Pre-release suffix appended to VERSION for human-facing displays (About modal,
+# crash reports, artifact filenames). CMake's VERSION field only accepts
+# MAJOR.MINOR.PATCH — the suffix lives here so it stays in one place.
+set(XOCEANUS_VERSION_SUFFIX "beta.1")
+set(XOCEANUS_FULL_VERSION   "${PROJECT_VERSION}-${XOCEANUS_VERSION_SUFFIX}")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -657,6 +663,7 @@ target_compile_definitions(XOceanus PUBLIC
     JUCE_WEB_BROWSER=0
     JUCE_USE_CURL=0
     JUCE_DISPLAY_SPLASH_SCREEN=0
+    XOCEANUS_VERSION_STRING="${XOCEANUS_FULL_VERSION}"
 )
 
 # JUCE_VST3_CAN_REPLACE_VST2 is only relevant when building VST3.
@@ -849,7 +856,7 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY "XOceanus")
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # DragNDrop creates a .dmg with the AU bundle and Standalone side-by-side.
     set(CPACK_GENERATOR "DragNDrop")
-    set(CPACK_DMG_VOLUME_NAME   "XOceanus ${PROJECT_VERSION}")
+    set(CPACK_DMG_VOLUME_NAME   "XOceanus ${XOCEANUS_FULL_VERSION}")
     set(CPACK_DMG_FORMAT        "UDZO")   # zlib-compressed, read-write
     set(CPACK_DMG_DS_STORE_SETUP_SCRIPT
         "${CMAKE_CURRENT_SOURCE_DIR}/Installer/dmg_setup.scpt"


### PR DESCRIPTION
## Summary
- Version: `1.0.0` → `1.0.0-beta.1` (display/artifact label)
- `CMakeLists.txt`: adds `XOCEANUS_VERSION_SUFFIX="beta.1"` and `XOCEANUS_FULL_VERSION` variable; exposes `XOCEANUS_VERSION_STRING` compile definition so `AboutModal.h` and `CrashReporter.h` display the full pre-release string
- `CHANGELOG.md`: cuts `[Unreleased]` → `[1.0.0-beta.1] — 2026-05-12` with V1 Ship Campaign summary; leaves fresh `[Unreleased]` stub for next cycle

Note: `CMakeLists.txt project(VERSION)` stays at `1.0.0` — CMake (min 3.22) rejects pre-release suffixes in the VERSION field. The beta suffix is tracked in a separate variable.

V1 ships unsigned-beta-mode per locked Apple-signing-deferred decision (#1444 → V1.1).
No tag created today — tagging is Day 13.

## Test plan
- [ ] `cmake -B build -DCMAKE_BUILD_TYPE=Release` configures without error
- [ ] AboutModal displays "1.0.0-beta.1" in host after build
- [ ] AU + VST3 DMG artifacts (built in Phase 3) report 1.0.0-beta.1
- [ ] Ear-test Day 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)