### PR TITLE
fix(brand): correct V1 preset count on site copy (19,859 → 14,267)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2320,7 +2320,7 @@ footer {
     </div>
     <div class="hero-stat-divider" aria-hidden="true"></div>
     <div class="hero-stat">
-      <span class="hero-stat-num">19K+</span>
+      <span class="hero-stat-num">14K+</span>
       <span class="hero-stat-label">Presets</span>
     </div>
   </div>

--- a/site/press-kit/index.html
+++ b/site/press-kit/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="XOceanus Press Kit — 86 engines, 15 coupling types, 19,859+ active presets. Free & open-source. By XO_OX Designs.">
+<meta name="description" content="XOceanus Press Kit — 86 engines, 15 coupling types, 14,267+ active presets. Free & open-source. By XO_OX Designs.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text x='4' y='24' font-size='24' fill='%23E9C46A'>X</text></svg>">
 <title>Press Kit — XOceanus by XO_OX Designs</title>
 <meta property="og:title" content="XOceanus Press Kit — XO_OX Designs">
@@ -654,7 +654,7 @@ footer {
         </tr>
         <tr>
           <th scope="row">Factory presets</th>
-          <td><strong>19,859+ active</strong> presets across 16 mood categories, organized by 6-dimensional Sonic DNA</td>
+          <td><strong>14,267+ active</strong> presets across 16 mood categories, organized by 6-dimensional Sonic DNA</td>
         </tr>
         <tr>
           <th scope="row">Mood categories</th>


### PR DESCRIPTION
## Summary

- **`site/index.html`**: hero stat `19K+` → `14K+`
- **`site/press-kit/index.html`**: table cell `19,859+ active` → `14,267+ active`; meta description `19,859+` → `14,267+`

Day 9 audit used a filename-prefix `find` that undercounted by ~33% (missed coupling presets, case-variant filenames, and mood-dir presets without an engine-name prefix). A defensible re-audit using the JSON `engines` field produces **14,267 presets across the 74-engine V1 fleet**. Standalone engines (Obese / Oblong / OddfeliX / OddOscar / Odyssey / Overbite / Overdub, ~984 presets) are excluded — the public number reflects V1 fleet only.

Followup to #1571 (fleet count fix). Audit trail: `audit-preset-floor-2026-05-09.md` post-audit-correction note.

## Verification

- Reproducible source-of-truth: `/tmp/v1-preset-count.sh` → **14,267**
- No other counts (engine count, mood count) changed
- `Tools/sync_engine_sources.py` has no `PRESET_COUNT` HTML sentinel — hand-edit is the correct approach here

## Files Changed

| File | Old | New |
|------|-----|-----|
| `site/index.html:2323` | `19K+` | `14K+` |
| `site/press-kit/index.html:6` | `19,859+ active presets` (meta) | `14,267+ active presets` |
| `site/press-kit/index.html:657` | `19,859+ active` (table) | `14,267+ active` |

## Flag: CLAUDE.md also stale

`CLAUDE.md` Product Identity section still reads `19,859 active factory presets` — outside this PR's `site/`-only scope per task hard rules. Recommend a follow-up CLAUDE.md update or inclusion in the next chore sweep.